### PR TITLE
feat: add rivet compliance report to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,26 @@ jobs:
           name: binary-${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
 
+  # ── Compliance report (HTML export via rivet) ─────────────────────────
+  build-compliance:
+    name: Build compliance report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate compliance report
+        id: report
+        uses: pulseengine/rivet/.github/actions/compliance@main
+        with:
+          theme: dark
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compliance-report
+          path: ${{ steps.report.outputs.archive-path }}
+
   # ── Test evidence bundle ──────────────────────────────────────────────
   build-test-evidence:
     name: Build test evidence
@@ -159,7 +179,7 @@ jobs:
   # ── Create GitHub Release ─────────────────────────────────────────────
   create-release:
     name: Create GitHub Release
-    needs: [build-binaries, build-test-evidence]
+    needs: [build-binaries, build-compliance, build-test-evidence]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds the rivet compliance report generation to the release workflow, using the reusable `pulseengine/rivet/.github/actions/compliance@main` composite action.

On tag push, the release now produces:
- Cross-platform binaries (5 targets)
- **Compliance report** (HTML traceability matrix, coverage, validation) -- NEW
- Test evidence bundle (JUnit, LCOV, analysis output)
- SHA256 checksums

## Test plan
- [x] CI passes on this PR
- [ ] Validated on next tag push (v0.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)