### PR TITLE
feat(cli): spar moves enumerate — design-space exploration (Track E commit 4/8)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1203,6 +1203,38 @@ artifacts:
     status: planned
     tags: [migration, track-e, v080, cli]
 
+  - id: REQ-MIGRATION-006
+    type: requirement
+    title: spar moves enumerate CLI — design-space exploration
+    description: >
+      System shall expose a `spar moves enumerate --component X
+      [--target-filter <substring>] [--format text|json]` CLI
+      subcommand that returns all valid hypothetical rebinding targets
+      for a component. The candidate-target set is derived from
+      `Spar_Migration::Allowed_Targets` (when set on the component) or
+      from every Processor / VirtualProcessor in the instance
+      otherwise. An optional `--target-filter` substring narrows the
+      candidate set when Allowed_Targets is absent and the model has
+      many processors. For each candidate the same overlay-validation
+      and analysis-pass pipeline as `spar moves verify`
+      (REQ-MIGRATION-005) is run, producing a per-candidate
+      `MoveCandidate` record with `ok` / `violations` /
+      `diagnostics_count` / `slack_ns`. The slack metric is the
+      simplest defensible v0.8.0 ranking: minimum (deadline −
+      response_time) across threads on the candidate target, parsed
+      from RTA's info-level diagnostics; `None` when RTA produced no
+      usable info diagnostics; negative-sentinel when RTA reports a
+      deadline miss. The full multi-objective ranking (weight, power,
+      EMV2 cost) lands in commits 5-6 with the solver-driven enumerator.
+      JSON output is the canonical machine-readable shape consumed by
+      the v0.9.0 MCP `spar.enumerate_moves` tool surface; text output
+      is a sortable table with a `total=N valid=K` summary footer.
+      Exit codes: 0 = at least one admissible candidate, 1 = no
+      admissible candidate (or input-resolution error). Per Track E
+      commit 4/8 of the v0.8.0 migration design research (§6.3).
+    status: planned
+    tags: [migration, track-e, v080, cli]
+
   - id: REQ-NETWORK-004
     type: requirement
     title: Typed network graph extraction from a SystemInstance

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1521,6 +1521,53 @@ artifacts:
       - type: satisfies
         target: REQ-MIGRATION-004
 
