### PR TITLE
feat: release workflow and CI quality gate upgrades

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+# Nextest configuration
+# See https://nexte.st/docs/configuration/
+
+[profile.ci]
+# Fail-fast disabled so all tests run even if some fail
+fail-fast = false
+
+[profile.ci.junit]
+# Output JUnit XML for CI consumption
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: "-D warnings"
 
 jobs:
+  # ── Fast checks ───────────────────────────────────────────────────────
   fmt:
     name: Format
     runs-on: ubuntu-latest
@@ -32,6 +33,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # ── Tests ─────────────────────────────────────────────────────────────
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -39,7 +41,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Run tests (JUnit XML output)
+        run: cargo nextest run --workspace --profile ci
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: ignore
+
+  # ── Security audits ──────────────────────────────────────────────────
+  audit:
+    name: Security Audit (RustSec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   deny:
     name: Cargo Deny
@@ -48,11 +72,35 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
 
-  audit:
-    name: Security Audit
+  # ── Code coverage ────────────────────────────────────────────────────
+  coverage:
+    name: Code Coverage
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          token: ${{ github.token }}
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Generate coverage (LCOV + HTML)
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --html --output-dir coverage-html
+      - name: Upload LCOV to Codecov
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage-html/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,192 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── Cross-platform binary builds ──────────────────────────────────────
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-14
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }} -p spar
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }} -p spar
+
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: strip "target/${TARGET}/release/spar" 2>/dev/null || true
+
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          ARCHIVE="spar-${VERSION}-${TARGET}.tar.gz"
+          mkdir -p staging
+          cp "target/${TARGET}/release/spar" staging/
+          tar -czf "$ARCHIVE" -C staging .
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          ARCHIVE="spar-${VERSION}-${TARGET}.zip"
+          mkdir -p staging
+          cp "target/${TARGET}/release/spar.exe" staging/
+          cd staging && 7z a "../$ARCHIVE" . && cd ..
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  # ── Test evidence bundle ──────────────────────────────────────────────
+  build-test-evidence:
+    name: Build test evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest,cargo-llvm-cov
+
+      - name: Run tests with JUnit XML
+        run: |
+          mkdir -p test-evidence/test-results
+          cargo nextest run --workspace --profile ci
+          cp target/nextest/ci/junit.xml test-evidence/test-results/junit.xml
+
+      - name: Generate coverage
+        run: |
+          mkdir -p test-evidence/coverage
+          cargo llvm-cov --workspace --lcov --output-path test-evidence/coverage/lcov.info
+          cargo llvm-cov report --workspace > test-evidence/coverage/summary.txt
+
+      - name: Run spar analyze on test models
+        run: |
+          mkdir -p test-evidence/validation
+          set +e
+          cargo run --release -- analyze --root Analysis_Pkg::Full_System.Impl \
+            test-data/analysis_test.aadl > test-evidence/validation/analyze-output.txt 2>&1
+          rc=$?
+          set -e
+          echo "exit_code=${rc}" >> test-evidence/validation/analyze-output.txt
+
+      - name: Generate metadata
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          jq -n \
+            --arg tag "${TAG}" \
+            --arg commit "${GITHUB_SHA}" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg rust_version "$(rustc --version)" \
+            --arg os "$(uname -srm)" \
+            '{tag: $tag, commit: $commit, timestamp: $timestamp, rust_version: $rust_version, os: $os}' \
+            > test-evidence/metadata.json
+
+      - name: Package
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          tar czf "spar-${VERSION}-test-evidence.tar.gz" test-evidence/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-evidence
+          path: spar-*-test-evidence.tar.gz
+
+  # ── Create GitHub Release ─────────────────────────────────────────────
+  create-release:
+    name: Create GitHub Release
+    needs: [build-binaries, build-test-evidence]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect assets
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} release/ \;
+          ls -la release/
+
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          gh release create "$VERSION" \
+            --title "spar $VERSION" \
+            --generate-notes \
+            release/*


### PR DESCRIPTION
## Summary
- New `release.yml` workflow triggered on `v*` tags — mirrors rivet's release pipeline
- Upgraded `ci.yml` with nextest, coverage, and Codecov integration
- Added `.config/nextest.toml` for JUnit XML output in CI

## Release workflow (on tag push)
- Cross-platform binary builds: linux x86/arm64, macOS x86/arm64, Windows x86
- Test evidence bundle: JUnit XML, LCOV coverage, spar analyze output, metadata.json
- SHA256 checksums for all artifacts
- GitHub Release creation with auto-generated notes

## CI upgrades
- Tests via cargo-nextest (JUnit XML artifact upload)
- Code coverage via cargo-llvm-cov (LCOV + HTML report artifact)
- Codecov upload when `CODECOV_TOKEN` secret is configured

## Test plan
- [x] CI workflow runs on this PR (format, clippy, test, deny, audit, coverage)
- [ ] Release workflow validated by tagging `v0.1.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)