### PR TITLE
chore(release): bump to v0.8.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,99 @@ All notable changes to spar are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-04-28
+
+This release promotes the Track D Phase 1 (TSN/Ethernet WCTT analysis) and
+Track E (frozen-platform / mobile-application + hypothetical-rebinding
+oracle) features that have been on `main` since v0.7.1. Also adds the
+`spar moves verify` and `spar moves enumerate` user-facing CLIs.
+
+### Added — Track D Phase 1: TSN/Ethernet WCTT analysis (6/6 commits)
+
+- **New crate `spar-network`** — Network Calculus primitives, NetworkGraph
+  extraction from `SystemInstance`, and supporting types. All values in
+  `u64` picoseconds / bytes / bits-per-second — no floating-point drift.
+- **`Spar_Network::*` property set** — `Switch_Type` (FIFO / Priority /
+  TSN), `Queue_Depth`, `Forwarding_Latency` (Time_Range), `Output_Rate`,
+  `WCTT_Budget`. Switches are modelled as `bus implementation` carrying
+  the `Switch_Type` discriminator (Option C of the design — AADL-spec-
+  conformant, no grammar extension).
+- **NC primitives** — `ArrivalCurve`, `ServiceCurve`, `backlog_bound`,
+  `delay_bound`, `residual_service`, `output_bound`. Closed-form for
+  the affine + rate-latency case.
+- **`WcttAnalysis` pass** — per-stream end-to-end traversal-time bounds
+  across the device/bus graph. New diagnostics: `WcttBound`,
+  `WcttExceedsBudget`, `WcttUnservable`, `WcttSwitchOverloaded`.
+- **`latency.rs` integration** — RTA-derived WCET on compute hops
+  alternates with WCTT-derived bounds on network hops, end-to-end.
+  `Bus_Properties::Latency` scalar remains the fallback for unannotated
+  buses, preserving v0.7.x behaviour.
+- **Lean theorems** — `proofs/Proofs/Network/MinPlus.lean` mirrors classical
+  NC closed-forms with monotonicity proved + `sorry`-with-`TODO(v1.0.0)` for
+  the universally-quantified arithmetic statements.
+
+Phase 2 (TSN-shaped service curves: TAS, CBS, frame preemption) is
+deferred to v0.8.x.
+
+### Added — Track E: hypothetical-rebinding oracle (7/8 commits)
+
+- **`Spar_Migration::*` property set** — `Frozen`, `Mobile`,
+  `Allowed_Targets`, `Pinned_Reason`. Plus `is_frozen` / `is_mobile`
+  helpers for HIR-level mobility queries.
+- **`BindingOverlay`** — HIR-level overlay so any analysis can run on a
+  hypothetical binding without mutating the `SystemInstance`. Validates
+  against Frozen / Allowed_Targets returning structured `FrozenViolation` /
+  `AllowedTargetsViolation` diagnostics.
+- **`spar moves verify --component X --to Y`** — first user-facing
+  surface of the migration oracle. Builds a `BindingOverlay`, runs
+  validation + analyses, returns structured pass/fail JSON. Exit codes
+  0/1/2 distinguish ok / analysis-error / binding-violation.
+- **`spar moves enumerate --component X`** — design-space exploration.
+  Lists every valid hypothetical rebinding target within `Allowed_Targets`
+  with verification status and a multi-objective ranking metric.
+- **Multi-objective ranking** — `--objective max-response | total-load |
+  total-power | total-weight | balanced`. Adds `Spar_Power::Power_Budget`
+  property. Score uses the same RTA + property-accessor machinery as
+  direct verification, so `verify` and `enumerate` stay consistent.
+- **Rivet variant integration** — both `verify` and `enumerate` accept
+  `--variant NAME` (implicit; shells out to `rivet`) or
+  `--variant-context PATH` (explicit; reads JSON blob). Variant filter
+  applies before overlay validation per the v1 contract's intersection
+  semantics.
+- **Documentation** — `docs/cli/moves.md` with flags, exit codes,
+  output schemas, candidate-set derivation, ranking semantics, worked
+  example.
+
+Commit 8 (MCP tool surface for `spar.verify_move` / `spar.enumerate_moves`)
+is v0.9.0 scope by design — read-only / idempotent only, deterministic
+apply stays CLI-exclusive.
+
+### Added — Track F: SysML v2 / KerML community engagement strategy
+
+- `docs/designs/track-f-sysml-kerml-engagement.md` — research-backed
+  engagement plan for the OMG SysML v2 ecosystem. Anchors on the
+  `Systems-Modeling/SysML-v2-AADL-Release` repo + named contacts at
+  Galois / CMU-SEI / Ellidiss. Includes verified `spar-sysml2` audit
+  (production-grade with full requirements roundtrip) + Rust ecosystem
+  positioning (`syster`, `Sysand`, `tree-sitter-sysml`).
+
+### Changed
+
+- COMPLIANCE.md narrative updated for v0.8.0 release; v0.9.0 horizon
+  noted (Track E commit 8 MCP, spar-insight, Track D Phase 2 conditional
+  on demand, syster license clarification).
+- Test count: ~2200+ across 18 crates (previously ~1900+ across 17).
+
+### Documentation
+
+- `docs/cli/moves.md` — comprehensive `spar moves verify` / `enumerate` reference.
+- `docs/designs/v0.7.0-hierarchical-rta.md`, `track-d-tsn-wctt-research.md`,
+  `track-e-migration-research.md`, `track-f-sysml-kerml-engagement.md`.
+- `docs/contracts/rivet-spar-variant-v1.md` — variant interchange contract.
+- `proofs/README.md` — proof tree overview.
+
+---
+
 ## [0.7.1] — 2026-04-27
 
 This release closes the v0.7.x line. Headline: full IRQ-aware response-time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "spar-base-db",
  "spar-hir-def",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1400,14 +1400,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Promotes Track D Phase 1 + Track E commits 1-7 from \"on main but unadvertised\" (v0.7.1) to \"officially released\" (v0.8.0).

- Cargo.toml workspace + vscode-spar/package.json: 0.7.1 → 0.8.0
- Cargo.lock refreshed
- CHANGELOG.md gains the v0.8.0 entry

## Headlines for v0.8.0

- **Track D Phase 1** — TSN/Ethernet WCTT analysis: new \`spar-network\` crate, NC primitives, \`WcttAnalysis\` pass, \`latency.rs\` integration with WCET+WCTT alternation, Lean theorems
- **Track E** — hypothetical-rebinding oracle: \`spar moves verify\`, \`spar moves enumerate\`, multi-objective ranking, rivet variant integration
- **Track F** — SysML v2 / KerML community engagement strategy

## Deferred

- Phase 2 TSN-shaped service curves (TAS/CBS/preemption) → v0.8.x
- Track E commit 8 MCP tool surface → v0.9.0 by design

## Test plan

- [x] \`cargo build --workspace\` clean
- [ ] CI green on this PR
- [ ] After merge: tag v0.8.0 → release.yml triggers binary builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)