+  - id: TEST-MOVES-ENUMERATE
+    type: feature
+    title: spar moves enumerate CLI integration tests
+    description: >
+      Integration tests in crates/spar-cli/tests/moves_enumerate.rs
+      that shell out to the `spar` binary and exercise the
+      `spar moves enumerate` subcommand (Track E commit 4/8). Coverage:
+      (1) when no Allowed_Targets is set, all processors in the
+          instance appear as candidates (cpu1 + cpu2 in the two-CPU
+          fixture);
+      (2) Allowed_Targets => (cpu1, cpu2) limits the candidate set
+          even when cpu3 exists in the instance;
+      (3) Spar_Migration::Frozen forces ok=false and a Frozen violation
+          on every candidate; valid=0 yields exit 1;
+      (4) --target-filter with a name not present in Allowed_Targets
+          (cpu3 vs Allowed_Targets => (cpu1, cpu2)) yields zero
+          candidates;
+      (5) RTA-fail fixture (Compute_Execution_Time > Period) makes
+          every candidate ok=false with diagnostics_count > 0;
+      (6) --target-filter cpu_x86 narrows a 3-processor model to two
+          candidates without altering per-candidate evaluation;
+      (7) text format ends with a `total=N valid=K` summary line;
+      (8) JSON output deserializes into the documented schema
+          (component / total / valid / candidates[] with target / ok /
+          violations / diagnostics_count / slack_ns);
+      (9) unknown --component name exits non-zero with the offending
+          name on stderr;
+      (10) running `spar moves enumerate` does not mutate the
+           underlying model — `spar analyze` returns identical output
+           before and after, and the AADL file on disk is unchanged.
+      Plus four unit tests in moves.rs::enumerate_tests covering
+      format-time round-trip, response-deadline pair extraction, and
+      violation-summary grouping.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar --test moves_enumerate
+    status: passing
+    tags: [migration, track-e, v080, cli]
+    links:
+      - type: satisfies
+        target: REQ-MIGRATION-006
+      - type: satisfies
+        target: REQ-MIGRATION-005
+      - type: satisfies
+        target: REQ-MIGRATION-004
+
   - id: TEST-SPAR-NETWORK-GRAPH
     type: feature
     title: Network graph extraction tests

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -91,6 +91,9 @@ fn print_usage() {
     eprintln!(
         "  moves    verify --root Package::Type.Impl --component <fqn> --to <processor> [--format text|json] <file...>"
     );
+    eprintln!(
+        "  moves    enumerate --root Package::Type.Impl --component <fqn> [--target-filter <s>] [--format text|json] <file...>"
+    );
 }
 
 fn cmd_lsp() {

--- a/crates/spar-cli/src/moves.rs
+++ b/crates/spar-cli/src/moves.rs
@@ -1,11 +1,20 @@
-//! `spar moves verify` — hypothetical-rebinding oracle (Track E commit 3/8).
+//! `spar moves verify` and `spar moves enumerate` — hypothetical-rebinding
+//! oracle (Track E commits 3/8 and 4/8).
 //!
 //! Per the v0.8.0 migration design research §6.3, this module exposes the
-//! first user-facing surface of the migration oracle: a CLI that takes a
-//! parsed AADL model, a component to (hypothetically) move, and a target
-//! processor, and returns a structured pass/fail report describing whether
-//! the move is admissible under the platform/application split and the
-//! existing analysis-pass suite.
+//! first two user-facing surfaces of the migration oracle:
+//!
+//! - `spar moves verify --component X --to Y` (commit 3): single
+//!   hypothetical-move pass/fail report.
+//! - `spar moves enumerate --component X` (commit 4): design-space
+//!   exploration listing every legal target with verification status
+//!   and an optional slack-rank metric.
+//!
+//! Both subcommands share the same parse / resolve / overlay / validate
+//! / render scaffolding. Verify is the canonical single-shot pipeline;
+//! enumerate fans the same pipeline out across a candidate-target set
+//! (either `Spar_Migration::Allowed_Targets` or every Processor /
+//! VirtualProcessor in the instance).
 //!
 //! # Pipeline
 //!
@@ -593,9 +602,11 @@ pub fn print_moves_usage() {
     eprintln!("Usage: spar moves <subcommand> [options]");
     eprintln!();
     eprintln!("Subcommands:");
-    eprintln!("  verify   Verify a hypothetical component move under the migration overlay.");
+    eprintln!("  verify     Verify a hypothetical component move under the migration overlay.");
+    eprintln!("  enumerate  List every valid hypothetical rebinding target for a component, with");
+    eprintln!("             per-candidate verification status and optional slack ranking.");
     eprintln!();
-    eprintln!("`spar moves enumerate` and `spar moves optimize` land in later commits.");
+    eprintln!("`spar moves optimize` lands in a later commit.");
 }
 
 /// Print `spar moves verify` usage to stderr and exit non-zero.
@@ -628,6 +639,7 @@ pub fn cmd_moves(args: &[String]) -> i32 {
     }
     match args[0].as_str() {
         "verify" => cmd_moves_verify(&args[1..]),
+        "enumerate" => cmd_moves_enumerate(&args[1..]),
         other => {
             eprintln!("Unknown moves subcommand: {other}");
             print_moves_usage();
@@ -734,4 +746,620 @@ fn cmd_moves_verify(args: &[String]) -> i32 {
 /// that all end with `process::exit`.
 pub fn cmd_moves_dispatch(args: &[String]) {
     process::exit(cmd_moves(args));
+}
+
+// ── enumerate (Track E commit 4/8) ──────────────────────────────────
+
+/// Parsed CLI arguments for `spar moves enumerate`.
+///
+/// Same shape as [`VerifyArgs`] minus `--to` (the target is *derived*
+/// per-candidate, not supplied by the user) plus an optional
+/// `--target-filter` to narrow the candidate set when the model has
+/// many processors and `Spar_Migration::Allowed_Targets` is absent.
+#[derive(Debug)]
+pub struct EnumerateArgs {
+    /// Path(s) to the AADL model file(s) to load.
+    pub model_files: Vec<String>,
+    /// Root system implementation in `Pkg::Type.Impl` form.
+    pub root: String,
+    /// FQN (or suffix / bare name) of the component to enumerate
+    /// candidates for.
+    pub component: String,
+    /// Optional substring (case-insensitive) that a candidate's FQN
+    /// must contain to be included. Useful when `Allowed_Targets` is
+    /// absent and the model has many processors.
+    pub target_filter: Option<String>,
+    /// Output format: `text` (default) or `json`.
+    pub format: String,
+}
+
+/// Per-candidate verification record produced by `spar moves enumerate`.
+///
+/// One [`MoveCandidate`] is emitted per (component, target) pair the
+/// algorithm considers — the target list comes from
+/// `Spar_Migration::Allowed_Targets` when set or from every Processor /
+/// VirtualProcessor in the instance otherwise. The fields capture
+/// whether the move would be admissible (`ok`), the structured
+/// violation list, and an optional slack metric for ranking.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MoveCandidate {
+    /// Fully-qualified name of the candidate target processor.
+    pub target: String,
+    /// True if the move is admissible: no overlay violations and no
+    /// error-severity diagnostics from the analysis suite.
+    pub ok: bool,
+    /// Overlay + analysis violations. Same shape as
+    /// [`MoveVerifyReport::violations`] for one-to-one round-trip
+    /// with `spar moves verify` output.
+    pub violations: Vec<Violation>,
+    /// Total error-severity analysis diagnostics for this candidate
+    /// (kept separately from the violation count so consumers can
+    /// rank "worst offenders" without traversing `violations`).
+    pub diagnostics_count: usize,
+    /// Optional slack metric: minimum (deadline − response_time) in
+    /// picoseconds across threads bound to the candidate target.
+    /// Higher is better; negative values indicate a deadline miss.
+    /// `None` when RTA produced no usable info-level diagnostics.
+    pub slack_ns: Option<i64>,
+}
+
+/// Output shape for `spar moves enumerate --format json`.
+///
+/// The canonical JSON contract for the v0.9.0 MCP
+/// `spar.enumerate_moves` tool surface; consumers downstream of the
+/// LLM tool will sort `candidates` by `slack_ns` descending (with
+/// `ok=true` first) to surface the most attractive moves.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MoveEnumerateReport {
+    /// FQN of the component being enumerated.
+    pub component: String,
+    /// All candidate targets considered (post target-filter).
+    pub candidates: Vec<MoveCandidate>,
+    /// Total candidates evaluated.
+    pub total: usize,
+    /// Number of `ok=true` candidates (admissible moves).
+    pub valid: usize,
+}
+
+/// Run `spar moves enumerate`, returning the desired process exit code.
+///
+/// Pipeline:
+///
+/// 1. Parse + instantiate the model (mirrors `run_verify`).
+/// 2. Resolve `--component` to a [`ComponentInstanceIdx`].
+/// 3. Build the candidate-target set from
+///    `Spar_Migration::Allowed_Targets` (when set) or from every
+///    Processor / VirtualProcessor in the instance otherwise.
+/// 4. Apply the optional `--target-filter` substring (case-insensitive
+///    against the candidate's FQN).
+/// 5. For each candidate: build a [`BindingOverlay::add_move`] overlay,
+///    run [`BindingOverlay::validate`], run the analysis suite, and
+///    derive a slack metric from RTA's info diagnostics.
+/// 6. Emit a [`MoveEnumerateReport`] in `text` or `json` form.
+///
+/// Exit codes mirror `verify` semantics:
+///
+/// | Code | Meaning |
+/// |---|---|
+/// | 0 | At least one admissible candidate (`valid >= 1`) |
+/// | 1 | All candidates failed analysis or produced no admissible move |
+/// | 2 | Input resolution failed (component / model / format) |
+pub fn run_enumerate(args: EnumerateArgs) -> Result<i32, MovesError> {
+    if args.format != "text" && args.format != "json" {
+        return Err(MovesError::UnknownFormat(args.format));
+    }
+    if args.model_files.is_empty() {
+        return Err(MovesError::Parse(
+            "(no files)".to_string(),
+            "spar moves enumerate requires at least one .aadl file".to_string(),
+        ));
+    }
+
+    // 1. Parse + instantiate.
+    let db = spar_hir_def::HirDefDatabase::default();
+    let mut trees = Vec::new();
+    for file_path in &args.model_files {
+        let source =
+            fs::read_to_string(file_path).map_err(|e| MovesError::Io(file_path.clone(), e))?;
+        let parsed = spar_syntax::parse(&source);
+        if !parsed.ok() {
+            let mut msg = String::new();
+            for err in parsed.errors() {
+                let (line, col) = spar_base_db::offset_to_line_col(&source, err.offset);
+                msg.push_str(&format!("{file_path}:{line}:{col}: {}\n", err.msg));
+            }
+            return Err(MovesError::Parse(file_path.clone(), msg));
+        }
+        let sf = spar_base_db::SourceFile::new(&db, file_path.clone(), source);
+        trees.push(spar_hir_def::file_item_tree(&db, sf));
+    }
+
+    let (pkg_name, type_name, impl_name) = parse_root_ref(&args.root)?;
+    let scope = spar_hir_def::GlobalScope::from_trees(trees);
+    let inst = SystemInstance::instantiate(
+        &scope,
+        &spar_hir_def::Name::new(&pkg_name),
+        &spar_hir_def::Name::new(&type_name),
+        &spar_hir_def::Name::new(&impl_name),
+    );
+    if inst.component_count() == 0 {
+        return Err(MovesError::UnknownRoot(args.root.clone()));
+    }
+
+    // 2. Resolve --component.
+    let comp_idx = resolve_component(&inst, &args.component)
+        .ok_or_else(|| MovesError::UnknownComponent(args.component.clone()))?;
+
+    // 3. Build the candidate-target set.
+    let candidates = candidate_targets(&inst, comp_idx, args.target_filter.as_deref());
+
+    // 4-5. Verify each candidate.
+    let mut report = MoveEnumerateReport {
+        component: fqn(&inst, comp_idx),
+        candidates: Vec::with_capacity(candidates.len()),
+        total: 0,
+        valid: 0,
+    };
+
+    for target_idx in candidates {
+        let candidate = verify_candidate(&inst, comp_idx, target_idx);
+        if candidate.ok {
+            report.valid += 1;
+        }
+        report.candidates.push(candidate);
+    }
+    report.total = report.candidates.len();
+
+    // Sort: ok=true first, then by slack desc (None last), then by FQN.
+    report.candidates.sort_by(|a, b| {
+        b.ok.cmp(&a.ok)
+            .then_with(|| match (a.slack_ns, b.slack_ns) {
+                (Some(sa), Some(sb)) => sb.cmp(&sa),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            .then_with(|| a.target.cmp(&b.target))
+    });
+
+    // 6. Render.
+    match args.format.as_str() {
+        "json" => render_enumerate_json(&report),
+        _ => render_enumerate_text(&report),
+    }
+
+    // Exit code: 0 if any admissible, 1 otherwise. (2 is reserved for
+    // input-resolution errors, returned via MovesError above.)
+    Ok(if report.valid > 0 { 0 } else { 1 })
+}
+
+/// Build the candidate-target index list for an enumerate run.
+///
+/// Resolution order:
+///
+/// 1. If the component declares a non-empty
+///    `Spar_Migration::Allowed_Targets` list, resolve each name to a
+///    component index via [`resolve_component`] and keep those.
+///    Names that don't resolve are silently dropped (the model would
+///    have already produced a property-rule warning).
+/// 2. Otherwise: collect every component with category Processor or
+///    VirtualProcessor.
+///
+/// The optional `target_filter` is applied as a case-insensitive
+/// substring match against each candidate's FQN.
+fn candidate_targets(
+    inst: &SystemInstance,
+    comp_idx: ComponentInstanceIdx,
+    target_filter: Option<&str>,
+) -> Vec<ComponentInstanceIdx> {
+    let props = inst.properties_for(comp_idx);
+    let allowed_names = spar_hir_def::read_allowed_targets(props);
+
+    let mut targets: Vec<ComponentInstanceIdx> = if !allowed_names.is_empty() {
+        allowed_names
+            .iter()
+            .filter_map(|n| resolve_component(inst, n))
+            .collect()
+    } else {
+        inst.all_components()
+            .filter(|(_, c)| {
+                matches!(
+                    c.category,
+                    ComponentCategory::Processor | ComponentCategory::VirtualProcessor
+                )
+            })
+            .map(|(idx, _)| idx)
+            .collect()
+    };
+
+    // De-duplicate while preserving order (Allowed_Targets may list
+    // the same processor twice, however unlikely).
+    let mut seen = std::collections::HashSet::new();
+    targets.retain(|idx| seen.insert(*idx));
+
+    if let Some(filter) = target_filter {
+        let needle = filter.to_ascii_lowercase();
+        targets.retain(|&idx| fqn(inst, idx).to_ascii_lowercase().contains(&needle));
+    }
+
+    targets
+}
+
+/// Run the verify pipeline for a single (component, target) pair and
+/// return a [`MoveCandidate`] record.
+///
+/// The implementation is structurally identical to the per-move portion
+/// of [`run_verify`] — overlay -> validate -> analyses -> build_report
+/// — but returns a candidate-shaped record instead of printing a
+/// per-move document.
+fn verify_candidate(
+    inst: &SystemInstance,
+    comp_idx: ComponentInstanceIdx,
+    target_idx: ComponentInstanceIdx,
+) -> MoveCandidate {
+    let mut overlay = BindingOverlay::new();
+    overlay.add_move(comp_idx, target_idx);
+    let overlay_diags = overlay.validate(inst);
+    let analysis_diags = run_all_analyses(inst);
+
+    let report = build_report(inst, comp_idx, target_idx, &overlay_diags, &analysis_diags);
+    let diagnostics_count = analysis_diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+
+    // Slack ranking: scan RTA info diagnostics for "thread '...' on
+    // processor '<TARGET>': response time <X> <= deadline <Y>" and
+    // compute min(Y - X) across threads bound to TARGET. If the
+    // analysis stream contains an RTA error-severity diagnostic for a
+    // thread bound to TARGET, slack is forced negative.
+    let target_name = inst.component(target_idx).name.as_str();
+    let slack_ns = compute_slack_ns(&analysis_diags, target_name);
+
+    let ok = overlay_diags.is_empty()
+        && !report.violations.iter().any(|v| {
+            matches!(
+                v,
+                Violation::AnalysisError {
+                    severity: SerSeverity::Error,
+                    ..
+                }
+            )
+        });
+
+    MoveCandidate {
+        target: fqn(inst, target_idx),
+        ok,
+        violations: report.violations,
+        diagnostics_count,
+        slack_ns,
+    }
+}
+
+/// Compute the slack metric for a candidate target.
+///
+/// Walks the analysis-diagnostic stream looking for RTA messages of the
+/// form `"thread '...' on processor '<target>': response time <X> <=
+/// deadline <Y>"`, parses the formatted times back into picoseconds,
+/// and returns the minimum `Y - X` across threads bound to `target`.
+///
+/// Returns:
+///
+/// - `Some(slack_ps)` (positive) when at least one matching info
+///   diagnostic was successfully parsed and no error was found.
+/// - `Some(negative)` when at least one matching error diagnostic
+///   reports a deadline miss for a thread on `target` (we encode the
+///   miss as -1 ps; the consumer cares about sign, not magnitude).
+/// - `None` when no RTA diagnostic mentions this target.
+fn compute_slack_ns(diags: &[AnalysisDiagnostic], target_name: &str) -> Option<i64> {
+    let target_lower = target_name.to_ascii_lowercase();
+    let mut min_slack: Option<i64> = None;
+    let mut had_miss = false;
+    let mut had_match = false;
+
+    for d in diags {
+        if d.analysis != "RtaAnalysis" {
+            continue;
+        }
+        let msg_lower = d.message.to_ascii_lowercase();
+        let needle = format!("on processor '{}'", target_lower);
+        if !msg_lower.contains(&needle) {
+            continue;
+        }
+        had_match = true;
+
+        if d.severity == Severity::Error && msg_lower.contains("misses deadline") {
+            had_miss = true;
+            continue;
+        }
+
+        // Parse "response time <X> <= deadline <Y>".
+        if let Some((rt, dl)) = parse_response_deadline(&d.message) {
+            let slack = dl as i64 - rt as i64;
+            min_slack = Some(min_slack.map(|m| m.min(slack)).unwrap_or(slack));
+        }
+    }
+
+    if had_miss {
+        // Deadline miss dominates: report a negative sentinel. The
+        // consumer just checks the sign for "is this candidate
+        // schedulable?".
+        return Some(-1);
+    }
+    if !had_match {
+        return None;
+    }
+    min_slack
+}
+
+/// Parse the `"response time <X> <= deadline <Y>"` substring from an
+/// RTA info-level diagnostic message.
+///
+/// Returns `(response_time_ps, deadline_ps)` if both formatted-time
+/// values parse cleanly; `None` otherwise. Parsing the formatted form
+/// is intentional — RTA does not currently expose its raw picosecond
+/// values via the diagnostic struct, and committing a parser here is
+/// cheaper than expanding the AnalysisDiagnostic shape just for the
+/// commit-4 ranking metric.
+fn parse_response_deadline(msg: &str) -> Option<(u64, u64)> {
+    let after_rt = msg.find("response time ")?;
+    let rest = &msg[after_rt + "response time ".len()..];
+    let le_pos = rest.find("<=")?;
+    let rt_str = rest[..le_pos].trim();
+    let after_dl = rest[le_pos + 2..].find("deadline ")?;
+    let dl_rest = &rest[le_pos + 2 + after_dl + "deadline ".len()..];
+    let dl_str = dl_rest.trim_end_matches(['.', ',']).trim();
+    Some((parse_format_time(rt_str)?, parse_format_time(dl_str)?))
+}
+
+/// Inverse of `spar_analysis::rta::format_time`: parse a `"<num> <unit>"`
+/// string back into picoseconds. Unit suffixes recognised: `ps`, `us`,
+/// `ms`, `sec`. Whitespace-tolerant; returns `None` on parse failure.
+fn parse_format_time(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let space = s.rfind(char::is_whitespace)?;
+    let num_str = s[..space].trim();
+    let unit = s[space..].trim();
+
+    let scale: u64 = match unit {
+        "ps" => 1,
+        "us" => 1_000_000,
+        "ms" => 1_000_000_000,
+        "sec" | "s" => 1_000_000_000_000,
+        _ => return None,
+    };
+
+    if let Ok(n) = num_str.parse::<u64>() {
+        return Some(n.saturating_mul(scale));
+    }
+    let f = num_str.parse::<f64>().ok()?;
+    if f.is_nan() || f.is_sign_negative() {
+        return None;
+    }
+    Some((f * scale as f64) as u64)
+}
+
+/// Render a [`MoveEnumerateReport`] as canonical pretty-printed JSON.
+fn render_enumerate_json(report: &MoveEnumerateReport) {
+    println!("{}", serde_json::to_string_pretty(report).unwrap());
+}
+
+/// Render a [`MoveEnumerateReport`] in human-readable tabular form.
+///
+/// Layout: a one-line component header, a fixed-width row per
+/// candidate (status / target / slack / violation summary), and a
+/// `total=N valid=K` summary footer mirroring the JSON shape.
+fn render_enumerate_text(report: &MoveEnumerateReport) {
+    println!(
+        "Enumerate {} ({} candidates)",
+        report.component, report.total
+    );
+    if report.candidates.is_empty() {
+        println!("  (no candidate targets)");
+    } else {
+        println!(
+            "  {:<6} {:<40} {:>14} {:>6}  violations",
+            "ok", "target", "slack", "errs",
+        );
+        for c in &report.candidates {
+            let status = if c.ok { "OK" } else { "FAIL" };
+            let slack = match c.slack_ns {
+                Some(n) if n < 0 => "<missed>".to_string(),
+                Some(n) => format!("{n} ps"),
+                None => "-".to_string(),
+            };
+            let viol_summary = summarise_violations(&c.violations);
+            println!(
+                "  {:<6} {:<40} {:>14} {:>6}  {}",
+                status, c.target, slack, c.diagnostics_count, viol_summary,
+            );
+        }
+    }
+    println!("total={} valid={}", report.total, report.valid);
+}
+
+/// Compress a [`Violation`] vector into a one-line summary for the
+/// text-format renderer (so a wide table stays one row per candidate).
+fn summarise_violations(violations: &[Violation]) -> String {
+    if violations.is_empty() {
+        return "none".to_string();
+    }
+    let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for v in violations {
+        let key = match v {
+            Violation::Frozen { .. } => "Frozen",
+            Violation::AllowedTargets { .. } => "AllowedTargets",
+            Violation::AnalysisError { .. } => "AnalysisError",
+        };
+        *counts.entry(key).or_default() += 1;
+    }
+    counts
+        .iter()
+        .map(|(k, n)| format!("{k}×{n}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Print `spar moves enumerate` usage to stderr.
+pub fn print_enumerate_usage() {
+    eprintln!("Usage: spar moves enumerate --root Pkg::Type.Impl --component <fqn> \\");
+    eprintln!("                            [--target-filter <substring>] [--format text|json] \\");
+    eprintln!("                            <model.aadl>...");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --root           Root system implementation in Pkg::Type.Impl form");
+    eprintln!("  --component      FQN (or suffix / bare name) of the component to enumerate");
+    eprintln!("  --target-filter  Optional case-insensitive substring filter on candidate FQNs");
+    eprintln!("  --format         Output format: text (default) or json");
+    eprintln!();
+    eprintln!("Candidate-target set:");
+    eprintln!(
+        "  - If the component declares Spar_Migration::Allowed_Targets, those names are used."
+    );
+    eprintln!("  - Otherwise every Processor / VirtualProcessor in the instance is a candidate.");
+    eprintln!();
+    eprintln!("Exit codes:");
+    eprintln!("  0  at least one candidate is admissible (valid >= 1)");
+    eprintln!("  1  no admissible candidate (or input-resolution error)");
+}
+
+/// Manual-arg parser for `spar moves enumerate`.
+fn cmd_moves_enumerate(args: &[String]) -> i32 {
+    let mut root = None;
+    let mut component = None;
+    let mut target_filter: Option<String> = None;
+    let mut format: Option<String> = None;
+    let mut model_files = Vec::new();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--root" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--root requires a value (Package::Type.Impl)");
+                    return 1;
+                }
+                root = Some(args[i].clone());
+            }
+            "--component" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--component requires a value");
+                    return 1;
+                }
+                component = Some(args[i].clone());
+            }
+            "--target-filter" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--target-filter requires a value");
+                    return 1;
+                }
+                target_filter = Some(args[i].clone());
+            }
+            "--format" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--format requires a value (text|json)");
+                    return 1;
+                }
+                format = Some(args[i].clone());
+            }
+            "--help" | "-h" => {
+                print_enumerate_usage();
+                return 0;
+            }
+            s if s.starts_with('-') => {
+                eprintln!("Unknown option: {s}");
+                print_enumerate_usage();
+                return 1;
+            }
+            s => model_files.push(s.to_string()),
+        }
+        i += 1;
+    }
+
+    let Some(root) = root else {
+        eprintln!("--root Package::Type.Impl is required");
+        return 1;
+    };
+    let Some(component) = component else {
+        eprintln!("--component is required");
+        return 1;
+    };
+    if model_files.is_empty() {
+        eprintln!("at least one .aadl file is required");
+        return 1;
+    }
+
+    let args = EnumerateArgs {
+        model_files,
+        root,
+        component,
+        target_filter,
+        format: format.unwrap_or_else(|| "text".to_string()),
+    };
+
+    match run_enumerate(args) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod enumerate_tests {
+    use super::*;
+
+    #[test]
+    fn parse_format_time_roundtrips_units() {
+        assert_eq!(parse_format_time("10 ms"), Some(10_000_000_000));
+        assert_eq!(parse_format_time("1.50 ms"), Some(1_500_000_000));
+        assert_eq!(parse_format_time("500 us"), Some(500_000_000));
+        assert_eq!(parse_format_time("100 ps"), Some(100));
+        assert_eq!(parse_format_time("2.00 sec"), Some(2_000_000_000_000));
+        assert_eq!(parse_format_time(""), None);
+        assert_eq!(parse_format_time("not a time"), None);
+        assert_eq!(parse_format_time("10 fortnights"), None);
+    }
+
+    #[test]
+    fn parse_response_deadline_extracts_pair() {
+        let msg = "thread 't1' on processor 'cpu1': response time 5 ms <= deadline 10 ms";
+        let pair = parse_response_deadline(msg).expect("expected to parse");
+        assert_eq!(pair, (5_000_000_000, 10_000_000_000));
+    }
+
+    #[test]
+    fn parse_response_deadline_returns_none_on_unrelated_message() {
+        let msg = "ARINC653 partition X has no period";
+        assert!(parse_response_deadline(msg).is_none());
+    }
+
+    #[test]
+    fn summarise_violations_groups_by_kind() {
+        let v = vec![
+            Violation::Frozen {
+                component: "t1".to_string(),
+                reason: "x".to_string(),
+            },
+            Violation::Frozen {
+                component: "t2".to_string(),
+                reason: "y".to_string(),
+            },
+            Violation::AnalysisError {
+                pass: "RTA".to_string(),
+                message: "miss".to_string(),
+                severity: SerSeverity::Error,
+                path: vec![],
+            },
+        ];
+        let s = summarise_violations(&v);
+        // Order is BTreeMap so AnalysisError comes before Frozen alphabetically.
+        assert!(s.contains("AnalysisError×1"));
+        assert!(s.contains("Frozen×2"));
+    }
 }

