### PR TITLE
feat(spar-wasm): add analyze function to WIT renderer

### DIFF
--- a/crates/spar-wasm/src/lib.rs
+++ b/crates/spar-wasm/src/lib.rs
@@ -11,7 +11,7 @@ mod graph;
 mod render;
 
 pub use graph::{ArchEdge, ArchNode, build_graph};
-pub use render::{render_aadl, render_aadl_from_fs, RenderError};
+pub use render::{analyze_aadl_from_fs, render_aadl, render_aadl_from_fs, RenderError};
 
 // ---------------------------------------------------------------------------
 // WIT guest bindings (WASM component only)
@@ -31,20 +31,38 @@ use bindings::exports::pulseengine::rivet::adapter::{
 };
 #[cfg(target_arch = "wasm32")]
 use bindings::exports::pulseengine::rivet::renderer::{
-    Guest as RendererGuest, RenderError as WitRenderError,
+    AnalysisDiagnostic as WitDiagnostic, Guest as RendererGuest, RenderError as WitRenderError,
 };
 
 #[cfg(target_arch = "wasm32")]
 struct SparComponent;
 
 #[cfg(target_arch = "wasm32")]
+fn map_render_err(e: render::RenderError) -> WitRenderError {
+    match e {
+        render::RenderError::ParseError(s) => WitRenderError::ParseError(s),
+        render::RenderError::NoRoot(s) => WitRenderError::NoRoot(s),
+        render::RenderError::LayoutError(s) => WitRenderError::LayoutError(s),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 impl RendererGuest for SparComponent {
     fn render(root: String, highlight: Vec<String>) -> Result<String, WitRenderError> {
-        render::render_aadl_from_fs(&root, &highlight).map_err(|e| match e {
-            render::RenderError::ParseError(s) => WitRenderError::ParseError(s),
-            render::RenderError::NoRoot(s) => WitRenderError::NoRoot(s),
-            render::RenderError::LayoutError(s) => WitRenderError::LayoutError(s),
-        })
+        render::render_aadl_from_fs(&root, &highlight).map_err(map_render_err)
+    }
+
+    fn analyze(root: String) -> Result<Vec<WitDiagnostic>, WitRenderError> {
+        let diags = render::analyze_aadl_from_fs(&root).map_err(map_render_err)?;
+        Ok(diags
+            .into_iter()
+            .map(|d| WitDiagnostic {
+                severity: format!("{:?}", d.severity).to_lowercase(),
+                message: d.message,
+                component_path: d.path.join("."),
+                analysis_name: d.analysis,
+            })
+            .collect())
     }
 }
 

--- a/crates/spar-wasm/src/render.rs
+++ b/crates/spar-wasm/src/render.rs
@@ -85,6 +85,62 @@ pub fn render_aadl_from_fs(root: &str, highlight: &[String]) -> Result<String, R
     render_graph_to_svg(&graph, highlight)
 }
 
+/// Run all analyses on the AADL model from filesystem.
+///
+/// Reads `.aadl` files from the current directory, instantiates the given
+/// root, and runs all registered analysis passes.
+pub fn analyze_aadl_from_fs(
+    root: &str,
+) -> Result<Vec<spar_analysis::AnalysisDiagnostic>, RenderError> {
+    let mut sources = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(".") {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "aadl") {
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    sources.push((path.display().to_string(), content));
+                }
+            }
+        }
+    }
+    if sources.is_empty() {
+        return Err(RenderError::ParseError("no .aadl files found".into()));
+    }
+
+    let db = Database::from_aadl(
+        &sources.iter().map(|(f, c)| (f.clone(), c.clone())).collect::<Vec<_>>(),
+    );
+
+    let instance = db
+        .instantiate(root)
+        .ok_or_else(|| RenderError::NoRoot(format!("cannot instantiate {}", root)))?;
+
+    if instance.diagnostics().iter().any(|d| d.contains("Unresolved")) {
+        return Err(RenderError::NoRoot(format!(
+            "root {} has unresolved components",
+            root
+        )));
+    }
+
+    let mut runner = spar_analysis::AnalysisRunner::new();
+    runner.register(Box::new(spar_analysis::connectivity::ConnectivityAnalysis));
+    runner.register(Box::new(spar_analysis::hierarchy::HierarchyAnalysis));
+    runner.register(Box::new(spar_analysis::completeness::CompletenessAnalysis));
+    runner.register(Box::new(spar_analysis::flow_check::FlowCheckAnalysis));
+    runner.register(Box::new(spar_analysis::mode_check::ModeCheckAnalysis));
+    runner.register(Box::new(spar_analysis::binding_check::BindingCheckAnalysis));
+    runner.register(Box::new(spar_analysis::scheduling::SchedulingAnalysis));
+    runner.register(Box::new(spar_analysis::latency::LatencyAnalysis));
+    runner.register(Box::new(spar_analysis::resource_budget::ResourceBudgetAnalysis));
+    runner.register(Box::new(spar_analysis::direction_rules::DirectionRuleAnalysis));
+    runner.register(Box::new(spar_analysis::connection_rules::ConnectionRuleAnalysis));
+    runner.register(Box::new(spar_analysis::mode_rules::ModeRuleAnalysis));
+    runner.register(Box::new(spar_analysis::subcomponent_rules::SubcomponentRuleAnalysis));
+    runner.register(Box::new(spar_analysis::emv2_analysis::Emv2Analysis));
+
+    Ok(runner.run_all(instance.inner()))
+}
+
 /// Parse AADL source, instantiate the given root, and render to SVG.
 ///
 /// `source` is the raw AADL text.  `root` is a qualified name such as

