### PR TITLE
fix: use pre-built rivet binary for compliance report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,14 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
 
       - name: Generate compliance report
         id: report
         uses: pulseengine/rivet/.github/actions/compliance@main
         with:
           theme: dark
+          rivet-version: v0.1.0
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The compliance action defaults to `rivet-version: source` which tries to `cargo build -p rivet-cli` — fails in the spar repo. Set `rivet-version: v0.1.0` to download the pre-built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)