--- a/crates/spar-cli/tests/moves_enumerate.rs
+++ b/crates/spar-cli/tests/moves_enumerate.rs
@@ -1,0 +1,714 @@
+//! Integration tests for `spar moves enumerate` (Track E commit 4/8).
+//!
+//! Each test builds a small inline AADL model, drops it into a per-test
+//! temp file (mirroring the `moves_verify.rs` pattern), and shells out
+//! to the `spar` binary. Tests assert exit codes, parse JSON / text
+//! output, and verify the candidate list shape.
+//!
+//! Test inventory (10 cases per the commit-4 spec):
+//!
+//!  1. `enumerate_lists_all_processors_when_no_allowed_targets`
+//!  2. `enumerate_respects_allowed_targets`
+//!  3. `enumerate_marks_frozen_target_as_invalid`
+//!  4. `enumerate_marks_unallowed_target_as_invalid`
+//!  5. `enumerate_propagates_analysis_diagnostics`
+//!  6. `enumerate_target_filter_narrows_candidates`
+//!  7. `enumerate_text_format_includes_summary_line`
+//!  8. `enumerate_json_format_parseable`
+//!  9. `enumerate_unknown_component_errors`
+//! 10. `enumerate_doesnt_mutate_underlying_model`
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn spar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spar"))
+}
+
+/// Per-test temp file: process id + per-test tag, to avoid races between
+/// parallel test runners on the same machine.
+fn write_model(tag: &str, body: &str) -> PathBuf {
+    let path = env::temp_dir().join(format!(
+        "spar_moves_enumerate_{}_{}.aadl",
+        std::process::id(),
+        tag,
+    ));
+    fs::write(&path, body).expect("write temp AADL");
+    path
+}
+
+fn cleanup(path: &PathBuf) {
+    let _ = fs::remove_file(path);
+}
+
+/// Two-processor model: thread t1 with no Allowed_Targets restriction.
+const TWO_CPU_MODEL: &str = "\
+package Migrate
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Migrate;
+";
+
+/// Three-processor model with Allowed_Targets => (cpu1, cpu2). cpu3
+/// exists in the instance but is *not* in the allowed list, so
+/// enumerate must skip it.
+const ALLOWED_TWO_OF_THREE: &str = "\
+package Allowed
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+    properties
+      Spar_Migration::Mobile => true;
+      Spar_Migration::Allowed_Targets => (reference (cpu1), reference (cpu2));
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      cpu3: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Allowed;
+";
+
+/// Frozen-thread model with two processors. Every move attempt must
+/// raise a Frozen violation.
+const FROZEN_MODEL: &str = "\
+package Frozen
+public
+  processor CPU
+  end CPU;
+
+  thread Plat
+    properties
+      Spar_Migration::Frozen => true;
+      Spar_Migration::Pinned_Reason => \"ASIL-D platform partition\";
+  end Plat;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Plat;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Frozen;
+";
+
+/// Periodic-overrun model: the thread asks for far more compute than
+/// any processor can supply, so RTA produces an error-severity
+/// diagnostic for every candidate target. Used to verify that
+/// enumerate surfaces analysis diagnostics into per-candidate counts.
+const RTA_FAIL_MODEL: &str = "\
+package RtaFail
+public
+  processor CPU
+    properties
+      Scheduling_Protocol => (RMS);
+  end CPU;
+
+  thread T
+    properties
+      Dispatch_Protocol => Periodic;
+      Period => 10 ms;
+      Compute_Execution_Time => 50 ms .. 50 ms;
+      Deadline => 10 ms;
+  end T;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread T;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end RtaFail;
+";
+
+/// Three-processor model (cpu_x86_a, cpu_x86_b, cpu_arm) used for the
+/// `--target-filter` test. No Allowed_Targets restriction → all three
+/// would be candidates without a filter.
+const FILTER_MODEL: &str = "\
+package Filter
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu_x86_a: processor CPU;
+      cpu_x86_b: processor CPU;
+      cpu_arm:   processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu_x86_a)) applies to app.t1;
+  end Sys.Impl;
+end Filter;
+";
+
+// ── 1. enumerate_lists_all_processors_when_no_allowed_targets ─────────
+
+#[test]
+fn enumerate_lists_all_processors_when_no_allowed_targets() {
+    // Two processors, no Allowed_Targets restriction: the candidate
+    // list must include cpu1 and cpu2.
+    let path = write_model("two_cpu_no_allowed", TWO_CPU_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Migrate::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected ok exit, got {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        out.status.code(),
+    );
+
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+    let candidates = v["candidates"]
+        .as_array()
+        .expect("candidates must be an array");
+    let target_names: Vec<String> = candidates
+        .iter()
+        .filter_map(|c| c["target"].as_str().map(String::from))
+        .collect();
+    assert!(
+        target_names.iter().any(|t| t.ends_with("cpu1")),
+        "expected cpu1 in candidates; got {target_names:?}",
+    );
+    assert!(
+        target_names.iter().any(|t| t.ends_with("cpu2")),
+        "expected cpu2 in candidates; got {target_names:?}",
+    );
+    assert_eq!(v["total"].as_u64(), Some(2));
+    cleanup(&path);
+}
+
+// ── 2. enumerate_respects_allowed_targets ─────────────────────────────
+
+#[test]
+fn enumerate_respects_allowed_targets() {
+    // Allowed_Targets => (cpu1, cpu2): cpu3 must be absent from the
+    // candidate list even though it exists in the model.
+    let path = write_model("allowed_two_of_three", ALLOWED_TWO_OF_THREE);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Allowed::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit 0; stdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    let names: Vec<String> = candidates
+        .iter()
+        .filter_map(|c| c["target"].as_str().map(String::from))
+        .collect();
+    assert_eq!(
+        candidates.len(),
+        2,
+        "expected exactly two candidates from Allowed_Targets, got {names:?}",
+    );
+    assert!(names.iter().any(|n| n.ends_with("cpu1")));
+    assert!(names.iter().any(|n| n.ends_with("cpu2")));
+    assert!(
+        names.iter().all(|n| !n.ends_with("cpu3")),
+        "cpu3 is not in Allowed_Targets but appeared in candidates: {names:?}",
+    );
+    cleanup(&path);
+}
+
+// ── 3. enumerate_marks_frozen_target_as_invalid ───────────────────────
+
+#[test]
+fn enumerate_marks_frozen_target_as_invalid() {
+    // For a Frozen thread, every candidate target produces a Frozen
+    // overlay violation → all candidates have ok=false. The total
+    // and valid counts must reflect that.
+    let path = write_model("frozen_invalid", FROZEN_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Frozen::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert!(
+        !candidates.is_empty(),
+        "expected at least one candidate target",
+    );
+    for c in candidates {
+        assert_eq!(
+            c["ok"].as_bool(),
+            Some(false),
+            "every Frozen-thread candidate must be ok=false; got {c}",
+        );
+        let viols = c["violations"].as_array().expect("violations");
+        assert!(
+            viols.iter().any(|v| v["kind"] == "Frozen"),
+            "expected Frozen violation on candidate {}; got {viols:?}",
+            c["target"],
+        );
+    }
+    assert_eq!(v["valid"].as_u64(), Some(0));
+    // Exit 1: no admissible candidate.
+    assert_eq!(out.status.code(), Some(1));
+    cleanup(&path);
+}
+
+// ── 4. enumerate_marks_unallowed_target_as_invalid ────────────────────
+
+#[test]
+fn enumerate_marks_unallowed_target_as_invalid() {
+    // When `--target-filter` is supplied with a name that *does* match
+    // a processor but the component restricts allowed targets, the
+    // intersection still respects Allowed_Targets — i.e. the filter
+    // narrows the already-allowed set; it does not bypass the
+    // platform/application split. With ALLOWED_TWO_OF_THREE we filter
+    // for "cpu3" and must get zero candidates because cpu3 is not in
+    // Allowed_Targets.
+    let path = write_model("filter_outside_allowed", ALLOWED_TWO_OF_THREE);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Allowed::Sys.Impl",
+            "--component",
+            "t1",
+            "--target-filter",
+            "cpu3",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert_eq!(
+        candidates.len(),
+        0,
+        "filter on cpu3 must yield no candidates given Allowed_Targets => (cpu1, cpu2); got {candidates:?}",
+    );
+    assert_eq!(v["total"].as_u64(), Some(0));
+    assert_eq!(v["valid"].as_u64(), Some(0));
+    // Zero admissible candidates → exit 1.
+    assert_eq!(out.status.code(), Some(1));
+    cleanup(&path);
+}
+
+// ── 5. enumerate_propagates_analysis_diagnostics ──────────────────────
+
+#[test]
+fn enumerate_propagates_analysis_diagnostics() {
+    // Periodic-overrun model: every candidate produces an
+    // error-severity RTA diagnostic. Each candidate must therefore
+    // have diagnostics_count > 0 and ok=false.
+    let path = write_model("rta_fail", RTA_FAIL_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "RtaFail::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert!(
+        !candidates.is_empty(),
+        "expected at least one candidate (cpu1, cpu2)",
+    );
+    for c in candidates {
+        let diag_count = c["diagnostics_count"].as_u64().unwrap_or(0);
+        assert!(
+            diag_count > 0,
+            "expected diagnostics_count > 0 on RTA-fail candidate {}, got {}",
+            c["target"],
+            diag_count,
+        );
+        assert_eq!(
+            c["ok"].as_bool(),
+            Some(false),
+            "RTA-fail candidate {} must be ok=false",
+            c["target"],
+        );
+    }
+    cleanup(&path);
+}
+
+// ── 6. enumerate_target_filter_narrows_candidates ─────────────────────
+
+#[test]
+fn enumerate_target_filter_narrows_candidates() {
+    // No --target-filter: 3 processors. With --target-filter cpu_x86:
+    // 2 processors. The filter must shrink the set without altering
+    // the order or evaluation of each remaining candidate.
+    let path = write_model("filter_narrow", FILTER_MODEL);
+
+    let unfiltered = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Filter::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar (no filter)");
+    let unfiltered_stdout = String::from_utf8_lossy(&unfiltered.stdout);
+    let unfiltered_json: serde_json::Value =
+        serde_json::from_str(&unfiltered_stdout).expect("unfiltered JSON");
+    assert_eq!(
+        unfiltered_json["total"].as_u64(),
+        Some(3),
+        "expected three candidates without --target-filter; got {unfiltered_json}",
+    );
+
+    let filtered = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Filter::Sys.Impl",
+            "--component",
+            "t1",
+            "--target-filter",
+            "cpu_x86",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar (filter)");
+    let filtered_stdout = String::from_utf8_lossy(&filtered.stdout);
+    let filtered_json: serde_json::Value =
+        serde_json::from_str(&filtered_stdout).expect("filtered JSON");
+    assert_eq!(
+        filtered_json["total"].as_u64(),
+        Some(2),
+        "expected two candidates with --target-filter cpu_x86; got {filtered_json}",
+    );
+
+    // And confirm the filtered set is a strict subset.
+    let filtered_names: Vec<String> = filtered_json["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|c| c["target"].as_str().map(String::from))
+        .collect();
+    assert!(
+        filtered_names.iter().all(|n| n.contains("cpu_x86")),
+        "every filtered candidate FQN must contain 'cpu_x86'; got {filtered_names:?}",
+    );
+
+    cleanup(&path);
+}
+
+// ── 7. enumerate_text_format_includes_summary_line ────────────────────
+
+#[test]
+fn enumerate_text_format_includes_summary_line() {
+    let path = write_model("text_summary", TWO_CPU_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Migrate::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "text",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Summary line of the form `total=2 valid=...`. Last
+    // non-empty line.
+    let last_line = stdout
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .unwrap_or_default();
+    assert!(
+        last_line.starts_with("total=") && last_line.contains(" valid="),
+        "expected text output to end with `total=N valid=K`; got last line: {last_line:?}\nfull stdout: {stdout}",
+    );
+    cleanup(&path);
+}
+
+// ── 8. enumerate_json_format_parseable ────────────────────────────────
+
+#[test]
+fn enumerate_json_format_parseable() {
+    let path = write_model("json_parseable", TWO_CPU_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Migrate::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+
+    assert!(
+        v["component"].is_string(),
+        "component must be string; got {v}"
+    );
+    assert!(v["total"].is_number(), "total must be number; got {v}");
+    assert!(v["valid"].is_number(), "valid must be number; got {v}");
+    let candidates = v["candidates"].as_array().expect("candidates is array");
+    for c in candidates {
+        assert!(c["target"].is_string(), "target must be string; got {c}");
+        assert!(c["ok"].is_boolean(), "ok must be boolean; got {c}");
+        assert!(
+            c["violations"].is_array(),
+            "violations must be array; got {c}"
+        );
+        assert!(
+            c["diagnostics_count"].is_number(),
+            "diagnostics_count must be number; got {c}",
+        );
+        // slack_ns is either null or a number.
+        assert!(
+            c["slack_ns"].is_null() || c["slack_ns"].is_number(),
+            "slack_ns must be null or number; got {c}",
+        );
+    }
+    cleanup(&path);
+}
+
+// ── 9. enumerate_unknown_component_errors ─────────────────────────────
+
+#[test]
+fn enumerate_unknown_component_errors() {
+    let path = write_model("unknown_comp", TWO_CPU_MODEL);
+
+    let out = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Migrate::Sys.Impl",
+            "--component",
+            "definitely_not_a_real_thread",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar");
+
+    assert!(
+        out.status.code() != Some(0),
+        "expected non-zero exit on unknown component",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("definitely_not_a_real_thread"),
+        "stderr should mention the unresolved component name; got: {stderr}",
+    );
+    cleanup(&path);
+}
+
+// ── 10. enumerate_doesnt_mutate_underlying_model ──────────────────────
+
+#[test]
+fn enumerate_doesnt_mutate_underlying_model() {
+    let path = write_model("nomutate_enum", TWO_CPU_MODEL);
+
+    // Snapshot analyze output before enumerate.
+    let before = spar()
+        .args(["analyze", "--root", "Migrate::Sys.Impl", "--format", "json"])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar analyze (before)");
+    let stdout_before = String::from_utf8_lossy(&before.stdout).to_string();
+
+    // Run enumerate.
+    let _ = spar()
+        .args([
+            "moves",
+            "enumerate",
+            "--root",
+            "Migrate::Sys.Impl",
+            "--component",
+            "t1",
+            "--format",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar moves enumerate");
+
+    // Snapshot analyze output after enumerate.
+    let after = spar()
+        .args(["analyze", "--root", "Migrate::Sys.Impl", "--format", "json"])
+        .arg(&path)
+        .output()
+        .expect("failed to run spar analyze (after)");
+    let stdout_after = String::from_utf8_lossy(&after.stdout).to_string();
+
+    assert_eq!(
+        stdout_before, stdout_after,
+        "spar analyze output diverged across spar moves enumerate; overlay is no longer non-mutating",
+    );
+
+    // And the file on disk must be untouched.
+    let on_disk = fs::read_to_string(&path).expect("read AADL");
+    assert_eq!(on_disk, TWO_CPU_MODEL, "AADL file was modified on disk");
+
+    cleanup(&path);
+}

--- a/crates/spar-hir-def/src/lib.rs
+++ b/crates/spar-hir-def/src/lib.rs
@@ -37,7 +37,7 @@ pub use item_tree::ItemTree;
 pub use name::{ClassifierRef, Name, PropertyRef};
 pub use overlay::{
     AllowedTargetsViolation, BindingOverlay, FrozenViolation, OverlayDiagnostic,
-    actual_processor_binding_with_overlay,
+    actual_processor_binding_with_overlay, read_allowed_targets,
 };
 pub use resolver::{GlobalScope, ItemLoc, ResolvedClassifier, ResolvedProperty};
 

--- a/crates/spar-hir-def/src/overlay.rs
+++ b/crates/spar-hir-def/src/overlay.rs
@@ -297,7 +297,11 @@ fn pinned_reason(props: &PropertyMap) -> Option<String> {
 /// `PropertyExpr::ReferenceValue`) and the raw-string fallback
 /// (`(reference (a), reference (b))`-style text). An absent or empty
 /// property returns an empty vector.
-fn read_allowed_targets(props: &PropertyMap) -> Vec<String> {
+///
+/// Exposed publicly so callers (notably `spar moves enumerate` in
+/// commit 4) can derive the candidate-target set without having to
+/// stage a single-move overlay just to ask "what's allowed for X?".
+pub fn read_allowed_targets(props: &PropertyMap) -> Vec<String> {
     // Typed path: a list of ReferenceValue items.
     if let Some(expr) = props.get_typed(SPAR_MIGRATION, "Allowed_Targets") {
         let mut out = Vec::new();


### PR DESCRIPTION
## Summary

Track E commit 4 of 8 for the v0.8.0 migration oracle.

Adds `spar moves enumerate --component X [--target-filter PREFIX] [--format {json,text}]`, the second user-facing surface of the migration oracle. Builds on commit 3 (`spar moves verify`, #166).

- **Candidate-target set.** When the component declares `Spar_Migration::Allowed_Targets`, those names are used. Otherwise every Processor / VirtualProcessor in the instance is a candidate. `--target-filter` is an optional case-insensitive substring narrower applied on top of either set.
- **Per-candidate verification.** Each candidate runs the same overlay + analysis pipeline as `spar moves verify`: build a single-move `BindingOverlay`, validate it (Frozen / Allowed_Targets), run the analysis suite, and produce a structured `MoveCandidate` (`target`, `ok`, `violations`, `diagnostics_count`, `slack_ns`).
- **Slack ranking (v0.8.0 simple metric).** `min(deadline − response_time)` in picoseconds, parsed from RTA's info-level `"thread '...' on processor '...': response time X <= deadline Y"` diagnostics. `None` when RTA produced no usable info diagnostics; negative-sentinel when RTA reports a deadline miss. The full multi-objective ranking (weight, power, EMV2 cost) lands in commits 5-6.
- **Output.** JSON is the canonical machine-readable shape (consumed by the v0.9.0 MCP `spar.enumerate_moves` tool surface). Text is a sortable table with a `total=N valid=K` summary footer.
- **Exit codes.** 0 if at least one admissible candidate (`valid >= 1`); 1 otherwise (or input-resolution error).

## What's NOT in this commit

- Full solver-driven enumeration (commits 5-6 — `spar-solver` integration).
- Multi-objective ranking (weight / power / EMV2 cost) — commits 5-6.
- MCP tool surface for `spar.enumerate_moves` — v0.9.0.
- Overlay-aware analysis passes (RTA / latency / bandwidth / EMV2 / ARINC653) — orthogonal Track E lift; current behaviour matches commit 3 (analyses see the un-overlayed instance).

## Files changed

- `crates/spar-cli/src/moves.rs` — extends with `EnumerateArgs`, `MoveCandidate`, `MoveEnumerateReport`, `run_enumerate`, candidate-target derivation, slack parser, text + JSON renderers, and dispatch wiring (~640 LOC). Reuses `VerifyArgs` / `Violation` / `build_report` / `resolve_component` / `fqn` from commit 3.
- `crates/spar-cli/src/main.rs` — top-level help line for the new subcommand.
- `crates/spar-cli/tests/moves_enumerate.rs` — 10 new integration tests.
- `crates/spar-hir-def/src/overlay.rs` + `lib.rs` — `read_allowed_targets` now `pub` (re-exported) so enumerate can derive the candidate set without staging an overlay just to ask.
- `artifacts/requirements.yaml` — `REQ-MIGRATION-006`.
- `artifacts/verification.yaml` — `TEST-MOVES-ENUMERATE` linked to REQ-MIGRATION-{004,005,006}.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (10 new integration tests + 4 new unit tests, additive on top of existing 800+; full workspace also passes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` clean (pre-existing INFO-level field-shape notes only)
- [x] Frozen-component fixture: every candidate ok=false; valid=0; exit 1
- [x] Allowed_Targets fixture: cpu3 (not allowed) excluded from candidate list
- [x] RTA-fail fixture: every candidate has diagnostics_count > 0 and ok=false
- [x] Target-filter narrows 3-CPU model to 2 candidates by substring match
- [x] Text format ends with `total=N valid=K`
- [x] JSON output deserializes into the documented schema
- [x] Unknown component name yields non-zero exit and stderr mention
- [x] `spar analyze` output is byte-identical before / after enumerate (overlay is read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)