### PR TITLE
fix(proofs): move RTAJittered.lean imports above all comments

### DIFF
--- a/proofs/Proofs/Scheduling/RTAJittered.lean
+++ b/proofs/Proofs/Scheduling/RTAJittered.lean
@@ -1,37 +1,37 @@
-/-! Mirrors `compute_response_time_jittered` in
-    `crates/spar-analysis/src/scheduling_verified.rs` (PR #147).
-    The Rust implementation is checked against this spec via property tests
-    in that file's `#[cfg(test)] mod tests`. -/
+/-! # Jittered Response Time Analysis — convergence theorems
 
-/-
-  Jittered Response Time Analysis (RTA) — Fixed-Point Convergence
+Mirrors `compute_response_time_jittered` in
+`crates/spar-analysis/src/scheduling_verified.rs` (PR #147).
+The Rust implementation is checked against this spec via property tests
+in that file's `#[cfg(test)] mod tests`.
 
-  Reference: Tindell & Clark, "Holistic schedulability analysis for
-  distributed hard real-time systems", Microprocessing & Microprogramming,
-  1994.  Joseph & Pandya 1986 for the un-jittered baseline.
+Reference: Tindell & Clark, "Holistic schedulability analysis for
+distributed hard real-time systems", Microprocessing & Microprogramming,
+1994.  Joseph & Pandya 1986 for the un-jittered baseline.
 
-  We extend the RTA recurrence in `RTA.lean` with three new ingredients:
-    1. The task under analysis has a release jitter `J_i` added as a
-       constant offset to its response window.
-    2. Each higher-priority task `j` has its own release jitter `J_j`
-       which inflates the ceiling count: ⌈(R + J_j) / T_j⌉ × C_j.
-    3. Periodic ISR overhead enters as an extra monotone term
-       `IsrOverhead : Nat → Nat`.
+We extend the RTA recurrence in `RTA.lean` with three new ingredients:
+  1. The task under analysis has a release jitter `J_i` added as a
+     constant offset to its response window.
+  2. Each higher-priority task `j` has its own release jitter `J_j`
+     which inflates the ceiling count: ⌈(R + J_j) / T_j⌉ × C_j.
+  3. Periodic ISR overhead enters as an extra monotone term
+     `IsrOverhead : Nat → Nat`.
 
-  Recurrence:
-    R(0)   = C_i + J_i
-    R(n+1) = C_i + J_i
-           + Σ_j ⌈(R(n) + J_j) / T_j⌉ × C_j
-           + IsrOverhead(R(n))
+Recurrence:
 
-  When all `J_j = 0`, `J_i = 0`, and `IsrOverhead = fun _ => 0`, this
-  reduces to `Spar.Scheduling.RTA.rtaStep` modulo packaging.
+  R(0)   = C_i + J_i
+  R(n+1) = C_i + J_i
+         + Σ_j ⌈(R(n) + J_j) / T_j⌉ × C_j
+         + IsrOverhead(R(n))
 
-  This file states the theorems anchoring the Rust implementation in
-  `compute_response_time_jittered`.  Convergence is established under
-  the same termination argument as the un-jittered case — monotone
-  non-decreasing sequence bounded by the deadline.
--/
+When all `J_j = 0`, `J_i = 0`, and `IsrOverhead = fun _ => 0`, this
+reduces to `Spar.Scheduling.RTA.rtaStep` modulo packaging.
+
+This file states the theorems anchoring the Rust implementation in
+`compute_response_time_jittered`.  Convergence is established under
+the same termination argument as the un-jittered case — monotone
+non-decreasing sequence bounded by the deadline. -/
+
 import Mathlib.Tactic
 import Proofs.Scheduling.RTA
 


### PR DESCRIPTION
## Summary

The new Lean CI gate from #151 surfaced a real syntax error in \`proofs/Proofs/Scheduling/RTAJittered.lean\` (landed in #148):

\`\`\`
error: Proofs/Scheduling/RTAJittered.lean:35:0:
       invalid 'import' command, it must be used in the beginning of the file
\`\`\`

Lean 4.29.0-rc6 requires \`import\` to come before any other top-level content. The original file had a leading \`/-!\` docstring (OK) followed by a \`/- ... -/\` block comment (NOT OK), then the imports. Lean treats the second block as a top-level command, which makes the imports illegal.

## Fix

Merged the two blocks into a single \`/-! ... -/\` module docstring placed **before** the imports. Lean's leading-docstring exception still holds, so imports remain \"at the beginning\".

Content unchanged — only the comment framing.

## Why this slipped through

The Track A commit-3 agent (#148) couldn't run \`lake build\` locally (no Lean toolchain in sandbox). It explicitly flagged this risk in its report. The new \`use-mathlib-cache: true\` path on #151 pulls Mathlib in ~5 min instead of timing out at 60 min, finally letting CI reach our in-tree files.

## Test plan

- [ ] CI Lean job passes
- [ ] No regressions to \`cargo test --workspace\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)