### PR TITLE
feat(moves): multi-objective enumeration ranking (Track E commit 5/8)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1235,6 +1235,34 @@ artifacts:
     status: planned
     tags: [migration, track-e, v080, cli]
 
+  - id: REQ-MIGRATION-007
+    type: requirement
+    title: Multi-objective candidate ranking for `spar moves enumerate`
+    description: >
+      System shall rank hypothetical-binding candidates via a configurable
+      multi-objective score (max-response | total-load | total-power |
+      total-weight | balanced) using the same RTA / property-accessor
+      machinery as direct verification. The score (lower = better)
+      aggregates per-axis values: max response time across overlay-bound
+      threads parsed from RTA Info-level diagnostics; total CPU load
+      summed from `Compute_Execution_Time / Period` over overlay-bound
+      threads; total power from `Spar_Power::Power_Budget` (with
+      compatible upstream fallbacks via SEI / Physical_Properties); total
+      weight from `Weight_Properties::Weight` (with upstream fallbacks).
+      Each enabled axis contributes 1/k of the total score where k is
+      the count of enabled axes; `balanced` enables all four equally.
+      Exposed via the new `spar moves enumerate --objective <mode>` CLI
+      option; default mode is `max-response` so commit-4 single-CPU
+      slack semantics are preserved. The ranker lives in
+      `spar-solver::enumerate` so verify/enumerate output stays in
+      lock-step. Adds the `Spar_Power::Power_Budget` standard property
+      (numeric milliwatts) so models without SEI in scope can still
+      participate. Does NOT alter the validity (`ok`) judgement —
+      objective changes only re-order the candidate list. Per Track E
+      commit 5/8 of the v0.8.0 migration design research (§6.4).
+    status: planned
+    tags: [migration, track-e, v080, cli, solver]
+
   - id: REQ-NETWORK-004
     type: requirement
     title: Typed network graph extraction from a SystemInstance

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1568,6 +1568,64 @@ artifacts:
       - type: satisfies
         target: REQ-MIGRATION-004
 
+  - id: TEST-MOVES-ENUMERATE-OBJECTIVES
+    type: feature
+    title: spar moves enumerate multi-objective ranking integration tests
+    description: >
+      Integration tests in
+      crates/spar-cli/tests/moves_enumerate_objectives.rs that shell out
+      to the `spar` binary and exercise the new `--objective` ranking
+      option (Track E commit 5/8). Coverage:
+      (1) without --objective, the JSON shape carries the new
+          `rank.score` and `rank.max_response_ns` fields (max-response
+          is the default mode);
+      (2) `--objective total-load` sorts the candidate that lands t1 on
+          an empty CPU ahead of the one that lands it on an already-
+          loaded CPU;
+      (3) `--objective total-power` reads `Spar_Power::Power_Budget`
+          off the candidate processor and sorts low-power ahead of
+          high-power;
+      (4) `--objective total-weight` reads `Weight_Properties::Weight`
+          and sorts light ahead of heavy;
+      (5) `--objective balanced` aggregates all four axes (each at 1/4
+          weight) and still distinguishes high-power from low-power;
+      (6) `--objective <bogus>` exits non-zero with a clear error message
+          mentioning the offending value;
+      (7) the set of admissible (`ok=true`) candidates is identical
+          across all five objective modes for the same model;
+      (8) when the model carries no rankable data, every candidate's
+          score collapses to 0.0;
+      (9) the deadline-miss sentinel inflates the score (>= 9.99 under
+          --objective max-response) and the offending candidate sorts
+          last;
+      (10) the text-format header uses a `score` column instead of the
+           commit-4 `slack` column.
+      Plus 11 unit tests in spar-solver::enumerate covering objective
+      flag presets, score aggregation under each mode, the
+      Spar_Power-first / SEI-fallback chain on `read_power_budget_mw`,
+      power and weight value parsers (mW/W/kW/uW; kg/g/mg/lb; bare =
+      mW or kg), the typed-expression numeric extractor, and degenerate
+      empty-overlay rank behaviour. Plus 2 unit tests in
+      spar-cli::moves::enumerate_tests covering --objective parser
+      coverage of the named modes and rejection of unknown values.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar --test moves_enumerate_objectives
+        - run: cargo test -p spar-solver enumerate::
+        - run: cargo test -p spar moves::enumerate_tests
+    status: passing
+    tags: [migration, track-e, v080, cli, solver]
+    links:
+      - type: satisfies
+        target: REQ-MIGRATION-007
+      - type: satisfies
+        target: REQ-MIGRATION-006
+      - type: satisfies
+        target: REQ-MIGRATION-005
+      - type: satisfies
+        target: REQ-MIGRATION-004
+
   - id: TEST-SPAR-NETWORK-GRAPH
     type: feature
     title: Network graph extraction tests

--- a/crates/spar-cli/src/moves.rs
+++ b/crates/spar-cli/src/moves.rs
@@ -72,6 +72,7 @@ use spar_analysis::{AnalysisDiagnostic, Severity};
 use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
 use spar_hir_def::item_tree::ComponentCategory;
 use spar_hir_def::{AllowedTargetsViolation, BindingOverlay, FrozenViolation, OverlayDiagnostic};
+use spar_solver::enumerate::{CandidateRank, EnumerationObjective, rank_candidate};
 
 /// Parsed CLI arguments for `spar moves verify`.
 ///
@@ -117,6 +118,10 @@ pub enum MovesError {
     },
     /// `--format` is neither `text` nor `json`.
     UnknownFormat(String),
+    /// `--objective` does not match any of the recognised modes
+    /// (`max-response`, `total-load`, `total-power`, `total-weight`,
+    /// `balanced`).
+    UnknownObjective(String),
 }
 
 impl std::fmt::Display for MovesError {
@@ -140,6 +145,11 @@ impl std::fmt::Display for MovesError {
             MovesError::UnknownFormat(fmt_) => {
                 write!(f, "--format {fmt_} is not recognised (expected text|json)")
             }
+            MovesError::UnknownObjective(o) => write!(
+                f,
+                "--objective {o} is not recognised (expected max-response | total-load | \
+                 total-power | total-weight | balanced)",
+            ),
         }
     }
 }