--- a/crates/spar-wasm/wit/adapter.wit
+++ b/crates/spar-wasm/wit/adapter.wit
@@ -107,6 +107,18 @@ interface renderer {
         layout-error(string),
     }
 
+    /// A diagnostic produced by an analysis pass.
+    record analysis-diagnostic {
+        /// "error", "warning", or "info"
+        severity: string,
+        /// Human-readable description
+        message: string,
+        /// Dot-separated component path (e.g. "top.cpu.partition1")
+        component-path: string,
+        /// Which analysis produced this (e.g. "connectivity", "emv2_fault_tree")
+        analysis-name: string,
+    }
+
     /// Render an AADL instance tree rooted at `root` (e.g. "Pkg::Impl").
     ///
     /// `highlight` is an optional list of component paths to visually
@@ -114,6 +126,12 @@ interface renderer {
     ///
     /// Returns the SVG document as a UTF-8 string, or a `render-error`.
     render: func(root: string, highlight: list<string>) -> result<string, render-error>;
+
+    /// Run all registered analyses on the AADL instance rooted at `root`.
+    ///
+    /// Returns a list of diagnostics (errors, warnings, info) from all
+    /// analysis passes (connectivity, hierarchy, EMV2, scheduling, etc.).
+    analyze: func(root: string) -> result<list<analysis-diagnostic>, render-error>;
 }
 
 /// World for a spar WASM component that can both adapt AADL artifacts


### PR DESCRIPTION
## Summary
- Add `analysis-diagnostic` record and `analyze` function to the WIT `renderer` interface
- Implement `analyze_aadl_from_fs()` in `render.rs` that registers and runs all 14 analysis passes
- Wire up `RendererGuest::analyze` in the WASM component to return structured diagnostics

## Analysis passes exposed
connectivity, hierarchy, completeness, flow_check, mode_check, binding_check, scheduling, latency, resource_budget, direction_rules, connection_rules, mode_rules, subcomponent_rules, emv2_fault_tree

## Test plan
- [x] All 14 existing spar-wasm tests pass
- [x] Native `cargo check` passes
- [x] `cargo build --target wasm32-wasip2` succeeds
- [x] jco transpile produces valid JS with `analyze` export in type definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)