### PR TITLE
fix(ci): scope Miri to instance tests, avoid rowan UB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,18 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
-      - name: Run Miri
-        run: cargo miri test -p spar-hir-def --lib
+      - name: Run Miri (instance model tests)
+        # Filter to instance:: tests to avoid known rowan UB (rust-analyzer/rowan issue 192).
+        # rowan's custom Arc implementation has a retag issue in HeaderSlice that
+        # triggers Miri's borrow stack check. This is upstream, not our code.
+        # Once rowan ships a fix, expand to full --lib.
+        run: "cargo miri test -p spar-hir-def --lib -- instance::"
         env:
           MIRIFLAGS: "-Zmiri-strict-provenance -Zmiri-disable-isolation"
 


### PR DESCRIPTION
## Summary
The Miri UB (`retag from SharedReadOnly`) is in **rowan 0.16.1**'s custom `Arc` implementation (`arc.rs:260`), not our code. This is tracked upstream as [rust-analyzer/rowan#192](https://github.com/rust-analyzer/rowan/issues/192).

**Fix:** Filter Miri to `instance::` tests only. These exercise our arena-indexed instance model (the code we care about) without hitting rowan's parser path. Removes `continue-on-error` so Miri is now a blocking check for our code.

23 instance tests pass Miri cleanly with strict provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)