### PR TITLE
fix(vscode): register commands before LSP, add README

### DIFF
--- a/vscode-spar/CHANGELOG.md
+++ b/vscode-spar/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.2.0 (2026-03-19)
+
+Initial release.
+
+### Features
+- AADL v2.2 syntax highlighting (TextMate grammar)
+- LSP client with 10 IDE features (diagnostics, hover, go-to-definition, completion, rename, formatting, code actions, document symbols, workspace symbols, inlay hints)
+- Live architecture diagram webview with interactive HTML
+- Port visualization with direction indicators and type colors
+- Orthogonal edge routing with obstacle avoidance
+- Pan/zoom/selection in diagram
+- Root system auto-detection and QuickPick selector
+- Status bar indicator for current root system

--- a/vscode-spar/README.md
+++ b/vscode-spar/README.md
@@ -1,0 +1,66 @@
+# AADL (spar) — VS Code Extension
+
+AADL v2.2 language support with live interactive architecture diagrams.
+
+Powered by [spar](https://github.com/pulseengine/spar), an open-source AADL toolchain with 21 analysis passes, port-aware rendering, and orthogonal edge routing.
+
+## Features
+
+### Syntax Highlighting
+Full TextMate grammar for AADL v2.2 — keywords, component categories, features, connections, properties, modes, and annexes.
+
+### Language Server (10 IDE Features)
+- **Diagnostics** — parser errors + 21 analysis passes on save
+- **Hover** — component types, features, keywords
+- **Go-to-Definition** — cross-file classifier references
+- **Completion** — keywords, classifiers, properties, packages
+- **Document Symbols** — packages, types, implementations
+- **Workspace Symbols** — search across all files
+- **Code Actions** — quick-fix end-names, semicolons, with-clauses
+- **Formatting** — hierarchical indentation
+- **Rename** — components, features, subcomponents
+- **Inlay Hints** — component category, connection direction
+
+### Live Architecture Diagram
+Interactive HTML diagram that updates on every save:
+- **Port visualization** with direction indicators and type colors
+- **Orthogonal edge routing** with obstacle avoidance
+- **Pan/zoom** — mouse wheel + drag
+- **Selection** — click nodes, Ctrl+click for multi-select
+- **Semantic zoom** — detail collapses at overview levels
+
+## Quick Start
+
+1. **Install spar binary** — download from [GitHub Releases](https://github.com/pulseengine/spar/releases/latest) and add to PATH
+2. **Open an AADL workspace** — any folder with `.aadl` files
+3. **Show diagram** — run `AADL: Show Architecture Diagram` from the command palette (Ctrl+Shift+P)
+4. **Select root** — if multiple system implementations exist, pick one from the QuickPick
+
+## Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `spar.binaryPath` | Path to spar binary | (auto-detect from PATH) |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `AADL: Show Architecture Diagram` | Open interactive diagram beside editor |
+| `AADL: Select Root System` | Choose which system implementation to render |
+
+## Requirements
+
+- **spar CLI** — download from [releases](https://github.com/pulseengine/spar/releases/latest) (Linux, macOS, Windows)
+- VS Code 1.100+
+
+## Links
+
+- [spar on GitHub](https://github.com/pulseengine/spar)
+- [Latest Release](https://github.com/pulseengine/spar/releases/latest)
+- [Issue Tracker](https://github.com/pulseengine/spar/issues)
+- [AADL Standard (SAE AS5506C)](https://www.sae.org/standards/content/as5506c/)
+
+## License
+
+MIT

--- a/vscode-spar/src/extension.ts
+++ b/vscode-spar/src/extension.ts
@@ -14,44 +14,56 @@ let statusBarItem: vscode.StatusBarItem;
 let renderTimer: ReturnType<typeof setTimeout> | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  // --- LSP Client ---
-  const sparPath = findSparBinary();
-  if (sparPath) {
-    const serverOptions: ServerOptions = {
-      command: sparPath,
-      args: ['lsp'],
-      transport: TransportKind.stdio,
-    };
-
-    const clientOptions: LanguageClientOptions = {
-      documentSelector: [{ scheme: 'file', language: 'aadl' }],
-      synchronize: {
-        fileEvents: vscode.workspace.createFileSystemWatcher('**/*.aadl'),
-      },
-    };
-
-    client = new LanguageClient('spar', 'AADL (spar)', serverOptions, clientOptions);
-    await client.start();
-    context.subscriptions.push({ dispose: () => client?.stop() });
-  } else {
-    vscode.window.showWarningMessage(
-      'spar binary not found. Install spar or set spar.binaryPath for LSP features.'
-    );
-  }
-
-  // --- Status Bar ---
-  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
-  statusBarItem.command = 'spar.selectRoot';
-  statusBarItem.tooltip = 'AADL root system for diagram';
-  updateStatusBar();
-  statusBarItem.show();
-  context.subscriptions.push(statusBarItem);
-
-  // --- Commands ---
+  // --- Commands (register FIRST, before anything that can fail) ---
   context.subscriptions.push(
     vscode.commands.registerCommand('spar.showDiagram', () => showDiagram(context)),
     vscode.commands.registerCommand('spar.selectRoot', () => selectRoot(context)),
   );
+
+  // --- Status Bar ---
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  statusBarItem.command = 'spar.selectRoot';
+  statusBarItem.tooltip = 'Click to select AADL root system for diagram';
+  updateStatusBar();
+  statusBarItem.show();
+  context.subscriptions.push(statusBarItem);
+
+  // --- LSP Client (may fail if binary not found — must not break commands) ---
+  const sparPath = findSparBinary();
+  if (sparPath) {
+    try {
+      const serverOptions: ServerOptions = {
+        command: sparPath,
+        args: ['lsp'],
+        transport: TransportKind.stdio,
+      };
+
+      const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'aadl' }],
+        synchronize: {
+          fileEvents: vscode.workspace.createFileSystemWatcher('**/*.aadl'),
+        },
+      };
+
+      client = new LanguageClient('spar', 'AADL (spar)', serverOptions, clientOptions);
+      await client.start();
+      context.subscriptions.push({ dispose: () => client?.stop() });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showWarningMessage(`spar LSP failed to start: ${msg}`);
+    }
+  } else {
+    const action = await vscode.window.showWarningMessage(
+      'spar binary not found. LSP features require the spar CLI.',
+      'Download spar',
+      'Set Path',
+    );
+    if (action === 'Download spar') {
+      vscode.env.openExternal(vscode.Uri.parse('https://github.com/pulseengine/spar/releases/latest'));
+    } else if (action === 'Set Path') {
+      vscode.commands.executeCommand('workbench.action.openSettings', 'spar.binaryPath');
+    }
+  }
 
   // --- Re-render on save ---
   context.subscriptions.push(
@@ -64,9 +76,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // --- Auto-detect root ---
-  if (!rootClassifier) {
-    await autoDetectRoot(context);
-  }
+  await autoDetectRoot(context);
 }
 
 export function deactivate() {
@@ -74,7 +84,7 @@ export function deactivate() {
   return client?.stop();
 }
 
-// --- Binary discovery (uses execFileSync — safe, no shell injection) ---
+// --- Binary discovery (execFileSync — safe, no shell injection) ---
 
 function findSparBinary(): string | undefined {
   const configured = vscode.workspace.getConfiguration('spar').get<string>('binaryPath');
@@ -95,20 +105,24 @@ function showDiagram(context: vscode.ExtensionContext) {
     return;
   }
 
+  if (!rootClassifier) {
+    selectRoot(context).then(() => {
+      if (rootClassifier) {
+        showDiagram(context);
+      }
+    });
+    return;
+  }
+
   diagramPanel = vscode.window.createWebviewPanel(
     'aadlDiagram',
-    `AADL: ${rootClassifier ?? 'No Root'}`,
+    `AADL: ${rootClassifier}`,
     vscode.ViewColumn.Beside,
     { enableScripts: true, retainContextWhenHidden: true }
   );
 
   diagramPanel.onDidDispose(() => { diagramPanel = undefined; });
-
-  if (rootClassifier) {
-    renderDiagram(context);
-  } else {
-    diagramPanel.webview.html = noRootHtml();
-  }
+  renderDiagram(context);
 }
 
 async function renderDiagram(_context: vscode.ExtensionContext) {
@@ -116,16 +130,21 @@ async function renderDiagram(_context: vscode.ExtensionContext) {
 
   const sparPath = findSparBinary();
   if (!sparPath) {
-    diagramPanel.webview.html = errorHtml('spar binary not found');
+    diagramPanel.webview.html = errorHtml(
+      'spar binary not found',
+      'Install spar from <a href="https://github.com/pulseengine/spar/releases/latest">GitHub Releases</a> or set <code>spar.binaryPath</code> in settings.'
+    );
     return;
   }
 
   try {
     const files = await vscode.workspace.findFiles('**/*.aadl');
     if (files.length === 0) {
-      diagramPanel.webview.html = errorHtml('No .aadl files found in workspace');
+      diagramPanel.webview.html = errorHtml('No .aadl files found', 'Open a workspace containing AADL files.');
       return;
     }
+
+    diagramPanel.webview.html = loadingHtml(rootClassifier);
 
     const filePaths = files.map((f) => f.fsPath);
 
@@ -142,7 +161,7 @@ async function renderDiagram(_context: vscode.ExtensionContext) {
     diagramPanel.title = `AADL: ${rootClassifier}`;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    diagramPanel.webview.html = errorHtml(message);
+    diagramPanel.webview.html = errorHtml('Render failed', message);
   }
 }
 
@@ -167,12 +186,12 @@ async function autoDetectRoot(context: vscode.ExtensionContext) {
 async function selectRoot(context: vscode.ExtensionContext) {
   const roots = await findSystemImplementations();
   if (roots.length === 0) {
-    vscode.window.showWarningMessage('No system implementations found in workspace');
+    vscode.window.showWarningMessage('No system implementations found in workspace .aadl files');
     return;
   }
 
   const picked = await vscode.window.showQuickPick(roots, {
-    placeHolder: 'Select root system implementation',
+    placeHolder: 'Select root system implementation for diagram',
   });
 
   if (picked) {
@@ -209,27 +228,34 @@ async function findSystemImplementations(): Promise<string[]> {
 function updateStatusBar() {
   statusBarItem.text = rootClassifier
     ? `$(circuit-board) ${rootClassifier}`
-    : '$(circuit-board) AADL: No Root';
+    : '$(circuit-board) AADL: Select Root';
 }
 
 // --- HTML templates ---
 
-function noRootHtml(): string {
+function loadingHtml(root: string): string {
   return `<!DOCTYPE html>
 <html><head><style>
 body{background:#1e1e2e;color:#cdd6f4;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh}
-.msg{text-align:center}code{background:#313244;padding:2px 6px;border-radius:4px}
-</style></head><body><div class="msg">
-<h2>No Root System Selected</h2>
-<p>Run <code>AADL: Select Root System</code> from the command palette.</p>
+.loader{text-align:center}
+.spinner{width:40px;height:40px;border:3px solid #313244;border-top:3px solid #89b4fa;border-radius:50%;animation:spin 1s linear infinite;margin:0 auto 1em}
+@keyframes spin{to{transform:rotate(360deg)}}
+</style></head><body><div class="loader">
+<div class="spinner"></div>
+<p>Rendering ${root.replace(/</g, '&lt;')}...</p>
 </div></body></html>`;
 }
 
-function errorHtml(message: string): string {
-  const e = message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+function errorHtml(title: string, detail: string): string {
   return `<!DOCTYPE html>
 <html><head><style>
-body{background:#1e1e2e;color:#f38ba8;font-family:system-ui;padding:2em}
-pre{background:#313244;padding:1em;border-radius:8px;white-space:pre-wrap;color:#cdd6f4}
-</style></head><body><h2>Render Error</h2><pre>${e}</pre></body></html>`;
+body{background:#1e1e2e;color:#cdd6f4;font-family:system-ui;padding:2em}
+h2{color:#f38ba8}
+pre{background:#313244;padding:1em;border-radius:8px;white-space:pre-wrap;overflow-x:auto}
+a{color:#89b4fa}code{background:#313244;padding:2px 6px;border-radius:4px}
+</style></head><body>
+<h2>${title.replace(/</g, '&lt;')}</h2>
+<pre>${detail.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>
+<p><a href="https://github.com/pulseengine/spar/releases/latest">Download latest spar release</a></p>
+</body></html>`;
 }


### PR DESCRIPTION
## Bug Fix
Commands `spar.showDiagram` and `spar.selectRoot` were "not found" because they were registered AFTER `client.start()` which throws if spar binary is missing. Now commands register first.

## Improvements
- README.md for marketplace (features, quick start, configuration, links)
- CHANGELOG.md
- Loading spinner in webview during rendering
- "Download spar" / "Set Path" action buttons when binary not found
- Auto-prompt root selection when showing diagram without a root selected
- Graceful LSP failure handling (catch + warning, don't abort activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)