### PR TITLE
feat(spar-analysis): add connection classifier type matching

### DIFF
--- a/crates/spar-analysis/src/arinc653.rs
+++ b/crates/spar-analysis/src/arinc653.rs
@@ -504,6 +504,8 @@ mod tests {
                 kind,
                 direction,
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/classifier_match.rs
+++ b/crates/spar-analysis/src/classifier_match.rs
@@ -1,0 +1,734 @@
+//! Connection classifier type matching (AS5506 §9).
+//!
+//! Validates that connection endpoints have compatible classifier types:
+//! - **CONN-CLASSIFIER-MATCH** — For port connections (DataPort, EventDataPort),
+//!   both endpoint classifiers must reference the same data type.
+//! - **CONN-ACCESS-MATCH** — For access connections, classifiers must match AND
+//!   access_kind must be compatible (Provides ↔ Requires).
+//! - **CONN-CLASSIFIER-MISSING** — Info-level: one endpoint has a classifier but
+//!   the other doesn't (potential type safety gap).
+
+use spar_hir_def::instance::{
+    ComponentInstanceIdx, FeatureInstance, SystemInstance,
+};
+use spar_hir_def::item_tree::{ConnectionKind, FeatureKind};
+use spar_hir_def::name::Name;
+
+use crate::{component_path, Analysis, AnalysisDiagnostic, Severity};
+
+/// Validates connection classifier type matching on the instance model.
+pub struct ClassifierMatchAnalysis;
+
+impl Analysis for ClassifierMatchAnalysis {
+    fn name(&self) -> &str {
+        "classifier_match"
+    }
+
+    fn analyze(&self, instance: &SystemInstance) -> Vec<AnalysisDiagnostic> {
+        let mut diags = Vec::new();
+
+        for (comp_idx, comp) in instance.all_components() {
+            for &conn_idx in &comp.connections {
+                let conn = &instance.connections[conn_idx];
+
+                let (src_end, dst_end) = match (&conn.src, &conn.dst) {
+                    (Some(s), Some(d)) => (s, d),
+                    _ => continue, // incomplete connection, skip
+                };
+
+                let src_feat =
+                    find_feature(instance, comp_idx, &src_end.subcomponent, &src_end.feature);
+                let dst_feat =
+                    find_feature(instance, comp_idx, &dst_end.subcomponent, &dst_end.feature);
+
+                let (src_feat, dst_feat) = match (src_feat, dst_feat) {
+                    (Some(s), Some(d)) => (s, d),
+                    _ => continue, // can't resolve, skip
+                };
+
+                let path = component_path(instance, comp_idx);
+
+                // Check classifier matching for port-like connections
+                if conn.kind == ConnectionKind::Port || conn.kind == ConnectionKind::Feature {
+                    check_port_classifier_match(
+                        &conn.name,
+                        src_feat,
+                        dst_feat,
+                        &src_end.feature,
+                        &dst_end.feature,
+                        &path,
+                        &mut diags,
+                    );
+                }
+
+                // Check access connection classifier + provides/requires compatibility
+                if conn.kind == ConnectionKind::Access {
+                    check_access_match(
+                        &conn.name,
+                        src_feat,
+                        dst_feat,
+                        &src_end.feature,
+                        &dst_end.feature,
+                        &path,
+                        &mut diags,
+                    );
+                }
+            }
+        }
+
+        diags
+    }
+}
+
+/// CONN-CLASSIFIER-MATCH / CONN-CLASSIFIER-MISSING for port connections.
+///
+/// For DataPort, EventDataPort, and Parameter features: if both endpoints
+/// have classifiers, they must reference the same data type (case-insensitive).
+/// If only one has a classifier, emit an info-level diagnostic.
+fn check_port_classifier_match(
+    conn_name: &Name,
+    src_feat: &FeatureInstance,
+    dst_feat: &FeatureInstance,
+    src_name: &Name,
+    dst_name: &Name,
+    path: &[String],
+    diags: &mut Vec<AnalysisDiagnostic>,
+) {
+    // Only check features that carry data classifiers
+    let carries_data = |kind: FeatureKind| {
+        matches!(
+            kind,
+            FeatureKind::DataPort | FeatureKind::EventDataPort | FeatureKind::Parameter
+        )
+    };
+
+    if !carries_data(src_feat.kind) && !carries_data(dst_feat.kind) {
+        return;
+    }
+
+    match (&src_feat.classifier, &dst_feat.classifier) {
+        (Some(src_cls), Some(dst_cls)) => {
+            // Both have classifiers — compare type names case-insensitively
+            if !classifiers_match(src_cls, dst_cls) {
+                diags.push(AnalysisDiagnostic {
+                    severity: Severity::Error,
+                    message: format!(
+                        "connection '{}': source feature '{}' has classifier '{}' but \
+                         destination feature '{}' has classifier '{}' — data types must match",
+                        conn_name, src_name, src_cls, dst_name, dst_cls
+                    ),
+                    path: path.to_vec(),
+                    analysis: "classifier_match".to_string(),
+                });
+            }
+        }
+        (Some(cls), None) => {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Info,
+                message: format!(
+                    "connection '{}': source feature '{}' has classifier '{}' but \
+                     destination feature '{}' has no classifier — potential type safety gap",
+                    conn_name, src_name, cls, dst_name
+                ),
+                path: path.to_vec(),
+                analysis: "classifier_match".to_string(),
+            });
+        }
+        (None, Some(cls)) => {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Info,
+                message: format!(
+                    "connection '{}': destination feature '{}' has classifier '{}' but \
+                     source feature '{}' has no classifier — potential type safety gap",
+                    conn_name, dst_name, cls, src_name
+                ),
+                path: path.to_vec(),
+                analysis: "classifier_match".to_string(),
+            });
+        }
+        (None, None) => {
+            // Neither has a classifier — nothing to check
+        }
+    }
+}
+
+/// CONN-ACCESS-MATCH for access connections.
+///
+/// For access connections (DataAccess, BusAccess, SubprogramAccess):
+/// - Classifiers must match (same as port connections)
+/// - Access kinds must be complementary (Provides ↔ Requires)
+fn check_access_match(
+    conn_name: &Name,
+    src_feat: &FeatureInstance,
+    dst_feat: &FeatureInstance,
+    src_name: &Name,
+    dst_name: &Name,
+    path: &[String],
+    diags: &mut Vec<AnalysisDiagnostic>,
+) {
+    let is_access = |kind: FeatureKind| {
+        matches!(
+            kind,
+            FeatureKind::DataAccess
+                | FeatureKind::BusAccess
+                | FeatureKind::SubprogramAccess
+                | FeatureKind::SubprogramGroupAccess
+        )
+    };
+
+    if !is_access(src_feat.kind) && !is_access(dst_feat.kind) {
+        return;
+    }
+
+    // Check classifier matching (same logic as ports)
+    match (&src_feat.classifier, &dst_feat.classifier) {
+        (Some(src_cls), Some(dst_cls)) => {
+            if !classifiers_match(src_cls, dst_cls) {
+                diags.push(AnalysisDiagnostic {
+                    severity: Severity::Error,
+                    message: format!(
+                        "connection '{}': source feature '{}' has classifier '{}' but \
+                         destination feature '{}' has classifier '{}' — access types must match",
+                        conn_name, src_name, src_cls, dst_name, dst_cls
+                    ),
+                    path: path.to_vec(),
+                    analysis: "classifier_match".to_string(),
+                });
+            }
+        }
+        (Some(cls), None) => {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Info,
+                message: format!(
+                    "connection '{}': source feature '{}' has classifier '{}' but \
+                     destination feature '{}' has no classifier — potential type safety gap",
+                    conn_name, src_name, cls, dst_name
+                ),
+                path: path.to_vec(),
+                analysis: "classifier_match".to_string(),
+            });
+        }
+        (None, Some(cls)) => {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Info,
+                message: format!(
+                    "connection '{}': destination feature '{}' has classifier '{}' but \
+                     source feature '{}' has no classifier — potential type safety gap",
+                    conn_name, dst_name, cls, src_name
+                ),
+                path: path.to_vec(),
+                analysis: "classifier_match".to_string(),
+            });
+        }
+        (None, None) => {}
+    }
+
+    // Check access kind compatibility: Provides ↔ Requires
+    match (&src_feat.access_kind, &dst_feat.access_kind) {
+        (Some(src_ak), Some(dst_ak)) => {
+            if src_ak == dst_ak {
+                diags.push(AnalysisDiagnostic {
+                    severity: Severity::Error,
+                    message: format!(
+                        "connection '{}': both source '{}' and destination '{}' are '{}' — \
+                         access connections require provides ↔ requires pairing",
+                        conn_name, src_name, dst_name, src_ak
+                    ),
+                    path: path.to_vec(),
+                    analysis: "classifier_match".to_string(),
+                });
+            }
+        }
+        _ => {
+            // One or both missing access_kind — skip (may not be resolvable)
+        }
+    }
+}
+
+/// Compare two classifier references for type-level equality.
+///
+/// Two classifiers match if their type names match (case-insensitive),
+/// and if both have package qualifiers, those must also match.
+fn classifiers_match(
+    a: &spar_hir_def::name::ClassifierRef,
+    b: &spar_hir_def::name::ClassifierRef,
+) -> bool {
+    // Type names must match
+    if !a.type_name.eq_ci(&b.type_name) {
+        return false;
+    }
+
+    // If both have package qualifiers, those must match too
+    match (&a.package, &b.package) {
+        (Some(pa), Some(pb)) => pa.eq_ci(pb),
+        // If only one has a package qualifier, we treat it as a match
+        // (the unqualified reference might resolve to the same package).
+        _ => true,
+    }
+}
+
+/// Find a feature instance by resolving a connection endpoint.
+fn find_feature<'a>(
+    instance: &'a SystemInstance,
+    owner: ComponentInstanceIdx,
+    subcomponent: &Option<Name>,
+    feature_name: &Name,
+) -> Option<&'a FeatureInstance> {
+    let comp = if let Some(sub_name) = subcomponent {
+        let owner_comp = instance.component(owner);
+        owner_comp
+            .children
+            .iter()
+            .find(|&&child_idx| instance.component(child_idx).name.eq_ci(sub_name))
+            .copied()?
+    } else {
+        owner
+    };
+
+    let comp_inst = instance.component(comp);
+    for &feat_idx in &comp_inst.features {
+        let feat = &instance.features[feat_idx];
+        if feat.name.eq_ci(feature_name) {
+            return Some(feat);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use la_arena::Arena;
+    use rustc_hash::FxHashMap;
+    use spar_hir_def::instance::*;
+    use spar_hir_def::item_tree::*;
+    use spar_hir_def::name::{ClassifierRef, Name};
+
+    struct TestBuilder {
+        components: Arena<ComponentInstance>,
+        features: Arena<FeatureInstance>,
+        connections: Arena<ConnectionInstance>,
+    }
+
+    impl TestBuilder {
+        fn new() -> Self {
+            Self {
+                components: Arena::default(),
+                features: Arena::default(),
+                connections: Arena::default(),
+            }
+        }
+
+        fn add_component(
+            &mut self,
+            name: &str,
+            category: ComponentCategory,
+            parent: Option<ComponentInstanceIdx>,
+        ) -> ComponentInstanceIdx {
+            self.components.alloc(ComponentInstance {
+                name: Name::new(name),
+                category,
+                type_name: Name::new(name),
+                impl_name: Some(Name::new("impl")),
+                package: Name::new("Pkg"),
+                parent,
+                children: Vec::new(),
+                features: Vec::new(),
+                connections: Vec::new(),
+                flows: Vec::new(),
+                modes: Vec::new(),
+                mode_transitions: Vec::new(),
+            })
+        }
+
+        fn add_feature(
+            &mut self,
+            name: &str,
+            kind: FeatureKind,
+            direction: Option<Direction>,
+            owner: ComponentInstanceIdx,
+            classifier: Option<ClassifierRef>,
+            access_kind: Option<AccessKind>,
+        ) -> FeatureInstanceIdx {
+            let idx = self.features.alloc(FeatureInstance {
+                name: Name::new(name),
+                kind,
+                direction,
+                owner,
+                classifier,
+                access_kind,
+            });
+            self.components[owner].features.push(idx);
+            idx
+        }
+
+        fn add_connection(
+            &mut self,
+            name: &str,
+            kind: ConnectionKind,
+            owner: ComponentInstanceIdx,
+            src: ConnectionEnd,
+            dst: ConnectionEnd,
+        ) -> ConnectionInstanceIdx {
+            let idx = self.connections.alloc(ConnectionInstance {
+                name: Name::new(name),
+                kind,
+                is_bidirectional: false,
+                owner,
+                src: Some(src),
+                dst: Some(dst),
+            });
+            self.components[owner].connections.push(idx);
+            idx
+        }
+
+        fn set_children(
+            &mut self,
+            parent: ComponentInstanceIdx,
+            children: Vec<ComponentInstanceIdx>,
+        ) {
+            self.components[parent].children = children;
+        }
+
+        fn build(self, root: ComponentInstanceIdx) -> SystemInstance {
+            SystemInstance {
+                root,
+                components: self.components,
+                features: self.features,
+                connections: self.connections,
+                flow_instances: Arena::default(),
+                end_to_end_flows: Arena::default(),
+                mode_instances: Arena::default(),
+                mode_transition_instances: Arena::default(),
+                diagnostics: Vec::new(),
+                property_maps: FxHashMap::default(),
+                semantic_connections: Vec::new(),
+                system_operation_modes: Vec::new(),
+            }
+        }
+    }
+
+    fn end(sub: Option<&str>, feat: &str) -> ConnectionEnd {
+        ConnectionEnd {
+            subcomponent: sub.map(Name::new),
+            feature: Name::new(feat),
+        }
+    }
+
+    fn cls(pkg: &str, typ: &str) -> Option<ClassifierRef> {
+        Some(ClassifierRef::qualified(Name::new(pkg), Name::new(typ)))
+    }
+
+    // ── CONN-CLASSIFIER-MATCH tests ──────────────────────────────────
+
+    #[test]
+    fn matching_classifiers_no_diagnostic() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "out1", FeatureKind::DataPort, Some(Direction::Out), a,
+            cls("DataTypes", "SensorData"), None,
+        );
+        b.add_feature(
+            "in1", FeatureKind::DataPort, Some(Direction::In), bb,
+            cls("DataTypes", "SensorData"), None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "out1"), end(Some("b"), "in1"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "matching classifiers should produce no diagnostics: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn mismatching_classifiers_error() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "out1", FeatureKind::DataPort, Some(Direction::Out), a,
+            cls("DataTypes", "SensorData"), None,
+        );
+        b.add_feature(
+            "in1", FeatureKind::DataPort, Some(Direction::In), bb,
+            cls("DataTypes", "CommandData"), None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "out1"), end(Some("b"), "in1"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        let errors: Vec<_> = diags.iter()
+            .filter(|d| d.severity == Severity::Error && d.message.contains("data types must match"))
+            .collect();
+        assert_eq!(
+            errors.len(), 1,
+            "mismatching classifiers should produce one error: {:?}", diags
+        );
+        assert!(errors[0].message.contains("SensorData"));
+        assert!(errors[0].message.contains("CommandData"));
+    }
+
+    #[test]
+    fn one_missing_classifier_info() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "out1", FeatureKind::DataPort, Some(Direction::Out), a,
+            cls("DataTypes", "SensorData"), None,
+        );
+        b.add_feature(
+            "in1", FeatureKind::DataPort, Some(Direction::In), bb,
+            None, None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "out1"), end(Some("b"), "in1"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        let infos: Vec<_> = diags.iter()
+            .filter(|d| d.severity == Severity::Info && d.message.contains("type safety gap"))
+            .collect();
+        assert_eq!(
+            infos.len(), 1,
+            "one missing classifier should produce info: {:?}", diags
+        );
+    }
+
+    #[test]
+    fn no_classifier_on_either_side_no_diagnostic() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "out1", FeatureKind::DataPort, Some(Direction::Out), a,
+            None, None,
+        );
+        b.add_feature(
+            "in1", FeatureKind::DataPort, Some(Direction::In), bb,
+            None, None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "out1"), end(Some("b"), "in1"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "no classifiers on either side should produce no diagnostics: {:?}",
+            diags
+        );
+    }
+
+    // ── CONN-ACCESS-MATCH tests ──────────────────────────────────────
+
+    #[test]
+    fn access_provides_requires_match_no_error() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "acc1", FeatureKind::DataAccess, None, a,
+            cls("DataTypes", "SharedBuffer"), Some(AccessKind::Provides),
+        );
+        b.add_feature(
+            "acc2", FeatureKind::DataAccess, None, bb,
+            cls("DataTypes", "SharedBuffer"), Some(AccessKind::Requires),
+        );
+        b.add_connection("c1", ConnectionKind::Access, root,
+            end(Some("a"), "acc1"), end(Some("b"), "acc2"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        let errors: Vec<_> = diags.iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "provides/requires pairing should produce no errors: {:?}", errors
+        );
+    }
+
+    #[test]
+    fn access_same_direction_error() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "acc1", FeatureKind::DataAccess, None, a,
+            cls("DataTypes", "SharedBuffer"), Some(AccessKind::Provides),
+        );
+        b.add_feature(
+            "acc2", FeatureKind::DataAccess, None, bb,
+            cls("DataTypes", "SharedBuffer"), Some(AccessKind::Provides),
+        );
+        b.add_connection("c1", ConnectionKind::Access, root,
+            end(Some("a"), "acc1"), end(Some("b"), "acc2"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        let errors: Vec<_> = diags.iter()
+            .filter(|d| d.severity == Severity::Error && d.message.contains("provides"))
+            .collect();
+        assert_eq!(
+            errors.len(), 1,
+            "same access direction should produce an error: {:?}", diags
+        );
+    }
+
+    #[test]
+    fn event_data_port_matching_classifier_ok() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "evt_out", FeatureKind::EventDataPort, Some(Direction::Out), a,
+            cls("DataTypes", "AlertMsg"), None,
+        );
+        b.add_feature(
+            "evt_in", FeatureKind::EventDataPort, Some(Direction::In), bb,
+            cls("DataTypes", "AlertMsg"), None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "evt_out"), end(Some("b"), "evt_in"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "matching EventDataPort classifiers should produce no diagnostics: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn cross_component_classifier_match() {
+        // Test across a deeper hierarchy: root -> mid -> leaf connections
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let mid_a = b.add_component("mid_a", ComponentCategory::System, Some(root));
+        let mid_b = b.add_component("mid_b", ComponentCategory::System, Some(root));
+
+        // Features on the mid-level components
+        b.add_feature(
+            "data_out", FeatureKind::DataPort, Some(Direction::Out), mid_a,
+            cls("Pkg", "Telemetry"), None,
+        );
+        b.add_feature(
+            "data_in", FeatureKind::DataPort, Some(Direction::In), mid_b,
+            cls("pkg", "telemetry"), None, // different case — should still match
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("mid_a"), "data_out"), end(Some("mid_b"), "data_in"));
+        b.set_children(root, vec![mid_a, mid_b]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "case-insensitive classifier match should produce no diagnostics: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn access_classifier_mismatch_error() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "bus_acc", FeatureKind::BusAccess, None, a,
+            cls("HW", "PCIBus"), Some(AccessKind::Provides),
+        );
+        b.add_feature(
+            "bus_acc", FeatureKind::BusAccess, None, bb,
+            cls("HW", "EthernetBus"), Some(AccessKind::Requires),
+        );
+        b.add_connection("c1", ConnectionKind::Access, root,
+            end(Some("a"), "bus_acc"), end(Some("b"), "bus_acc"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        let errors: Vec<_> = diags.iter()
+            .filter(|d| d.severity == Severity::Error && d.message.contains("access types must match"))
+            .collect();
+        assert_eq!(
+            errors.len(), 1,
+            "access classifier mismatch should produce an error: {:?}", diags
+        );
+    }
+
+    #[test]
+    fn event_port_no_classifier_check() {
+        // Pure event ports don't carry data classifiers — should not trigger diagnostics
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let a = b.add_component("a", ComponentCategory::Process, Some(root));
+        let bb = b.add_component("b", ComponentCategory::Process, Some(root));
+        b.add_feature(
+            "evt_out", FeatureKind::EventPort, Some(Direction::Out), a,
+            None, None,
+        );
+        b.add_feature(
+            "evt_in", FeatureKind::EventPort, Some(Direction::In), bb,
+            None, None,
+        );
+        b.add_connection("c1", ConnectionKind::Port, root,
+            end(Some("a"), "evt_out"), end(Some("b"), "evt_in"));
+        b.set_children(root, vec![a, bb]);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "pure event ports should not produce classifier diagnostics: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn incomplete_connection_skipped() {
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let idx = b.connections.alloc(ConnectionInstance {
+            name: Name::new("c_incomplete"),
+            kind: ConnectionKind::Port,
+            is_bidirectional: false,
+            owner: root,
+            src: None,
+            dst: None,
+        });
+        b.components[root].connections.push(idx);
+
+        let inst = b.build(root);
+        let diags = ClassifierMatchAnalysis.analyze(&inst);
+        assert!(
+            diags.is_empty(),
+            "incomplete connections should be skipped: {:?}",
+            diags
+        );
+    }
+}