@@ -755,7 +765,9 @@ pub fn cmd_moves_dispatch(args: &[String]) {
 /// Same shape as [`VerifyArgs`] minus `--to` (the target is *derived*
 /// per-candidate, not supplied by the user) plus an optional
 /// `--target-filter` to narrow the candidate set when the model has
-/// many processors and `Spar_Migration::Allowed_Targets` is absent.
+/// many processors and `Spar_Migration::Allowed_Targets` is absent,
+/// and a multi-objective `--objective` selector that drives the
+/// candidate ranking score (Track E commit 5/8).
 #[derive(Debug)]
 pub struct EnumerateArgs {
     /// Path(s) to the AADL model file(s) to load.
@@ -771,6 +783,10 @@ pub struct EnumerateArgs {
     pub target_filter: Option<String>,
     /// Output format: `text` (default) or `json`.
     pub format: String,
+    /// Multi-objective ranking spec. Default
+    /// `EnumerationObjective::max_response()` — equivalent to commit 4's
+    /// slack-only ranking on single-CPU models.
+    pub objective: EnumerationObjective,
 }
 
 /// Per-candidate verification record produced by `spar moves enumerate`.
@@ -780,8 +796,8 @@ pub struct EnumerateArgs {
 /// `Spar_Migration::Allowed_Targets` when set or from every Processor /
 /// VirtualProcessor in the instance otherwise. The fields capture
 /// whether the move would be admissible (`ok`), the structured
-/// violation list, and an optional slack metric for ranking.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+/// violation list, and the multi-objective rank score (Track E commit 5/8).
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct MoveCandidate {
     /// Fully-qualified name of the candidate target processor.
     pub target: String,
@@ -796,20 +812,20 @@ pub struct MoveCandidate {
     /// (kept separately from the violation count so consumers can
     /// rank "worst offenders" without traversing `violations`).
     pub diagnostics_count: usize,
-    /// Optional slack metric: minimum (deadline − response_time) in
-    /// picoseconds across threads bound to the candidate target.
-    /// Higher is better; negative values indicate a deadline miss.
-    /// `None` when RTA produced no usable info-level diagnostics.
-    pub slack_ns: Option<i64>,
+    /// Multi-objective rank computed by the solver-driven ranker
+    /// (commit 5/8). Lower `rank.score` is better; the per-axis values
+    /// (`max_response_ns`, `total_load`, …) stay accessible for
+    /// breakdown rendering and post-hoc resorting.
+    pub rank: CandidateRank,
 }
 
 /// Output shape for `spar moves enumerate --format json`.
 ///
 /// The canonical JSON contract for the v0.9.0 MCP
 /// `spar.enumerate_moves` tool surface; consumers downstream of the
-/// LLM tool will sort `candidates` by `slack_ns` descending (with
+/// LLM tool will sort `candidates` by `rank.score` ascending (with
 /// `ok=true` first) to surface the most attractive moves.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct MoveEnumerateReport {
     /// FQN of the component being enumerated.
     pub component: String,
@@ -902,7 +918,7 @@ pub fn run_enumerate(args: EnumerateArgs) -> Result<i32, MovesError> {
     };
 
     for target_idx in candidates {
-        let candidate = verify_candidate(&inst, comp_idx, target_idx);
+        let candidate = verify_candidate(&inst, comp_idx, target_idx, &args.objective);
         if candidate.ok {
             report.valid += 1;
         }
@@ -910,14 +926,17 @@ pub fn run_enumerate(args: EnumerateArgs) -> Result<i32, MovesError> {
     }
     report.total = report.candidates.len();
 
-    // Sort: ok=true first, then by slack desc (None last), then by FQN.
+    // Sort: ok=true first, then by score ascending (lower = better,
+    // matching the convention of all four single-objective modes), then
+    // by FQN as a stable tie-breaker. Ranks with NaN sort *last* so a
+    // degenerate model never floats above well-defined scores.
     report.candidates.sort_by(|a, b| {
         b.ok.cmp(&a.ok)
-            .then_with(|| match (a.slack_ns, b.slack_ns) {
-                (Some(sa), Some(sb)) => sb.cmp(&sa),
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => std::cmp::Ordering::Equal,
+            .then_with(|| {
+                a.rank
+                    .score
+                    .partial_cmp(&b.rank.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
             })
             .then_with(|| a.target.cmp(&b.target))
     });
@@ -992,10 +1011,17 @@ fn candidate_targets(
 /// of [`run_verify`] — overlay -> validate -> analyses -> build_report
 /// — but returns a candidate-shaped record instead of printing a
 /// per-move document.
+///
+/// Track E commit 5/8: ranking is now performed by
+/// [`spar_solver::enumerate::rank_candidate`], which runs the same
+/// analysis suite and also reads the `Spar_Power::Power_Budget` /
+/// `Weight_Properties::Weight` properties to populate the
+/// multi-objective score.
 fn verify_candidate(
     inst: &SystemInstance,
     comp_idx: ComponentInstanceIdx,
     target_idx: ComponentInstanceIdx,
+    objective: &EnumerationObjective,
 ) -> MoveCandidate {
     let mut overlay = BindingOverlay::new();
     overlay.add_move(comp_idx, target_idx);
@@ -1008,13 +1034,12 @@ fn verify_candidate(
         .filter(|d| d.severity == Severity::Error)
         .count();
 
-    // Slack ranking: scan RTA info diagnostics for "thread '...' on
-    // processor '<TARGET>': response time <X> <= deadline <Y>" and
-    // compute min(Y - X) across threads bound to TARGET. If the
-    // analysis stream contains an RTA error-severity diagnostic for a
-    // thread bound to TARGET, slack is forced negative.
-    let target_name = inst.component(target_idx).name.as_str();
-    let slack_ns = compute_slack_ns(&analysis_diags, target_name);
+    // Solver-derived multi-objective ranking. The ranker runs its own
+    // analysis pass internally (so we double-pay for analyses on each
+    // candidate); this matches the commit-5 spec and keeps the score
+    // and `violations` lists strictly consistent — both come from the
+    // same un-overlayed analysis stream the verify-pipeline produces.
+    let rank = rank_candidate(inst, &overlay, objective);
 
     let ok = overlay_diags.is_empty()
         && !report.violations.iter().any(|v| {
@@ -1032,111 +1057,8 @@ fn verify_candidate(
         ok,
         violations: report.violations,
         diagnostics_count,
-        slack_ns,
+        rank,
     }
-}
-
-/// Compute the slack metric for a candidate target.
-///
-/// Walks the analysis-diagnostic stream looking for RTA messages of the
-/// form `"thread '...' on processor '<target>': response time <X> <=
-/// deadline <Y>"`, parses the formatted times back into picoseconds,
-/// and returns the minimum `Y - X` across threads bound to `target`.
-///
-/// Returns:
-///
-/// - `Some(slack_ps)` (positive) when at least one matching info
-///   diagnostic was successfully parsed and no error was found.
-/// - `Some(negative)` when at least one matching error diagnostic
-///   reports a deadline miss for a thread on `target` (we encode the
-///   miss as -1 ps; the consumer cares about sign, not magnitude).
-/// - `None` when no RTA diagnostic mentions this target.
-fn compute_slack_ns(diags: &[AnalysisDiagnostic], target_name: &str) -> Option<i64> {
-    let target_lower = target_name.to_ascii_lowercase();
-    let mut min_slack: Option<i64> = None;
-    let mut had_miss = false;
-    let mut had_match = false;
-
-    for d in diags {
-        if d.analysis != "RtaAnalysis" {
-            continue;
-        }
-        let msg_lower = d.message.to_ascii_lowercase();
-        let needle = format!("on processor '{}'", target_lower);
-        if !msg_lower.contains(&needle) {
-            continue;
-        }
-        had_match = true;
-
-        if d.severity == Severity::Error && msg_lower.contains("misses deadline") {
-            had_miss = true;
-            continue;
-        }
-
-        // Parse "response time <X> <= deadline <Y>".
-        if let Some((rt, dl)) = parse_response_deadline(&d.message) {
-            let slack = dl as i64 - rt as i64;
-            min_slack = Some(min_slack.map(|m| m.min(slack)).unwrap_or(slack));
-        }
-    }
-
-    if had_miss {
-        // Deadline miss dominates: report a negative sentinel. The
-        // consumer just checks the sign for "is this candidate
-        // schedulable?".
-        return Some(-1);
-    }
-    if !had_match {
-        return None;
-    }
-    min_slack
-}
-
-/// Parse the `"response time <X> <= deadline <Y>"` substring from an
-/// RTA info-level diagnostic message.
-///
-/// Returns `(response_time_ps, deadline_ps)` if both formatted-time
-/// values parse cleanly; `None` otherwise. Parsing the formatted form
-/// is intentional — RTA does not currently expose its raw picosecond
-/// values via the diagnostic struct, and committing a parser here is
-/// cheaper than expanding the AnalysisDiagnostic shape just for the
-/// commit-4 ranking metric.
-fn parse_response_deadline(msg: &str) -> Option<(u64, u64)> {
-    let after_rt = msg.find("response time ")?;
-    let rest = &msg[after_rt + "response time ".len()..];
-    let le_pos = rest.find("<=")?;
-    let rt_str = rest[..le_pos].trim();
-    let after_dl = rest[le_pos + 2..].find("deadline ")?;
-    let dl_rest = &rest[le_pos + 2 + after_dl + "deadline ".len()..];
-    let dl_str = dl_rest.trim_end_matches(['.', ',']).trim();
-    Some((parse_format_time(rt_str)?, parse_format_time(dl_str)?))
-}
-
-/// Inverse of `spar_analysis::rta::format_time`: parse a `"<num> <unit>"`
-/// string back into picoseconds. Unit suffixes recognised: `ps`, `us`,
-/// `ms`, `sec`. Whitespace-tolerant; returns `None` on parse failure.
-fn parse_format_time(s: &str) -> Option<u64> {
-    let s = s.trim();
-    let space = s.rfind(char::is_whitespace)?;
-    let num_str = s[..space].trim();
-    let unit = s[space..].trim();
-
-    let scale: u64 = match unit {
-        "ps" => 1,
-        "us" => 1_000_000,
-        "ms" => 1_000_000_000,
-        "sec" | "s" => 1_000_000_000_000,
-        _ => return None,
-    };
-
-    if let Ok(n) = num_str.parse::<u64>() {
-        return Some(n.saturating_mul(scale));
-    }
-    let f = num_str.parse::<f64>().ok()?;
-    if f.is_nan() || f.is_sign_negative() {
-        return None;
-    }
-    Some((f * scale as f64) as u64)
 }
 
 /// Render a [`MoveEnumerateReport`] as canonical pretty-printed JSON.
@@ -1147,8 +1069,13 @@ fn render_enumerate_json(report: &MoveEnumerateReport) {
 /// Render a [`MoveEnumerateReport`] in human-readable tabular form.
 ///
 /// Layout: a one-line component header, a fixed-width row per
-/// candidate (status / target / slack / violation summary), and a
-/// `total=N valid=K` summary footer mirroring the JSON shape.
+/// candidate (status / target / score / errs / violation summary),
+/// and a `total=N valid=K` summary footer mirroring the JSON shape.
+///
+/// Track E commit 5/8: the `slack` column from commit 4 is replaced by
+/// a `score` column (lower = better) carrying the multi-objective
+/// rank value; `<missed>` is emitted for deadline-miss candidates so
+/// the column stays one token wide.
 fn render_enumerate_text(report: &MoveEnumerateReport) {
     println!(
         "Enumerate {} ({} candidates)",
@@ -1158,24 +1085,31 @@ fn render_enumerate_text(report: &MoveEnumerateReport) {
         println!("  (no candidate targets)");
     } else {
         println!(
-            "  {:<6} {:<40} {:>14} {:>6}  violations",
-            "ok", "target", "slack", "errs",
+            "  {:<6} {:<40} {:>10} {:>6}  violations",
+            "ok", "target", "score", "errs",
         );
         for c in &report.candidates {
             let status = if c.ok { "OK" } else { "FAIL" };
-            let slack = match c.slack_ns {
-                Some(n) if n < 0 => "<missed>".to_string(),
-                Some(n) => format!("{n} ps"),
-                None => "-".to_string(),
-            };
+            let score_str = format_score(&c.rank);
             let viol_summary = summarise_violations(&c.violations);
             println!(
-                "  {:<6} {:<40} {:>14} {:>6}  {}",
-                status, c.target, slack, c.diagnostics_count, viol_summary,
+                "  {:<6} {:<40} {:>10} {:>6}  {}",
+                status, c.target, score_str, c.diagnostics_count, viol_summary,
             );
         }
     }
     println!("total={} valid={}", report.total, report.valid);
+}
+
+/// Render a [`CandidateRank::score`] as a fixed-precision token for the
+/// text-format renderer. Deadline-miss candidates (negative
+/// `max_response_ns` sentinel) get a `<missed>` token instead so the
+/// column stays one word wide and is greppable.
+fn format_score(rank: &CandidateRank) -> String {
+    if matches!(rank.max_response_ns, Some(n) if n < 0) {
+        return "<missed>".to_string();
+    }
+    format!("{:.4}", rank.score)
 }
 
 /// Compress a [`Violation`] vector into a one-line summary for the
@@ -1203,13 +1137,17 @@ fn summarise_violations(violations: &[Violation]) -> String {
 /// Print `spar moves enumerate` usage to stderr.
 pub fn print_enumerate_usage() {
     eprintln!("Usage: spar moves enumerate --root Pkg::Type.Impl --component <fqn> \\");
-    eprintln!("                            [--target-filter <substring>] [--format text|json] \\");
-    eprintln!("                            <model.aadl>...");
+    eprintln!("                            [--target-filter <substring>] [--objective <mode>] \\");
+    eprintln!("                            [--format text|json] <model.aadl>...");
     eprintln!();
     eprintln!("Options:");
     eprintln!("  --root           Root system implementation in Pkg::Type.Impl form");
     eprintln!("  --component      FQN (or suffix / bare name) of the component to enumerate");
     eprintln!("  --target-filter  Optional case-insensitive substring filter on candidate FQNs");
+    eprintln!(
+        "  --objective      Ranking objective: max-response (default), total-load, total-power,"
+    );
+    eprintln!("                   total-weight, or balanced (all four equally weighted)");
     eprintln!("  --format         Output format: text (default) or json");
     eprintln!();
     eprintln!("Candidate-target set:");
@@ -1223,12 +1161,36 @@ pub fn print_enumerate_usage() {
     eprintln!("  1  no admissible candidate (or input-resolution error)");
 }
 
+/// Parse the `--objective` CLI value into an [`EnumerationObjective`].
+///
+/// Recognised modes (case-insensitive, dashed form):
+///
+/// - `max-response` — single-axis: minimise max response time.
+/// - `total-load`   — single-axis: minimise total CPU utilisation.
+/// - `total-power`  — single-axis: minimise total power (Spar_Power).
+/// - `total-weight` — single-axis: minimise total weight.
+/// - `balanced`     — all four axes equally weighted.
+///
+/// Returns [`MovesError::UnknownObjective`] for any other input so the
+/// CLI driver can surface a clear message and a non-zero exit.
+fn parse_objective(s: &str) -> Result<EnumerationObjective, MovesError> {
+    match s.to_ascii_lowercase().as_str() {
+        "max-response" => Ok(EnumerationObjective::max_response()),
+        "total-load" => Ok(EnumerationObjective::total_load()),
+        "total-power" => Ok(EnumerationObjective::total_power()),
+        "total-weight" => Ok(EnumerationObjective::total_weight()),
+        "balanced" => Ok(EnumerationObjective::balanced()),
+        _ => Err(MovesError::UnknownObjective(s.to_string())),
+    }
+}
+
 /// Manual-arg parser for `spar moves enumerate`.
 fn cmd_moves_enumerate(args: &[String]) -> i32 {
     let mut root = None;
     let mut component = None;
     let mut target_filter: Option<String> = None;
     let mut format: Option<String> = None;
+    let mut objective_str: Option<String> = None;
     let mut model_files = Vec::new();
 
     let mut i = 0;
@@ -1257,6 +1219,17 @@ fn cmd_moves_enumerate(args: &[String]) -> i32 {
                     return 1;
                 }
                 target_filter = Some(args[i].clone());
+            }
+            "--objective" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!(
+                        "--objective requires a value (max-response | total-load | \
+                         total-power | total-weight | balanced)"
+                    );
+                    return 1;
+                }
+                objective_str = Some(args[i].clone());
             }
             "--format" => {
                 i += 1;
@@ -1293,12 +1266,24 @@ fn cmd_moves_enumerate(args: &[String]) -> i32 {
         return 1;
     }
 
+    let objective = match objective_str.as_deref() {
+        None => EnumerationObjective::max_response(),
+        Some(s) => match parse_objective(s) {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 1;
+            }
+        },
+    };
+
     let args = EnumerateArgs {
         model_files,
         root,
         component,
         target_filter,
         format: format.unwrap_or_else(|| "text".to_string()),
+        objective,
     };
 
     match run_enumerate(args) {
@@ -1313,31 +1298,6 @@ fn cmd_moves_enumerate(args: &[String]) -> i32 {
 #[cfg(test)]
 mod enumerate_tests {
     use super::*;
-
-    #[test]
-    fn parse_format_time_roundtrips_units() {
-        assert_eq!(parse_format_time("10 ms"), Some(10_000_000_000));
-        assert_eq!(parse_format_time("1.50 ms"), Some(1_500_000_000));
-        assert_eq!(parse_format_time("500 us"), Some(500_000_000));
-        assert_eq!(parse_format_time("100 ps"), Some(100));
-        assert_eq!(parse_format_time("2.00 sec"), Some(2_000_000_000_000));
-        assert_eq!(parse_format_time(""), None);
-        assert_eq!(parse_format_time("not a time"), None);
-        assert_eq!(parse_format_time("10 fortnights"), None);
-    }
-
-    #[test]
-    fn parse_response_deadline_extracts_pair() {
-        let msg = "thread 't1' on processor 'cpu1': response time 5 ms <= deadline 10 ms";
-        let pair = parse_response_deadline(msg).expect("expected to parse");
-        assert_eq!(pair, (5_000_000_000, 10_000_000_000));
-    }
-
-    #[test]
-    fn parse_response_deadline_returns_none_on_unrelated_message() {
-        let msg = "ARINC653 partition X has no period";
-        assert!(parse_response_deadline(msg).is_none());
-    }
 
     #[test]
     fn summarise_violations_groups_by_kind() {
@@ -1361,5 +1321,35 @@ mod enumerate_tests {
         // Order is BTreeMap so AnalysisError comes before Frozen alphabetically.
         assert!(s.contains("AnalysisError×1"));
         assert!(s.contains("Frozen×2"));
+    }
+
+    #[test]
+    fn parse_objective_recognises_named_modes() {
+        assert!(matches!(
+            parse_objective("max-response"),
+            Ok(o) if o == EnumerationObjective::max_response()
+        ));
+        assert!(matches!(
+            parse_objective("total-load"),
+            Ok(o) if o == EnumerationObjective::total_load()
+        ));
+        assert!(matches!(
+            parse_objective("total-power"),
+            Ok(o) if o == EnumerationObjective::total_power()
+        ));
+        assert!(matches!(
+            parse_objective("total-weight"),
+            Ok(o) if o == EnumerationObjective::total_weight()
+        ));
+        assert!(matches!(
+            parse_objective("balanced"),
+            Ok(o) if o == EnumerationObjective::balanced()
+        ));
+    }
+
+    #[test]
+    fn parse_objective_rejects_unknown() {
+        let err = parse_objective("not-a-real-mode").unwrap_err();
+        assert!(matches!(err, MovesError::UnknownObjective(s) if s == "not-a-real-mode"));
     }
 }

--- a/crates/spar-cli/tests/moves_enumerate_objectives.rs
+++ b/crates/spar-cli/tests/moves_enumerate_objectives.rs
@@ -1,0 +1,634 @@
+//! Integration tests for `spar moves enumerate --objective <mode>`
+//! (Track E commit 5/8).
+//!
+//! Each test builds a small inline AADL model, drops it into a per-test
+//! temp file (mirroring the `moves_enumerate.rs` pattern), and shells
+//! out to the `spar` binary. Tests assert exit codes, parse JSON / text
+//! output, and verify the multi-objective ranking shape.
+//!
+//! Test inventory (10 cases per the commit-5 spec):
+//!
+//!  1. `default_objective_is_max_response`
+//!  2. `total_load_objective_picks_least_loaded_cpu`
+//!  3. `total_power_objective_reads_spar_power`
+//!  4. `total_weight_objective_reads_weight_property`
+//!  5. `balanced_objective_aggregates_all_four`
+//!  6. `unknown_objective_errors_clearly`
+//!  7. `objective_doesnt_change_validity`
+//!  8. `score_zero_when_no_objective_data`
+//!  9. `negative_max_response_indicates_deadline_miss`
+//! 10. `enumerate_text_format_includes_score_column`
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn spar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spar"))
+}
+
+fn write_model(tag: &str, body: &str) -> PathBuf {
+    let path = env::temp_dir().join(format!(
+        "spar_moves_enumerate_objectives_{}_{}.aadl",
+        std::process::id(),
+        tag,
+    ));
+    fs::write(&path, body).expect("write temp AADL");
+    path
+}
+
+fn cleanup(path: &PathBuf) {
+    let _ = fs::remove_file(path);
+}
+
+/// Two-CPU baseline: minimal model used wherever the test is asserting
+/// orthogonal behaviour and the actual analysis numbers don't matter.
+const BASELINE_MODEL: &str = "\
+package Obj
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Obj;
+";
+
+/// Two CPUs with very different power budgets attached.
+///
+/// Test 3 asserts that under `--objective total-power` the candidate
+/// with the lower-power CPU sorts ahead of the one with the
+/// higher-power CPU. Spar_Power::Power_Budget is read directly from
+/// the candidate processor.
+const POWER_MODEL: &str = "\
+package PowerObj
+public
+  processor LowPowerCPU
+    properties
+      Spar_Power::Power_Budget => 100 ms;
+  end LowPowerCPU;
+
+  processor HighPowerCPU
+    properties
+      Spar_Power::Power_Budget => 5000 ms;
+  end HighPowerCPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu_low:  processor LowPowerCPU;
+      cpu_high: processor HighPowerCPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu_low)) applies to app.t1;
+  end Sys.Impl;
+end PowerObj;
+";
+
+/// Two CPUs with very different declared weights.
+const WEIGHT_MODEL: &str = "\
+package WeightObj
+public
+  processor LightCPU
+    properties
+      Weight_Properties::Weight => 1 ms;
+  end LightCPU;
+
+  processor HeavyCPU
+    properties
+      Weight_Properties::Weight => 1000 ms;
+  end HeavyCPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu_light: processor LightCPU;
+      cpu_heavy: processor HeavyCPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu_light)) applies to app.t1;
+  end Sys.Impl;
+end WeightObj;
+";
+
+/// Two CPUs with one already loaded by an existing thread (`busy`)
+/// while the other (`empty`) is unbound.
+///
+/// Under `--objective total-load`, ranking the candidate that lands
+/// `t1` on `cpu_busy` must score higher (worse) than landing on
+/// `cpu_empty` because cpu_busy already has a thread costing wcet/period
+/// = 0.5 of utilisation under the (un-overlayed) declared binding.
+const LOAD_MODEL: &str = "\
+package LoadObj
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+    properties
+      Dispatch_Protocol => Periodic;
+      Period => 100 ms;
+      Compute_Execution_Time => 50 ms .. 50 ms;
+      Deadline => 100 ms;
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+      t_existing: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu_empty: processor CPU;
+      cpu_busy:  processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu_empty)) applies to app.t1;
+      Actual_Processor_Binding => (reference (cpu_busy))  applies to app.t_existing;
+  end Sys.Impl;
+end LoadObj;
+";
+
+/// Same shape as `LOAD_MODEL` but with execution times that *miss*
+/// the deadline on every candidate, exercising the deadline-miss path.
+const DEADLINE_MISS_MODEL: &str = "\
+package MissObj
+public
+  processor CPU
+    properties
+      Scheduling_Protocol => (RMS);
+  end CPU;
+
+  thread Worker
+    properties
+      Dispatch_Protocol => Periodic;
+      Period => 10 ms;
+      Compute_Execution_Time => 50 ms .. 50 ms;
+      Deadline => 10 ms;
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end MissObj;
+";
+
+fn run_enumerate(model_path: &PathBuf, root: &str, args: &[&str]) -> std::process::Output {
+    let mut cmd = spar();
+    cmd.args(["moves", "enumerate", "--root", root, "--component", "t1"]);
+    cmd.args(args);
+    cmd.arg(model_path);
+    cmd.output().expect("failed to run spar")
+}
+
+// ── 1. default_objective_is_max_response ─────────────────────────────
+
+#[test]
+fn default_objective_is_max_response() {
+    // Without --objective, the score must reflect the
+    // max-response single-objective metric. With BASELINE_MODEL
+    // (no period / wcet) the max_response_ns should be None and
+    // hence score = 0 for every candidate. We verify the JSON shape
+    // carries `rank.max_response_ns` and `rank.score` keys.
+    let path = write_model("default_obj", BASELINE_MODEL);
+    let out = run_enumerate(&path, "Obj::Sys.Impl", &["--format", "json"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("stdout was not valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert!(!candidates.is_empty(), "expected at least one candidate");
+    for c in candidates {
+        let rank = &c["rank"];
+        assert!(
+            rank.is_object(),
+            "rank must be an object on every candidate"
+        );
+        assert!(rank["score"].is_number(), "rank.score must be a number");
+        // max_response_ns is null or i64 (None or a value)
+        assert!(
+            rank["max_response_ns"].is_null() || rank["max_response_ns"].is_number(),
+            "rank.max_response_ns must be null or number; got {rank}"
+        );
+    }
+    cleanup(&path);
+}
+
+// ── 2. total_load_objective_picks_least_loaded_cpu ───────────────────
+
+#[test]
+fn total_load_objective_picks_least_loaded_cpu() {
+    // Two CPUs: cpu_empty has no other thread; cpu_busy carries
+    // t_existing. Under --objective total-load, the candidate moving
+    // t1 to cpu_empty must rank ahead of (lower score than) the one
+    // moving t1 to cpu_busy.
+    let path = write_model("total_load", LOAD_MODEL);
+    let out = run_enumerate(
+        &path,
+        "LoadObj::Sys.Impl",
+        &["--objective", "total-load", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+
+    // Find the cpu_empty and cpu_busy entries.
+    let by_target = |needle: &str| {
+        candidates
+            .iter()
+            .find(|c| c["target"].as_str().unwrap_or("").ends_with(needle))
+            .unwrap_or_else(|| panic!("no candidate matched '{needle}': {candidates:?}"))
+    };
+    let empty = by_target("cpu_empty");
+    let busy = by_target("cpu_busy");
+
+    let s_empty = empty["rank"]["score"].as_f64().unwrap();
+    let s_busy = busy["rank"]["score"].as_f64().unwrap();
+
+    assert!(
+        s_empty <= s_busy,
+        "expected cpu_empty score ({s_empty}) <= cpu_busy score ({s_busy})",
+    );
+
+    // Sorting should also reflect this: first ok=true candidate is cpu_empty.
+    let first_ok = candidates
+        .iter()
+        .find(|c| c["ok"].as_bool() == Some(true))
+        .expect("at least one ok candidate");
+    assert!(
+        first_ok["target"].as_str().unwrap().ends_with("cpu_empty"),
+        "expected the lowest-load candidate to sort first; got {}",
+        first_ok["target"],
+    );
+    cleanup(&path);
+}
+
+// ── 3. total_power_objective_reads_spar_power ────────────────────────
+
+#[test]
+fn total_power_objective_reads_spar_power() {
+    let path = write_model("total_power", POWER_MODEL);
+    let out = run_enumerate(
+        &path,
+        "PowerObj::Sys.Impl",
+        &["--objective", "total-power", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+
+    let by_target = |needle: &str| {
+        candidates
+            .iter()
+            .find(|c| c["target"].as_str().unwrap_or("").ends_with(needle))
+            .unwrap_or_else(|| panic!("no candidate matched '{needle}'"))
+    };
+    let low = by_target("cpu_low");
+    let high = by_target("cpu_high");
+
+    // Both candidates must have a populated total_power_mw value
+    // (read from Spar_Power::Power_Budget on the target processor).
+    let low_power = low["rank"]["total_power_mw"].as_u64();
+    let high_power = high["rank"]["total_power_mw"].as_u64();
+    assert!(
+        low_power.is_some() && high_power.is_some(),
+        "expected total_power_mw on both candidates; got {low_power:?} / {high_power:?}",
+    );
+    assert!(
+        low_power.unwrap() < high_power.unwrap(),
+        "low-power CPU must report less power; got {low_power:?} vs {high_power:?}",
+    );
+
+    let s_low = low["rank"]["score"].as_f64().unwrap();
+    let s_high = high["rank"]["score"].as_f64().unwrap();
+    assert!(
+        s_low < s_high,
+        "expected cpu_low score ({s_low}) < cpu_high score ({s_high})",
+    );
+    cleanup(&path);
+}
+
+// ── 4. total_weight_objective_reads_weight_property ──────────────────
+
+#[test]
+fn total_weight_objective_reads_weight_property() {
+    let path = write_model("total_weight", WEIGHT_MODEL);
+    let out = run_enumerate(
+        &path,
+        "WeightObj::Sys.Impl",
+        &["--objective", "total-weight", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+
+    let by_target = |needle: &str| {
+        candidates
+            .iter()
+            .find(|c| c["target"].as_str().unwrap_or("").ends_with(needle))
+            .unwrap_or_else(|| panic!("no candidate matched '{needle}'"))
+    };
+    let light = by_target("cpu_light");
+    let heavy = by_target("cpu_heavy");
+
+    let light_w = light["rank"]["total_weight_g"].as_u64();
+    let heavy_w = heavy["rank"]["total_weight_g"].as_u64();
+    assert!(
+        light_w.is_some() && heavy_w.is_some(),
+        "expected total_weight_g on both candidates; got {light_w:?} / {heavy_w:?}",
+    );
+    assert!(
+        light_w.unwrap() < heavy_w.unwrap(),
+        "light CPU must report less weight; got {light_w:?} vs {heavy_w:?}",
+    );
+
+    let s_light = light["rank"]["score"].as_f64().unwrap();
+    let s_heavy = heavy["rank"]["score"].as_f64().unwrap();
+    assert!(
+        s_light < s_heavy,
+        "expected cpu_light score ({s_light}) < cpu_heavy score ({s_heavy})",
+    );
+    cleanup(&path);
+}
+
+// ── 5. balanced_objective_aggregates_all_four ────────────────────────
+
+#[test]
+fn balanced_objective_aggregates_all_four() {
+    // Use POWER_MODEL: with --objective balanced, the score still
+    // differentiates the two candidates because total-power varies
+    // across targets, but each axis carries 1/4 of the total weight.
+    // Verify (a) score is non-zero on at least one candidate, and
+    // (b) the cpu_high candidate scores higher than cpu_low.
+    let path = write_model("balanced", POWER_MODEL);
+    let out = run_enumerate(
+        &path,
+        "PowerObj::Sys.Impl",
+        &["--objective", "balanced", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+
+    let by_target = |needle: &str| {
+        candidates
+            .iter()
+            .find(|c| c["target"].as_str().unwrap_or("").ends_with(needle))
+            .unwrap_or_else(|| panic!("no candidate matched '{needle}'"))
+    };
+    let low = by_target("cpu_low");
+    let high = by_target("cpu_high");
+
+    let s_low = low["rank"]["score"].as_f64().unwrap();
+    let s_high = high["rank"]["score"].as_f64().unwrap();
+    assert!(
+        s_high > s_low,
+        "balanced score should still penalise high-power candidate; got low={s_low} high={s_high}",
+    );
+    // Score must be > 0 since power values are non-zero.
+    assert!(
+        s_high > 0.0,
+        "expected non-zero balanced score on the high-power candidate; got {s_high}",
+    );
+    cleanup(&path);
+}
+
+// ── 6. unknown_objective_errors_clearly ──────────────────────────────
+
+#[test]
+fn unknown_objective_errors_clearly() {
+    let path = write_model("unknown_obj", BASELINE_MODEL);
+    let out = run_enumerate(
+        &path,
+        "Obj::Sys.Impl",
+        &["--objective", "not-a-real-mode", "--format", "json"],
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.code() != Some(0),
+        "expected non-zero exit on bad --objective"
+    );
+    assert!(
+        stderr.contains("not-a-real-mode") || stderr.contains("--objective"),
+        "stderr should mention the offending objective or --objective; got: {stderr}",
+    );
+    cleanup(&path);
+}
+
+// ── 7. objective_doesnt_change_validity ──────────────────────────────
+
+#[test]
+fn objective_doesnt_change_validity() {
+    // For the same model, the set of `ok=true` candidates must be
+    // identical regardless of which objective drives the ranking.
+    // Only the order changes.
+    let path = write_model("validity", POWER_MODEL);
+
+    let valid_set = |args: &[&str]| -> std::collections::BTreeSet<String> {
+        let out = run_enumerate(&path, "PowerObj::Sys.Impl", args);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+        v["candidates"]
+            .as_array()
+            .expect("candidates")
+            .iter()
+            .filter(|c| c["ok"].as_bool() == Some(true))
+            .map(|c| c["target"].as_str().unwrap_or("").to_string())
+            .collect()
+    };
+
+    let s_default = valid_set(&["--format", "json"]);
+    let s_load = valid_set(&["--objective", "total-load", "--format", "json"]);
+    let s_power = valid_set(&["--objective", "total-power", "--format", "json"]);
+    let s_balanced = valid_set(&["--objective", "balanced", "--format", "json"]);
+
+    assert_eq!(s_default, s_load, "objective change altered validity set");
+    assert_eq!(s_default, s_power, "objective change altered validity set");
+    assert_eq!(
+        s_default, s_balanced,
+        "objective change altered validity set"
+    );
+    cleanup(&path);
+}
+
+// ── 8. score_zero_when_no_objective_data ─────────────────────────────
+
+#[test]
+fn score_zero_when_no_objective_data() {
+    // BASELINE_MODEL has no Period / Compute_Execution_Time, no
+    // Spar_Power, and no Weight properties on either CPU. Under
+    // any objective other than balanced, the score collapses to 0
+    // for every candidate.
+    let path = write_model("no_data", BASELINE_MODEL);
+    let out = run_enumerate(
+        &path,
+        "Obj::Sys.Impl",
+        &["--objective", "total-power", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert!(!candidates.is_empty());
+    for c in candidates {
+        let s = c["rank"]["score"].as_f64().unwrap();
+        assert_eq!(
+            s, 0.0,
+            "expected score=0 on every candidate when no data is available; got {s}",
+        );
+    }
+    cleanup(&path);
+}
+
+// ── 9. negative_max_response_indicates_deadline_miss ─────────────────
+
+#[test]
+fn negative_max_response_indicates_deadline_miss() {
+    // The deadline-miss model produces an RTA Error on every
+    // candidate. The corresponding rank.max_response_ns must be
+    // negative (sentinel) on those candidates and the score must
+    // reflect the inflated contribution (10.0 under
+    // --objective max-response).
+    let path = write_model("miss", DEADLINE_MISS_MODEL);
+    let out = run_enumerate(
+        &path,
+        "MissObj::Sys.Impl",
+        &["--objective", "max-response", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let candidates = v["candidates"].as_array().expect("candidates");
+    assert!(!candidates.is_empty());
+    let mut had_miss = false;
+    for c in candidates {
+        let mrs = c["rank"]["max_response_ns"].as_i64();
+        if let Some(n) = mrs
+            && n < 0
+        {
+            had_miss = true;
+            let s = c["rank"]["score"].as_f64().unwrap();
+            assert!(
+                s >= 9.99,
+                "deadline-miss candidate score should be inflated; got {s} for target {}",
+                c["target"],
+            );
+        }
+    }
+    assert!(
+        had_miss,
+        "expected at least one candidate to have a deadline-miss sentinel",
+    );
+
+    // Such candidates must rank *last* — i.e., the last candidate's
+    // score is at least the first candidate's score.
+    let first_score = candidates[0]["rank"]["score"].as_f64().unwrap();
+    let last_score = candidates[candidates.len() - 1]["rank"]["score"]
+        .as_f64()
+        .unwrap();
+    assert!(
+        last_score >= first_score,
+        "deadline-miss candidate must not sort ahead of an admissible candidate; first={first_score}, last={last_score}",
+    );
+    cleanup(&path);
+}
+
+// ── 10. enumerate_text_format_includes_score_column ──────────────────
+
+#[test]
+fn enumerate_text_format_includes_score_column() {
+    let path = write_model("text_score", BASELINE_MODEL);
+    let out = run_enumerate(&path, "Obj::Sys.Impl", &["--format", "text"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The header row must mention "score" (not "slack"). The first
+    // header line begins with "  ok" and ends with "violations" per
+    // render_enumerate_text.
+    let header = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("ok") && l.contains("target"))
+        .unwrap_or_else(|| panic!("no enumerate-table header found in output:\n{stdout}"));
+    assert!(
+        header.contains("score"),
+        "expected `score` column header; got: {header:?}\nfull stdout: {stdout}"
+    );
+    assert!(
+        !header.contains("slack"),
+        "text format should no longer carry a `slack` column; got: {header:?}",
+    );
+    cleanup(&path);
+}

--- a/crates/spar-hir-def/src/standard_properties.rs
+++ b/crates/spar-hir-def/src/standard_properties.rs
@@ -38,6 +38,7 @@ pub const STANDARD_PROPERTY_SET_NAMES: &[&str] = &[
     "Spar_Trace",
     "Spar_Network",
     "Spar_Migration",
+    "Spar_Power",
 ];
 
 // ── Timing_Properties ───────────────────────────────────────────────
@@ -430,6 +431,32 @@ const SPAR_MIGRATION: &[(&str, &str)] = &[
     ("Pinned_Reason", "aadlstring"),
 ];
 
+// ── Spar_Power ──────────────────────────────────────────────────────
+//
+// Non-standard property set defined by spar itself (not AS5506); used
+// by the v0.8.0 Track E commit 5/8 multi-objective enumeration ranker
+// (`spar moves enumerate --objective total-power`). Sits alongside the
+// existing `SEI::PowerBudget` / `Physical_Properties::Power_Budget`
+// vocabulary read by `spar-analysis::weight_power` so users with neither
+// of those upstream sets in scope can still annotate per-component
+// power consumption for design-space ranking.
+//
+// Modeled as `Time` so the value lowers to picoseconds via the existing
+// AADL time-unit machinery — semantically the value carries milliwatts
+// and is read with [`crate::power::read_power_budget_mw`], but using
+// `Time` for the declarative type lets us reuse the time-aware lowerer
+// without inventing a new "Power" base type for v0.8.0. The `mw`
+// suffix is documented in the helper, not enforced at the
+// property-set level.
+
+const SPAR_POWER: &[(&str, &str)] = &[
+    // Per-component power-budget annotation in milliwatts. Read by the
+    // multi-objective ranker so users can score candidate bindings on
+    // total power. Optional — when absent the candidate's power
+    // contribution to the score is zero.
+    ("Power_Budget", "Time"),
+];
+
 /// Helper: collect properties from a table into the result vector.
 fn collect_properties(
     table: &[(&'static str, &'static str)],
@@ -469,6 +496,7 @@ pub fn all_standard_properties() -> Vec<StandardProperty> {
     collect_properties(SPAR_TRACE, "Spar_Trace", &mut result);
     collect_properties(SPAR_NETWORK, "Spar_Network", &mut result);
     collect_properties(SPAR_MIGRATION, "Spar_Migration", &mut result);
+    collect_properties(SPAR_POWER, "Spar_Power", &mut result);
 
     result
 }
@@ -498,6 +526,7 @@ fn lookup_table(set_lower: &str) -> Option<&'static [(&'static str, &'static str
         "spar_trace" => Some(SPAR_TRACE),
         "spar_network" => Some(SPAR_NETWORK),
         "spar_migration" => Some(SPAR_MIGRATION),
+        "spar_power" => Some(SPAR_POWER),
         _ => None,
     }
 }
@@ -546,6 +575,7 @@ mod tests {
         assert!(is_standard_property_set("Spar_Trace"));
         assert!(is_standard_property_set("Spar_Network"));
         assert!(is_standard_property_set("Spar_Migration"));
+        assert!(is_standard_property_set("Spar_Power"));
 
         // Case-insensitive
         assert!(is_standard_property_set("timing_properties"));
@@ -1013,14 +1043,15 @@ mod tests {
     #[test]
     fn test_all_standard_properties_total_count() {
         let all = all_standard_properties();
-        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 = 121
+        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 + 1 = 122
         // (Timing + Communication + Memory + Deployment + Thread + Programming
         //  + Modeling + AADL_Project + Spar_Timing + Spar_Trace + Spar_Network
-        //  + Spar_Migration)
+        //  + Spar_Migration + Spar_Power)
         // Thread_Properties: +1 for Locking_Protocol (v0.7.1 PIP/PCP).
         // Spar_Timing: +1 for Critical_Section_Blocking (v0.7.1 PIP/PCP).
         // Spar_Network: +1 for WCTT_Budget (Track D commit 4).
-        assert_eq!(all.len(), 121);
+        // Spar_Power: +1 for Power_Budget (Track E commit 5/8 ranker).
+        assert_eq!(all.len(), 122);
     }
 
     #[test]

--- a/crates/spar-solver/src/enumerate.rs
+++ b/crates/spar-solver/src/enumerate.rs
@@ -1,0 +1,840 @@
+//! Overlay-aware multi-objective candidate ranking (Track E commit 5/8).
+//!
+//! Extends the v0.7.x [`crate::milp`] surface with a *ranking* mode used
+//! by `spar moves enumerate` to score hypothetical bindings. Where
+//! [`crate::milp::solve_milp`] picks one optimal binding, this module
+//! takes a [`BindingOverlay`] that describes a *single* candidate move
+//! and produces a [`CandidateRank`] whose components capture the same
+//! axes the verify-pipeline already exposes:
+//!
+//! - **Max response time** across threads bound (under the overlay) to
+//!   any candidate processor — derived from the existing RTA pass via
+//!   message parsing, mirroring the slack-extraction loop in commit 4.
+//! - **Total CPU load** as the worst-case sum of `wcet/period` over
+//!   threads visible under the overlay.
+//! - **Total power** read from `Spar_Power::Power_Budget` (and the
+//!   compatible `SEI::PowerBudget` / `Physical_Properties::Power_Budget`
+//!   keys upstream of `weight_power`).
+//! - **Total weight** read from `Weight_Properties::Weight` and the
+//!   compatible upstream keys.
+//!
+//! The aggregate `score` is a normalised, weighted sum (lower = better)
+//! computed from the boolean flags in [`EnumerationObjective`]. Each
+//! enabled objective contributes `1/k` where `k` is the count of
+//! enabled objectives; an empty objective set yields `score = 0` which
+//! lets callers pass `Default::default()` as a "no preference" probe.
+//!
+//! # Why not invoke MILP here?
+//!
+//! The v0.8.0 commit-5 promise is *consistent multi-objective ranking*
+//! using the same machinery the verify-pipeline runs — not full
+//! MILP-driven enumeration. Running MILP per candidate would double
+//! solver work for the candidate-loop case and add a HiGHS dependency
+//! on the rank path. We keep the existing `solve_milp` for fresh
+//! allocation and reuse RTA + property-accessor lookups for ranking.
+//! Full MILP-driven enumeration lands in commit 6/8 if the empirical
+//! cost/benefit makes the case.
+
+use serde::Serialize;
+
+use spar_analysis::{AnalysisDiagnostic, AnalysisRunner, Severity};
+use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
+use spar_hir_def::item_tree::{ComponentCategory, PropertyExpr};
+use spar_hir_def::overlay::{BindingOverlay, actual_processor_binding_with_overlay};
+use spar_hir_def::properties::PropertyMap;
+
+/// Multi-objective rank specification for a hypothetical binding.
+///
+/// All four fields are independent boolean flags. Setting more than one
+/// produces a *balanced* score — each enabled objective contributes
+/// `1/k` of the total, where `k` is the number of enabled flags.
+///
+/// `Default` returns all-false; the resulting score is always zero,
+/// which makes `EnumerationObjective::default()` a reasonable
+/// "no preference" probe in tests that want to exercise the
+/// rank-extraction plumbing without picking a metric.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct EnumerationObjective {
+    /// Score by maximum response time across overlay-bound threads.
+    /// Lower = better; deadline misses produce a negative
+    /// `max_response_ns` and a large positive score contribution.
+    pub minimize_max_response: bool,
+    /// Score by aggregate CPU utilization (sum of `wcet/period`
+    /// across bound threads).
+    pub minimize_total_load: bool,
+    /// Score by total power consumption read from
+    /// `Spar_Power::Power_Budget` (with upstream fallbacks via
+    /// `SEI::PowerBudget` / `Physical_Properties::Power_Budget`).
+    pub minimize_total_power: bool,
+    /// Score by total weight read from `Weight_Properties::Weight`
+    /// (with upstream `SEI::GrossWeight` / `Weight` fallbacks).
+    pub minimize_total_weight: bool,
+}
+
+impl EnumerationObjective {
+    /// All four objectives enabled, weighted equally.
+    pub fn balanced() -> Self {
+        Self {
+            minimize_max_response: true,
+            minimize_total_load: true,
+            minimize_total_power: true,
+            minimize_total_weight: true,
+        }
+    }
+
+    /// Single-objective: maximum response time only.
+    pub fn max_response() -> Self {
+        Self {
+            minimize_max_response: true,
+            ..Self::default()
+        }
+    }
+
+    /// Single-objective: total CPU utilization only.
+    pub fn total_load() -> Self {
+        Self {
+            minimize_total_load: true,
+            ..Self::default()
+        }
+    }
+
+    /// Single-objective: total power consumption only.
+    pub fn total_power() -> Self {
+        Self {
+            minimize_total_power: true,
+            ..Self::default()
+        }
+    }
+
+    /// Single-objective: total weight only.
+    pub fn total_weight() -> Self {
+        Self {
+            minimize_total_weight: true,
+            ..Self::default()
+        }
+    }
+
+    /// Number of enabled flags (1..=4 for the named modes, 0 for `Default`).
+    pub fn enabled_count(&self) -> u32 {
+        u32::from(self.minimize_max_response)
+            + u32::from(self.minimize_total_load)
+            + u32::from(self.minimize_total_power)
+            + u32::from(self.minimize_total_weight)
+    }
+}
+
+/// Multi-objective rank produced for a candidate hypothetical binding.
+///
+/// `score` is the aggregate (lower = better) computed from the per-axis
+/// values and the enabled flags in [`EnumerationObjective`]. The raw
+/// per-axis values stay accessible so callers can render a verbose
+/// breakdown, sort by a different axis post-hoc, or feed the values
+/// into the JSON shape consumed by the v0.9.0 MCP tool surface.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct CandidateRank {
+    /// Worst-case response time observed across overlay-bound threads,
+    /// in picoseconds. `None` when RTA produced no usable Info-level
+    /// "response time" diagnostic for any thread under the overlay.
+    /// `Some(negative)` is the deadline-miss sentinel — cleared to a
+    /// large positive contribution by the score aggregator.
+    pub max_response_ns: Option<i64>,
+    /// Sum of `wcet_ps / period_ps` across overlay-bound threads.
+    /// Range `0.0..=N` (N = thread count); typical "healthy" models
+    /// stay under the processor-count.
+    pub total_load: f64,
+    /// Sum of per-component `Spar_Power::Power_Budget` (or fallback
+    /// keys) in milliwatts. `None` when no power property is set on
+    /// any of the overlay-visited components.
+    pub total_power_mw: Option<u64>,
+    /// Sum of per-component `Weight_Properties::Weight` (or fallback
+    /// keys) in grams. `None` when no weight property is set on any
+    /// of the overlay-visited components.
+    pub total_weight_g: Option<u64>,
+    /// Aggregate score (lower = better). Zero when no objective flag
+    /// is enabled or when the model carries no rankable data.
+    pub score: f64,
+}
+
+/// Rank a hypothetical binding under an overlay against a multi-objective
+/// specification.
+///
+/// Walks every thread in the instance, computes the effective binding
+/// via [`actual_processor_binding_with_overlay`], and aggregates:
+///
+/// - response times via the existing RTA pass (one full pass per call);
+/// - utilization from declared `Period` / `Compute_Execution_Time`;
+/// - power from `Spar_Power::Power_Budget` (or compatible fallbacks);
+/// - weight from `Weight_Properties::Weight` (or compatible fallbacks).
+///
+/// The score is a sum of normalised per-axis contributions, each
+/// scaled by `1/k` where `k` is [`EnumerationObjective::enabled_count`].
+/// Per-axis normalisation is by-design conservative (the goal is
+/// stable ordering across models, not absolute magnitudes):
+///
+/// - `max_response_ns`: divided by 1 ms (the conventional deadline
+///   floor in the analysis suite); deadline misses contribute 10.0.
+/// - `total_load`: passed through unchanged (already normalised in
+///   `[0.0, 1.0]`-per-CPU range).
+/// - `total_power_mw`: divided by 1000 (mW → W).
+/// - `total_weight_g`: divided by 1000 (g → kg).
+///
+/// Ties on score sort downstream by FQN, mirroring commit 4's existing
+/// candidate-sort behaviour.
+///
+/// # Determinism
+///
+/// The function is deterministic for a fixed (`instance`, `overlay`,
+/// `objective`) triple — no randomness, no time-dependent inputs, no
+/// hash-iteration-order dependence.
+pub fn rank_candidate(
+    instance: &SystemInstance,
+    overlay: &BindingOverlay,
+    objective: &EnumerationObjective,
+) -> CandidateRank {
+    // Run the analysis suite once per call. We need RTA's diagnostic
+    // stream to derive the max-response and we want a single,
+    // well-defined production path so the rank output stays in lock-step
+    // with what `spar moves verify` reports.
+    let analysis_diags = run_all_analyses(instance);
+
+    // Identify the candidate target processor — the value the overlay
+    // adds, or (degenerate case) None. When the overlay carries
+    // multiple moves, we use the union of all moved-to targets when
+    // scanning RTA messages so multi-component plans rank correctly.
+    let target_names: Vec<String> = overlay
+        .moves
+        .values()
+        .map(|&idx| instance.component(idx).name.as_str().to_ascii_lowercase())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    let max_response_ns = compute_max_response_ns(&analysis_diags, &target_names);
+
+    // Overlay-aware utilisation aggregate. We sum over every thread
+    // whose effective binding (under the overlay) is one of the
+    // candidate targets.
+    let total_load = compute_total_load(instance, overlay, &target_names);
+
+    // Power & weight aggregate over overlay-visited components.
+    let total_power_mw = compute_total_power_mw(instance, overlay);
+    let total_weight_g = compute_total_weight_g(instance, overlay);
+
+    let score = aggregate_score(
+        objective,
+        max_response_ns,
+        total_load,
+        total_power_mw,
+        total_weight_g,
+    );
+
+    CandidateRank {
+        max_response_ns,
+        total_load,
+        total_power_mw,
+        total_weight_g,
+        score,
+    }
+}
+
+/// Run every registered analysis pass against the instance.
+///
+/// Mirrors the helper in `spar-cli::moves` so callers in either crate
+/// surface the same diagnostic stream.
+fn run_all_analyses(instance: &SystemInstance) -> Vec<AnalysisDiagnostic> {
+    let mut runner = AnalysisRunner::new();
+    runner.register_all();
+    runner.run_all(instance)
+}
+
+/// Compute `max(response_time)` in picoseconds across threads on a set
+/// of candidate processor names.
+///
+/// Walks the analysis-diagnostic stream looking for RTA messages of the
+/// form `"thread '...' on processor '<target>': response time <X> <=
+/// deadline <Y>"` (Info, parsed for the response-time value) or
+/// `"thread '...' on processor '<target>' misses deadline"` (Error,
+/// returns the negative-sentinel). Returns:
+///
+/// - `Some(picoseconds)` (positive) — the max response across matched
+///   threads.
+/// - `Some(-1)` — a deadline miss was found on any matched thread.
+/// - `None` — no RTA diagnostic mentions any candidate target (e.g.,
+///   the model has no RTA-visible threads).
+fn compute_max_response_ns(diags: &[AnalysisDiagnostic], target_names: &[String]) -> Option<i64> {
+    if target_names.is_empty() {
+        return None;
+    }
+    let mut max_response: Option<i64> = None;
+    let mut had_miss = false;
+    let mut had_match = false;
+
+    for d in diags {
+        if d.analysis != "rta" && d.analysis != "RtaAnalysis" {
+            continue;
+        }
+        let msg_lower = d.message.to_ascii_lowercase();
+        let mentions_target = target_names
+            .iter()
+            .any(|t| msg_lower.contains(&format!("on processor '{t}'")));
+        if !mentions_target {
+            continue;
+        }
+        had_match = true;
+
+        if d.severity == Severity::Error && msg_lower.contains("misses deadline") {
+            had_miss = true;
+            continue;
+        }
+
+        if let Some((rt_ps, _dl_ps)) = parse_response_deadline(&d.message) {
+            let rt_signed = rt_ps as i64;
+            max_response = Some(max_response.map_or(rt_signed, |cur| cur.max(rt_signed)));
+        }
+    }
+
+    if had_miss {
+        return Some(-1);
+    }
+    if !had_match {
+        return None;
+    }
+    max_response
+}
+
+/// Sum of `wcet/period` for threads whose overlay-effective processor
+/// binding resolves to one of the candidate target names.
+fn compute_total_load(
+    instance: &SystemInstance,
+    overlay: &BindingOverlay,
+    target_names: &[String],
+) -> f64 {
+    if target_names.is_empty() {
+        return 0.0;
+    }
+    let mut total = 0.0_f64;
+    for (idx, comp) in instance.all_components() {
+        if comp.category != ComponentCategory::Thread {
+            continue;
+        }
+        let Some(bound_idx) = actual_processor_binding_with_overlay(instance, idx, Some(overlay))
+        else {
+            continue;
+        };
+        let bound_name = instance
+            .component(bound_idx)
+            .name
+            .as_str()
+            .to_ascii_lowercase();
+        if !target_names.iter().any(|t| t == &bound_name) {
+            continue;
+        }
+        let props = instance.properties_for(idx);
+        let period_ps =
+            spar_analysis::property_accessors::get_timing_property(props, "Period").unwrap_or(0);
+        let wcet_ps = spar_analysis::property_accessors::get_execution_time(props).unwrap_or(0);
+        if period_ps == 0 || wcet_ps == 0 {
+            continue;
+        }
+        total += wcet_ps as f64 / period_ps as f64;
+    }
+    total
+}
+
+/// Sum every overlay-visited component's `Power_Budget` in milliwatts.
+///
+/// Reads the canonical `Spar_Power::Power_Budget` first, falling back
+/// to the upstream `SEI::PowerBudget` / `Physical_Properties::Power_Budget`
+/// keys for compatibility with models authored before commit 5/8 added
+/// the spar-defined property set.
+fn compute_total_power_mw(instance: &SystemInstance, overlay: &BindingOverlay) -> Option<u64> {
+    let mut total: u64 = 0;
+    let mut had_any = false;
+
+    let visited = overlay_visited_components(overlay);
+    for idx in visited {
+        let props = instance.properties_for(idx);
+        if let Some(mw) = read_power_budget_mw(props) {
+            total = total.saturating_add(mw);
+            had_any = true;
+        }
+    }
+    if had_any { Some(total) } else { None }
+}
+
+/// Sum every overlay-visited component's `Weight` in grams.
+///
+/// Reads `Weight_Properties::Weight` first, falling back to the
+/// upstream `SEI::GrossWeight`, `SEI::Weight`, and unqualified `Weight`
+/// keys per the v0.7.x weight_power convention.
+fn compute_total_weight_g(instance: &SystemInstance, overlay: &BindingOverlay) -> Option<u64> {
+    let mut total: u64 = 0;
+    let mut had_any = false;
+
+    let visited = overlay_visited_components(overlay);
+    for idx in visited {
+        let props = instance.properties_for(idx);
+        if let Some(g) = read_weight_g(props) {
+            total = total.saturating_add(g);
+            had_any = true;
+        }
+    }
+    if had_any { Some(total) } else { None }
+}
+
+/// Components an overlay touches: each moved component plus each
+/// distinct target it points at. Sorted by raw-arena order via the
+/// [`ComponentInstanceIdx`] hash so the iteration is deterministic
+/// for a fixed overlay.
+fn overlay_visited_components(overlay: &BindingOverlay) -> Vec<ComponentInstanceIdx> {
+    let mut set: std::collections::BTreeSet<ComponentInstanceIdx> =
+        std::collections::BTreeSet::new();
+    for (&from, &to) in &overlay.moves {
+        set.insert(from);
+        set.insert(to);
+    }
+    set.into_iter().collect()
+}
+
+/// Read a component's power budget in milliwatts.
+///
+/// Prefers `Spar_Power::Power_Budget` (introduced in commit 5/8); falls
+/// back to the legacy `SEI::PowerBudget` / `Physical_Properties::*`
+/// keys used by the v0.7.x weight_power analysis. Accepts unit suffixes
+/// `mW` (default), `W`, `kW`, `uW`.
+pub fn read_power_budget_mw(props: &PropertyMap) -> Option<u64> {
+    // Typed path: Spar_Power::Power_Budget — registered as Time so the
+    // value lowers to picoseconds on the typed path. We accept either
+    // a typed numeric (treated as mW directly) or fall through to the
+    // raw-string path for the canonical "<n> <unit>" shape.
+    if let Some(expr) = props.get_typed("Spar_Power", "Power_Budget")
+        && let Some(mw) = numeric_from_expr(expr)
+    {
+        return Some(mw);
+    }
+    let raw = props
+        .get("Spar_Power", "Power_Budget")
+        .or_else(|| props.get("SEI", "PowerBudget"))
+        .or_else(|| props.get("Physical_Properties", "PowerBudget"))
+        .or_else(|| props.get("Physical_Properties", "Power_Budget"))
+        .or_else(|| props.get("", "PowerBudget"))
+        .or_else(|| props.get("", "Power_Budget"))?;
+    parse_power_value_mw(raw)
+}
+
+/// Read a component's weight in grams.
+fn read_weight_g(props: &PropertyMap) -> Option<u64> {
+    if let Some(expr) = props.get_typed("Weight_Properties", "Weight")
+        && let Some(g) = numeric_from_expr(expr)
+    {
+        return Some(g);
+    }
+    let raw = props
+        .get("Weight_Properties", "Weight")
+        .or_else(|| props.get("SEI", "GrossWeight"))
+        .or_else(|| props.get("SEI", "Weight"))
+        .or_else(|| props.get("Physical_Properties", "GrossWeight"))
+        .or_else(|| props.get("Physical_Properties", "Weight"))
+        .or_else(|| props.get("", "GrossWeight"))
+        .or_else(|| props.get("", "Weight"))?;
+    parse_weight_value_g(raw)
+}
+
+/// Try to extract an integer numeric from a typed property expression.
+///
+/// Handles the [`PropertyExpr::Integer`] form (with an optional unit
+/// name we ignore here — unit reconciliation is the caller's concern)
+/// and the [`PropertyExpr::Real`] form (parsed from its stored string
+/// representation).
+fn numeric_from_expr(expr: &PropertyExpr) -> Option<u64> {
+    match expr {
+        PropertyExpr::Integer(n, _) => u64::try_from(*n).ok(),
+        PropertyExpr::Real(s, _) => {
+            let f = s.parse::<f64>().ok()?;
+            if !f.is_finite() || f < 0.0 {
+                None
+            } else {
+                Some(f as u64)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Parse a power value (mW). Accepts `mW`, `kW`, `uW`, `W` suffixes;
+/// bare numbers are interpreted as milliwatts.
+///
+/// Ordering matters: prefix-disambiguating suffixes (`mW`, `kW`, `uW`)
+/// must be checked before bare `W` so `"500 uW"` is not misread as
+/// `"500 u" + "W"`.
+fn parse_power_value_mw(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let s = s.trim_start_matches('=').trim();
+    for &(suffix, factor) in &[
+        ("mW", 1.0_f64),
+        ("kW", 1_000_000.0),
+        ("uW", 0.001),
+        ("W", 1_000.0),
+    ] {
+        if let Some(num_str) = s.strip_suffix(suffix) {
+            let num = num_str.trim().parse::<f64>().ok()?;
+            if !num.is_finite() || num < 0.0 {
+                return None;
+            }
+            return Some((num * factor) as u64);
+        }
+    }
+    let num = s.parse::<f64>().ok()?;
+    if !num.is_finite() || num < 0.0 {
+        return None;
+    }
+    Some(num as u64)
+}
+
+/// Parse a weight value (grams). Accepts `kg`, `g`, `mg`, `lb` suffixes;
+/// bare numbers are interpreted as kilograms (matching the legacy
+/// `weight_power.rs` convention).
+fn parse_weight_value_g(s: &str) -> Option<u64> {
+    let s = s.trim();
+    for &(suffix, factor_g) in &[
+        ("kg", 1_000.0_f64),
+        ("mg", 0.001),
+        ("g", 1.0),
+        ("lb", 453.592),
+    ] {
+        if let Some(num_str) = s.strip_suffix(suffix) {
+            let num = num_str.trim().parse::<f64>().ok()?;
+            if !num.is_finite() || num < 0.0 {
+                return None;
+            }
+            return Some((num * factor_g) as u64);
+        }
+    }
+    // Bare number: interpret as kilograms, matching the existing
+    // `parse_weight_value` convention in `spar-analysis::weight_power`.
+    let num = s.parse::<f64>().ok()?;
+    if !num.is_finite() || num < 0.0 {
+        return None;
+    }
+    Some((num * 1_000.0) as u64)
+}
+
+/// Parse `"response time <X> <= deadline <Y>"` from an RTA Info-level
+/// diagnostic. Returns `(rt_ps, dl_ps)` or `None`.
+fn parse_response_deadline(msg: &str) -> Option<(u64, u64)> {
+    let after_rt = msg.find("response time ")?;
+    let rest = &msg[after_rt + "response time ".len()..];
+    let le_pos = rest.find("<=")?;
+    let rt_str = rest[..le_pos].trim();
+    let after_dl = rest[le_pos + 2..].find("deadline ")?;
+    let dl_rest = &rest[le_pos + 2 + after_dl + "deadline ".len()..];
+    let dl_str = dl_rest.trim_end_matches(['.', ',']).trim();
+    Some((parse_format_time_ps(rt_str)?, parse_format_time_ps(dl_str)?))
+}
+
+/// Inverse of `spar-analysis::rta::format_time`: parse `"<n> <unit>"`
+/// back into picoseconds. Recognises `ps`, `us`, `ms`, `sec` / `s`.
+fn parse_format_time_ps(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let space = s.rfind(char::is_whitespace)?;
+    let num_str = s[..space].trim();
+    let unit = s[space..].trim();
+    let scale: u64 = match unit {
+        "ps" => 1,
+        "us" => 1_000_000,
+        "ms" => 1_000_000_000,
+        "sec" | "s" => 1_000_000_000_000,
+        _ => return None,
+    };
+    if let Ok(n) = num_str.parse::<u64>() {
+        return Some(n.saturating_mul(scale));
+    }
+    let f = num_str.parse::<f64>().ok()?;
+    if !f.is_finite() || f.is_sign_negative() {
+        return None;
+    }
+    Some((f * scale as f64) as u64)
+}
+
+/// Aggregate the per-axis values into a single score under the
+/// objective spec. Lower = better. See the [`rank_candidate`] doc
+/// comment for normalisation rationale.
+fn aggregate_score(
+    objective: &EnumerationObjective,
+    max_response_ns: Option<i64>,
+    total_load: f64,
+    total_power_mw: Option<u64>,
+    total_weight_g: Option<u64>,
+) -> f64 {
+    let k = objective.enabled_count();
+    if k == 0 {
+        return 0.0;
+    }
+    let weight = 1.0 / f64::from(k);
+
+    let mut score = 0.0_f64;
+
+    if objective.minimize_max_response {
+        let contribution = match max_response_ns {
+            None => 0.0,
+            Some(n) if n < 0 => 10.0, // deadline-miss sentinel
+            Some(n) => (n as f64) / 1_000_000_000.0, // ns ÷ 1 ms (in ps)
+        };
+        score += weight * contribution;
+    }
+    if objective.minimize_total_load {
+        score += weight * total_load;
+    }
+    if objective.minimize_total_power {
+        let contribution = total_power_mw.map_or(0.0, |mw| (mw as f64) / 1_000.0);
+        score += weight * contribution;
+    }
+    if objective.minimize_total_weight {
+        let contribution = total_weight_g.map_or(0.0, |g| (g as f64) / 1_000.0);
+        score += weight * contribution;
+    }
+
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use la_arena::Arena;
+    use rustc_hash::FxHashMap;
+    use spar_hir_def::instance::ComponentInstance;
+    use spar_hir_def::name::{Name, PropertyRef};
+    use spar_hir_def::properties::{PropertyMap, PropertyValue};
+
+    fn empty_props() -> PropertyMap {
+        PropertyMap::new()
+    }
+
+    fn props_with_string(set: &str, name: &str, value: &str) -> PropertyMap {
+        let mut p = PropertyMap::new();
+        p.add(PropertyValue {
+            name: PropertyRef {
+                property_set: if set.is_empty() {
+                    None
+                } else {
+                    Some(Name::new(set))
+                },
+                property_name: Name::new(name),
+            },
+            value: value.to_string(),
+            typed_expr: None,
+            is_append: false,
+        });
+        p
+    }
+
+    fn make_instance_with_components(
+        names: &[(&str, ComponentCategory)],
+    ) -> (SystemInstance, Vec<ComponentInstanceIdx>) {
+        let mut components: Arena<ComponentInstance> = Arena::default();
+        let root = components.alloc(ComponentInstance {
+            name: Name::new("root"),
+            category: ComponentCategory::System,
+            type_name: Name::new("Root"),
+            impl_name: Some(Name::new("impl")),
+            package: Name::new("Pkg"),
+            parent: None,
+            children: Vec::new(),
+            features: Vec::new(),
+            connections: Vec::new(),
+            flows: Vec::new(),
+            modes: Vec::new(),
+            mode_transitions: Vec::new(),
+            array_index: None,
+            in_modes: Vec::new(),
+        });
+        let mut child_idx = Vec::new();
+        for (n, c) in names {
+            let idx = components.alloc(ComponentInstance {
+                name: Name::new(n),
+                category: *c,
+                type_name: Name::new("T"),
+                impl_name: None,
+                package: Name::new("Pkg"),
+                parent: Some(root),
+                children: Vec::new(),
+                features: Vec::new(),
+                connections: Vec::new(),
+                flows: Vec::new(),
+                modes: Vec::new(),
+                mode_transitions: Vec::new(),
+                array_index: None,
+                in_modes: Vec::new(),
+            });
+            child_idx.push(idx);
+        }
+        components[root].children = child_idx.clone();
+        let instance = SystemInstance {
+            root,
+            components,
+            features: Arena::default(),
+            connections: Arena::default(),
+            flow_instances: Arena::default(),
+            end_to_end_flows: Arena::default(),
+            mode_instances: Arena::default(),
+            mode_transition_instances: Arena::default(),
+            diagnostics: Vec::new(),
+            property_maps: FxHashMap::default(),
+            semantic_connections: Vec::new(),
+            system_operation_modes: Vec::new(),
+        };
+        let mut all = vec![root];
+        all.extend(child_idx);
+        (instance, all)
+    }
+
+    #[test]
+    fn objective_default_score_is_zero() {
+        // No flags enabled → score must be 0 regardless of input.
+        let s = aggregate_score(
+            &EnumerationObjective::default(),
+            Some(1_000_000),
+            0.5,
+            Some(500),
+            Some(1000),
+        );
+        assert_eq!(s, 0.0);
+    }
+
+    #[test]
+    fn objective_balanced_aggregates_all_four() {
+        // Balanced objective: weight = 0.25; result mixes all four axes.
+        let s = aggregate_score(
+            &EnumerationObjective::balanced(),
+            Some(1_000_000_000), // 1 ms in ps → contribution 1.0
+            0.4,                 // load 0.4
+            Some(2_000),         // 2000 mW → 2.0 W
+            Some(1_500),         // 1500 g → 1.5 kg
+        );
+        // 0.25*(1.0 + 0.4 + 2.0 + 1.5) = 0.25 * 4.9 = 1.225
+        assert!((s - 1.225).abs() < 1e-9, "score = {s}");
+    }
+
+    #[test]
+    fn objective_max_response_deadline_miss_inflates_score() {
+        let s = aggregate_score(
+            &EnumerationObjective::max_response(),
+            Some(-1), // deadline miss sentinel → 10.0 contribution
+            0.0,
+            None,
+            None,
+        );
+        assert_eq!(s, 10.0);
+    }
+
+    #[test]
+    fn enabled_count_reflects_flags() {
+        assert_eq!(EnumerationObjective::default().enabled_count(), 0);
+        assert_eq!(EnumerationObjective::max_response().enabled_count(), 1);
+        assert_eq!(EnumerationObjective::balanced().enabled_count(), 4);
+    }
+
+    #[test]
+    fn parse_power_value_mw_handles_units() {
+        assert_eq!(parse_power_value_mw("100 mW"), Some(100));
+        assert_eq!(parse_power_value_mw("2 W"), Some(2_000));
+        assert_eq!(parse_power_value_mw("1.5 kW"), Some(1_500_000));
+        assert_eq!(parse_power_value_mw("500 uW"), Some(0));
+        assert_eq!(parse_power_value_mw("250"), Some(250)); // bare = mW
+        assert_eq!(parse_power_value_mw("not-a-number"), None);
+        assert_eq!(parse_power_value_mw("-5 W"), None);
+    }
+
+    #[test]
+    fn parse_weight_value_g_handles_units() {
+        assert_eq!(parse_weight_value_g("100 g"), Some(100));
+        assert_eq!(parse_weight_value_g("1 kg"), Some(1_000));
+        assert_eq!(parse_weight_value_g("500 mg"), Some(0));
+        // Bare number: interpret as kg.
+        assert_eq!(parse_weight_value_g("2"), Some(2_000));
+    }
+
+    #[test]
+    fn read_power_budget_uses_spar_power_first() {
+        let p = props_with_string("Spar_Power", "Power_Budget", "300 mW");
+        assert_eq!(read_power_budget_mw(&p), Some(300));
+    }
+
+    #[test]
+    fn read_power_budget_falls_back_to_sei() {
+        let p = props_with_string("SEI", "PowerBudget", "1 W");
+        assert_eq!(read_power_budget_mw(&p), Some(1_000));
+    }
+
+    #[test]
+    fn read_power_budget_returns_none_when_absent() {
+        assert_eq!(read_power_budget_mw(&empty_props()), None);
+    }
+
+    #[test]
+    fn rank_candidate_empty_overlay_has_score_zero_for_default_objective() {
+        // Degenerate case: empty overlay + default (no flags) objective
+        // → score zero, no rankable data emitted.
+        let (instance, _idxs) = make_instance_with_components(&[
+            ("t1", ComponentCategory::Thread),
+            ("cpu1", ComponentCategory::Processor),
+        ]);
+        let overlay = BindingOverlay::new();
+        let rank = rank_candidate(&instance, &overlay, &EnumerationObjective::default());
+        assert_eq!(rank.score, 0.0);
+        assert_eq!(rank.max_response_ns, None);
+        assert_eq!(rank.total_load, 0.0);
+        assert_eq!(rank.total_power_mw, None);
+        assert_eq!(rank.total_weight_g, None);
+    }
+
+    #[test]
+    fn rank_candidate_reads_power_from_overlay_visited() {
+        // Overlay touches two components, both with Spar_Power::Power_Budget.
+        // Total power must be the sum.
+        let (mut instance, idxs) = make_instance_with_components(&[
+            ("t1", ComponentCategory::Thread),
+            ("cpu1", ComponentCategory::Processor),
+            ("cpu2", ComponentCategory::Processor),
+        ]);
+        let (t1, cpu1, cpu2) = (idxs[1], idxs[2], idxs[3]);
+
+        // Set Power_Budget on t1 (50 mW) and cpu2 (1 W).
+        instance
+            .property_maps
+            .entry(t1)
+            .or_default()
+            .add(PropertyValue {
+                name: PropertyRef {
+                    property_set: Some(Name::new("Spar_Power")),
+                    property_name: Name::new("Power_Budget"),
+                },
+                value: "50 mW".to_string(),
+                typed_expr: None,
+                is_append: false,
+            });
+        instance
+            .property_maps
+            .entry(cpu2)
+            .or_default()
+            .add(PropertyValue {
+                name: PropertyRef {
+                    property_set: Some(Name::new("Spar_Power")),
+                    property_name: Name::new("Power_Budget"),
+                },
+                value: "1 W".to_string(),
+                typed_expr: None,
+                is_append: false,
+            });
+        let _ = cpu1;
+
+        let mut overlay = BindingOverlay::new();
+        overlay.add_move(t1, cpu2);
+
+        let rank = rank_candidate(&instance, &overlay, &EnumerationObjective::total_power());
+        // 50 mW (t1) + 1000 mW (cpu2) = 1050 mW
+        assert_eq!(rank.total_power_mw, Some(1_050));
+        // total_power normalised: 1050 / 1000 = 1.05
+        assert!((rank.score - 1.05).abs() < 1e-9, "score = {}", rank.score);
+    }
+}

--- a/crates/spar-solver/src/lib.rs
+++ b/crates/spar-solver/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod allocate;
 pub mod constraints;
+pub mod enumerate;
 pub mod milp;
 pub mod nsga2;
 pub mod topology;


### PR DESCRIPTION
## Summary

- Adds `spar-solver::enumerate::rank_candidate` — overlay-aware multi-objective ranker that consumes the same RTA + property-accessor machinery the verify-pipeline already uses, so verify/enumerate outputs stay in lock-step.
- Wires the new ranker into `spar moves enumerate`: the commit-4 `slack_ns` field is replaced by a richer `rank: CandidateRank` carrying max-response, total-load, total-power, total-weight, and an aggregate score (lower = better).
- Adds the `Spar_Power::Power_Budget` standard property (numeric milliwatts) so models without SEI / Physical_Properties in scope can still annotate per-component power for ranking.
- Adds CLI option `--objective {max-response | total-load | total-power | total-weight | balanced}`. Default is `max-response`, which preserves commit-4 slack semantics on single-CPU models. `balanced` weights all four axes equally (each at 1/4).
- New requirement: `REQ-MIGRATION-007`. New verification entry: `TEST-MOVES-ENUMERATE-OBJECTIVES` linked to REQ-MIGRATION-{004,005,006,007}.

## What stayed the same

- The set of admissible (`ok=true`) candidates is unchanged across all five objective modes — only ordering changes.
- `spar moves enumerate` still does not mutate the underlying model; the existing non-mutation regression test stays green.
- Exit codes, JSON top-level shape (`component / total / valid / candidates`), and CLI plumbing for `--root` / `--component` / `--target-filter` / `--format` are unchanged.

## What changed in JSON shape

- Per-candidate `slack_ns` is removed; replaced by a `rank` object with five keys:
  `max_response_ns` (i64 or null), `total_load` (f64), `total_power_mw` (u64 or null), `total_weight_g` (u64 or null), `score` (f64).
- The text-format header column `slack` is replaced by `score`. Deadline-miss candidates render as `<missed>` (matching the commit-4 idiom).

## Test plan

- [x] `cargo test --workspace` — 0 failures (10 new integration tests in `moves_enumerate_objectives.rs`, 11 unit tests in `spar-solver::enumerate`, 2 unit tests in `spar-cli::moves::enumerate_tests`; all 10 commit-4 enumerate tests still pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `rivet validate` — PASS.

## Files changed

- `artifacts/requirements.yaml` — append `REQ-MIGRATION-007`.
- `artifacts/verification.yaml` — append `TEST-MOVES-ENUMERATE-OBJECTIVES`.
- `crates/spar-cli/src/moves.rs` — replace slack with rank; add `--objective` parser; new `MovesError::UnknownObjective`; updated text/JSON renderers.
- `crates/spar-cli/tests/moves_enumerate_objectives.rs` — new (10 integration tests).
- `crates/spar-hir-def/src/standard_properties.rs` — register `Spar_Power::Power_Budget`; bump set count.
- `crates/spar-solver/src/enumerate.rs` — new (rank_candidate, EnumerationObjective, CandidateRank, power/weight readers, RTA-message parsers, 11 unit tests).
- `crates/spar-solver/src/lib.rs` — export the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)