### PR TITLE
chore: bump VS Code extension version to 0.4.0

### DIFF
--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump vscode-spar/package.json version from 0.3.0 to 0.4.0
- Required for release workflow version consistency check

## Test plan
- [x] No code changes, only version field

🤖 Generated with [Claude Code](https://claude.com/claude-code)