--- a/crates/spar-analysis/src/connection_rules.rs
+++ b/crates/spar-analysis/src/connection_rules.rs
@@ -223,6 +223,8 @@ mod tests {
                 kind,
                 direction,
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/direction_rules.rs
+++ b/crates/spar-analysis/src/direction_rules.rs
@@ -363,6 +363,8 @@ mod tests {
                 kind,
                 direction,
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/flow_check.rs
+++ b/crates/spar-analysis/src/flow_check.rs
@@ -240,6 +240,8 @@ mod tests {
                 kind,
                 direction: Some(dir),
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/legality.rs
+++ b/crates/spar-analysis/src/legality.rs
@@ -487,6 +487,8 @@ mod tests {
                 kind,
                 direction,
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/lib.rs
+++ b/crates/spar-analysis/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod arinc653;
 pub mod binding_check;
 pub mod category_check;
+pub mod classifier_match;
 pub mod completeness;
 pub mod connection_rules;
 pub mod connectivity;

--- a/crates/spar-analysis/src/mode_check.rs
+++ b/crates/spar-analysis/src/mode_check.rs
@@ -222,6 +222,8 @@ mod tests {
                 kind,
                 direction: Some(dir),
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/mode_rules.rs
+++ b/crates/spar-analysis/src/mode_rules.rs
@@ -190,6 +190,8 @@ mod tests {
                 kind,
                 direction: Some(dir),
                 owner,
+                classifier: None,
+                access_kind: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/tests.rs
+++ b/crates/spar-analysis/src/tests.rs
@@ -69,6 +69,8 @@ impl TestInstanceBuilder {
             kind,
             direction,
             owner,
+            classifier: None,
+            access_kind: None,
         });
         self.components[owner].features.push(idx);
         idx

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -431,6 +431,7 @@ fn run_all_analyses(
 ) -> Vec<spar_analysis::AnalysisDiagnostic> {
     use spar_analysis::arinc653::Arinc653Analysis;
     use spar_analysis::binding_check::BindingCheckAnalysis;
+    use spar_analysis::classifier_match::ClassifierMatchAnalysis;
     use spar_analysis::completeness::CompletenessAnalysis;
     use spar_analysis::connectivity::ConnectivityAnalysis;
     use spar_analysis::direction_rules::DirectionRuleAnalysis;
@@ -448,6 +449,7 @@ fn run_all_analyses(
     runner.register(Box::new(HierarchyAnalysis));
     runner.register(Box::new(CompletenessAnalysis));
     runner.register(Box::new(DirectionRuleAnalysis));
+    runner.register(Box::new(ClassifierMatchAnalysis));
     runner.register(Box::new(BindingCheckAnalysis));
     runner.register(Box::new(FlowCheckAnalysis));
     runner.register(Box::new(ModeCheckAnalysis));

--- a/crates/spar-hir-def/src/instance.rs
+++ b/crates/spar-hir-def/src/instance.rs
@@ -12,7 +12,7 @@ use la_arena::{Arena, Idx};
 use rustc_hash::FxHashMap;
 
 use crate::feature_group::{expand_feature_group, ExpandedFeature};
-use crate::item_tree::{ComponentCategory, ConnectionKind, Direction, FeatureKind, FlowKind};
+use crate::item_tree::{AccessKind, ComponentCategory, ConnectionKind, Direction, FeatureKind, FlowKind};
 use crate::name::{ClassifierRef, Name};
 use crate::properties::PropertyMap;
 use crate::resolver::{GlobalScope, ResolvedClassifier};
@@ -83,6 +83,10 @@ pub struct FeatureInstance {
     pub kind: FeatureKind,
     pub direction: Option<Direction>,
     pub owner: ComponentInstanceIdx,
+    /// Classifier reference for the feature's data type (if any).
+    pub classifier: Option<ClassifierRef>,
+    /// For access features: provides or requires.
+    pub access_kind: Option<AccessKind>,
 }
 
 /// A connection instance.
@@ -926,6 +930,8 @@ impl<'a> Builder<'a> {
                             kind: feat.kind,
                             direction: feat.direction,
                             owner: idx,
+                            classifier: feat.classifier.clone(),
+                            access_kind: feat.access_kind,
                         });
                         feat_indices.push(fi);
                     }

--- a/crates/spar-wasm/src/render.rs
+++ b/crates/spar-wasm/src/render.rs
@@ -134,6 +134,7 @@ pub fn analyze_aadl_from_fs(
     runner.register(Box::new(spar_analysis::resource_budget::ResourceBudgetAnalysis));
     runner.register(Box::new(spar_analysis::direction_rules::DirectionRuleAnalysis));
     runner.register(Box::new(spar_analysis::connection_rules::ConnectionRuleAnalysis));
+    runner.register(Box::new(spar_analysis::classifier_match::ClassifierMatchAnalysis));
     runner.register(Box::new(spar_analysis::mode_rules::ModeRuleAnalysis));
     runner.register(Box::new(spar_analysis::subcomponent_rules::SubcomponentRuleAnalysis));
     runner.register(Box::new(spar_analysis::emv2_analysis::Emv2Analysis));


### PR DESCRIPTION
## Summary
- Extend `FeatureInstance` with `classifier` and `access_kind` fields
- Add `ClassifierMatchAnalysis` with 3 rules: CONN-CLASSIFIER-MATCH, CONN-ACCESS-MATCH, CONN-CLASSIFIER-MISSING
- Register in CLI and WASM analysis runner

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)