### PR TITLE
fix: remove unsupported --workspace flag from llvm-cov report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           mkdir -p test-evidence/coverage
           cargo llvm-cov --workspace --lcov --output-path test-evidence/coverage/lcov.info
-          cargo llvm-cov report --workspace > test-evidence/coverage/summary.txt
+          cargo llvm-cov report > test-evidence/coverage/summary.txt
 
       - name: Run spar analyze on test models
         run: |


### PR DESCRIPTION
Fixes the release workflow test evidence build failure — `cargo llvm-cov report` doesn't support `--workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)