### PR TITLE
feat(insight): spar-insight crate + Tier 1 CTF discrepancy detection (Track G v0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "spar-codegen",
  "spar-hir",
  "spar-hir-def",
+ "spar-insight",
  "spar-parser",
  "spar-render",
  "spar-solver",
@@ -1311,6 +1312,18 @@ dependencies = [
  "serde",
  "smol_str",
  "spar-base-db",
+ "spar-syntax",
+]
+
+[[package]]
+name = "spar-insight"
+version = "0.8.0"
+dependencies = [
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "spar-base-db",
+ "spar-hir-def",
  "spar-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/spar-verify-macros",
     "crates/spar-verify",
     "crates/spar-wasm",
+    "crates/spar-insight",
 ]
 
 [workspace.package]
@@ -42,6 +43,7 @@ spar-sysml2 = { path = "crates/spar-sysml2" }
 spar-transform = { path = "crates/spar-transform" }
 spar-variants = { path = "crates/spar-variants" }
 spar-codegen = { path = "crates/spar-codegen" }
+spar-insight = { path = "crates/spar-insight" }
 rowan = "0.16"
 salsa = "0.26"
 la-arena = "0.3"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1459,4 +1459,40 @@ artifacts:
     status: planned
     tags: [network, tsn, wctt, v081]
 
+  # ── Track G: spar-insight discrepancy assistant (v0.9.0) ──────────
+
+  - id: REQ-INSIGHT-001
+    type: requirement
+    title: Tier 1 CTF ingestion + per-probe timing distributions
+    description: >
+      spar-insight ingests Tier 1 CTF traces from Zephyr (`k_sem_give`,
+      `k_sem_take`, `k_timer_expiry` plus `probe_point_enter` /
+      `probe_point_exit` markers) and produces a per-probe-point timing
+      distribution (min / max / mean over the observed
+      enter→exit durations) comparable to the
+      `Spar_Trace::Expected_BCET` / `Expected_WCET` / `Expected_Mean`
+      predictions declared on AADL components. Tier 1 of the Gale
+      tracing strategy in the project memory; full binary CTF +
+      babeltrace2 ingestion is a v0.9.x follow-up.
+    status: implemented
+    tags: [insight, trace, ctf, tier1, v090]
+
+  - id: REQ-INSIGHT-002
+    type: requirement
+    title: Rules-based discrepancy detection (5 kinds)
+    description: >
+      Rules-based discrepancy detection emits structured diagnostics
+      keyed by probe id: `WcetViolated` (Error,
+      observed.max > Expected_WCET), `BcetUnderestimated` (Warn,
+      observed.min < Expected_BCET), `MeanDrift` (Info,
+      |observed.mean − Expected_Mean| > 20% of Expected_Mean),
+      `MissingProbe` (Info, trace samples for an undeclared probe),
+      and `UnobservedProbe` (Warn, declared `Expected_*` with no trace
+      samples). Wired into the CLI as
+      `spar insight verify-trace --root Pkg::Sys.Impl --trace trace.ctf
+      model.aadl`. The formal-statistics layer (Hoeffding bounds, etc.)
+      is deferred per project memory's R3 proof-assistant deferral.
+    status: implemented
+    tags: [insight, trace, cli, v090]
+
   # Research findings tracked separately in research/findings.yaml

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1923,3 +1923,32 @@ artifacts:
         target: REQ-TSN-001
       - type: satisfies
         target: REQ-NETWORK-001
+
+  - id: TEST-INSIGHT-DISCREPANCY
+    type: feature
+    title: spar-insight CTF parser + 5-kind discrepancy detection
+    description: >
+      Unit + integration tests in crates/spar-insight covering Tier 1
+      CTF text parsing (timestamp / event-name / payload, blank +
+      comment lines, malformed-line rejection), Zephyr event
+      classification (`k_sem_give`, `k_sem_take`, `k_timer_expiry`,
+      `probe_point_enter` / `probe_point_exit`, fallthrough to
+      `Custom`), enter/exit pairing for per-probe timing extraction
+      (clean pairing, orphan dropping, independent probes), and the
+      rules-based discrepancy detector (`WcetViolated`,
+      `BcetUnderestimated`, `MeanDrift`, `UnobservedProbe`,
+      `MissingProbe`) end-to-end against an instantiated
+      `SystemInstance` whose Brake.Impl declares
+      `Spar_Trace::Expected_BCET / Expected_WCET / Expected_Mean`.
+      Also exercises `DiscrepancyReport::to_json` / `to_text`.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-insight
+    status: passing
+    tags: [v0.9.0, insight, trace, ctf, tier1]
+    links:
+      - type: satisfies
+        target: REQ-INSIGHT-001
+      - type: satisfies
+        target: REQ-INSIGHT-002

--- a/crates/spar-cli/Cargo.toml
+++ b/crates/spar-cli/Cargo.toml
@@ -23,6 +23,7 @@ spar-solver.workspace = true
 spar-render.workspace = true
 spar-codegen.workspace = true
 spar-variants.workspace = true
+spar-insight.workspace = true
 etch.workspace = true
 la-arena.workspace = true
 rowan.workspace = true

--- a/crates/spar-cli/src/insight.rs
+++ b/crates/spar-cli/src/insight.rs
@@ -1,0 +1,141 @@
+//! `spar insight verify-trace` subcommand — Track G v0.9.0.
+//!
+//! Wraps `spar_insight::analyze` over a parsed AADL model + a textual
+//! Zephyr CTF trace and prints the [`DiscrepancyReport`] as JSON
+//! (default) or text.
+
+use std::fs;
+use std::process;
+
+use spar_hir_def::instance::SystemInstance;
+use spar_hir_def::{GlobalScope, HirDefDatabase, Name, file_item_tree};
+use spar_insight::{analyze, parse_ctf};
+
+use crate::parse_root_ref;
+
+pub fn cmd_insight(args: &[String]) {
+    if args.is_empty() {
+        eprintln!("Usage: spar insight <subcommand> [options] <file...>");
+        eprintln!();
+        eprintln!("Subcommands:");
+        eprintln!(
+            "  verify-trace --root Pkg::Type.Impl --trace trace.ctf [--format text|json] <file...>"
+        );
+        process::exit(1);
+    }
+    match args[0].as_str() {
+        "verify-trace" => cmd_verify_trace(&args[1..]),
+        other => {
+            eprintln!("Unknown insight subcommand: {other}");
+            process::exit(1);
+        }
+    }
+}
+
+fn cmd_verify_trace(args: &[String]) {
+    let mut root: Option<String> = None;
+    let mut trace_path: Option<String> = None;
+    let mut format: Option<String> = None;
+    let mut files: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--root" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--root requires a value (Package::Type.Impl)");
+                    process::exit(1);
+                }
+                root = Some(args[i].clone());
+            }
+            "--trace" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--trace requires a path");
+                    process::exit(1);
+                }
+                trace_path = Some(args[i].clone());
+            }
+            "--format" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("--format requires a value (text|json)");
+                    process::exit(1);
+                }
+                format = Some(args[i].clone());
+            }
+            s if s.starts_with('-') => {
+                eprintln!("Unknown option: {s}");
+                process::exit(1);
+            }
+            s => files.push(s.to_string()),
+        }
+        i += 1;
+    }
+
+    let root = root.unwrap_or_else(|| {
+        eprintln!("--root Package::Type.Impl is required");
+        process::exit(1);
+    });
+    let trace_path = trace_path.unwrap_or_else(|| {
+        eprintln!("--trace <path> is required");
+        process::exit(1);
+    });
+    if files.is_empty() {
+        eprintln!("Missing AADL file argument(s)");
+        process::exit(1);
+    }
+
+    let (pkg_name, type_name, impl_name) = parse_root_ref(&root);
+
+    let db = HirDefDatabase::default();
+    let mut trees = Vec::new();
+    for file_path in &files {
+        let source = fs::read_to_string(file_path).unwrap_or_else(|e| {
+            eprintln!("Cannot read {file_path}: {e}");
+            process::exit(1);
+        });
+        let parsed = spar_syntax::parse(&source);
+        if !parsed.ok() {
+            for err in parsed.errors() {
+                let (line, col) = spar_base_db::offset_to_line_col(&source, err.offset);
+                eprintln!("{file_path}:{line}:{col}: {}", err.msg);
+            }
+            eprintln!("Cannot verify-trace: parse errors in {file_path}");
+            process::exit(1);
+        }
+        let sf = spar_base_db::SourceFile::new(&db, file_path.clone(), source);
+        trees.push(file_item_tree(&db, sf));
+    }
+    let scope = GlobalScope::from_trees(trees);
+    let instance = SystemInstance::instantiate(
+        &scope,
+        &Name::new(&pkg_name),
+        &Name::new(&type_name),
+        &Name::new(&impl_name),
+    );
+
+    let trace_src = fs::read_to_string(&trace_path).unwrap_or_else(|e| {
+        eprintln!("Cannot read trace {trace_path}: {e}");
+        process::exit(1);
+    });
+    let events = match parse_ctf(&trace_src) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Cannot parse trace {trace_path}: {e}");
+            process::exit(1);
+        }
+    };
+
+    let report = analyze(&events, &instance);
+    let want_text = format.as_deref() == Some("text");
+    if want_text {
+        print!("{}", report.to_text());
+    } else {
+        println!("{}", report.to_json());
+    }
+    if report.has_errors() {
+        process::exit(1);
+    }
+}

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod assertion;
 mod diff;
+mod insight;
 mod lsp;
 mod moves;
 mod refactor;
@@ -44,6 +45,7 @@ fn main() {
         "generate" => cmd_sysml2_generate(&args[2..]),
         "lsp" => cmd_lsp(),
         "moves" => moves::cmd_moves_dispatch(&args[2..]),
+        "insight" => insight::cmd_insight(&args[2..]),
         other => {
             eprintln!("Unknown command: {other}");
             process::exit(1);
@@ -68,6 +70,7 @@ fn print_usage() {
     eprintln!(
         "  moves      Hypothetical-rebinding oracle (verify a move under the migration overlay)"
     );
+    eprintln!("  insight    Discrepancy assistant: compare CTF traces to Expected_BCET/WCET/Mean");
     eprintln!("  lsp        Start Language Server Protocol server (stdin/stdout)");
     eprintln!();
     eprintln!("Options:");
@@ -94,6 +97,9 @@ fn print_usage() {
     );
     eprintln!(
         "  moves    enumerate --root Package::Type.Impl --component <fqn> [--target-filter <s>] [--format text|json] <file...>"
+    );
+    eprintln!(
+        "  insight  verify-trace --root Package::Type.Impl --trace trace.ctf [--format text|json] <file...>"
     );
 }
 
@@ -1680,7 +1686,7 @@ fn is_safe_generated_path(path: &str) -> bool {
         && !path.starts_with('\\')
 }
 
-fn parse_root_ref(s: &str) -> (String, String, String) {
+pub(crate) fn parse_root_ref(s: &str) -> (String, String, String) {
     // Expected format: Package::Type.Impl
     let parts: Vec<&str> = s.splitn(2, "::").collect();
     if parts.len() != 2 {

--- a/crates/spar-insight/Cargo.toml
+++ b/crates/spar-insight/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "spar-insight"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Statistical-discrepancy assistant: compares observed CTF timing traces to spar's Expected_BCET/WCET/Mean model predictions"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+spar-hir-def.workspace = true
+
+[dev-dependencies]
+pretty_assertions = "1"
+spar-syntax.workspace = true
+spar-base-db.workspace = true

--- a/crates/spar-insight/src/ctf.rs
+++ b/crates/spar-insight/src/ctf.rs
@@ -1,0 +1,278 @@
+//! Minimal CTF (Common Trace Format) text-stream parser.
+//!
+//! We support the textual CTF subset that Zephyr's
+//! `subsys/tracing/format/format_common.c` produces with
+//! `tracing_format_string`:
+//!
+//! ```text
+//! <timestamp_ns>: <event_name>(<arg1>=<v1>, <arg2>=<v2>, ...)
+//! ```
+//!
+//! Each non-empty, non-`#`-prefixed line is one [`CtfEvent`].
+//!
+//! Full binary CTF + babeltrace2 is intentionally out-of-scope here —
+//! it is queued as a v0.9.x follow-up. Tier 1 of the Gale tracing
+//! strategy only needs timestamp + event-class + payload, and the
+//! textual subset is everything we need from Zephyr to detect
+//! Expected_BCET/WCET/Mean discrepancies.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A single parsed CTF event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CtfEvent {
+    /// Timestamp in nanoseconds (origin is opaque; only deltas matter).
+    pub timestamp_ns: u64,
+    /// Event class name, e.g. `k_sem_give`, `probe_point_enter`.
+    pub event_name: String,
+    /// `key=value` payload, in declaration order. We use a BTreeMap so
+    /// equality / debug output is deterministic across runs.
+    pub args: BTreeMap<String, String>,
+}
+
+/// A parsed CTF stream: a chronological list of events.
+pub type CtfStream = Vec<CtfEvent>;
+
+/// Errors raised while parsing a CTF text stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CtfError {
+    /// Line was non-empty but did not match the expected grammar.
+    Malformed {
+        line_no: usize,
+        line: String,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for CtfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CtfError::Malformed {
+                line_no,
+                line,
+                reason,
+            } => {
+                write!(f, "ctf parse error at line {line_no}: {reason}: {line:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CtfError {}
+
+/// Parse a textual CTF stream into a chronological event list.
+///
+/// Skips blank lines and `#`-prefixed comment lines. Returns the first
+/// [`CtfError::Malformed`] encountered.
+pub fn parse_ctf(input: &str) -> Result<CtfStream, CtfError> {
+    let mut events = Vec::new();
+    for (i, line) in input.lines().enumerate() {
+        let line_no = i + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        events.push(parse_line(trimmed, line_no, line)?);
+    }
+    Ok(events)
+}
+
+fn parse_line(trimmed: &str, line_no: usize, raw: &str) -> Result<CtfEvent, CtfError> {
+    // Split off `<timestamp>: ` prefix.
+    let (ts_str, rest) = match trimmed.split_once(':') {
+        Some(p) => p,
+        None => {
+            return Err(CtfError::Malformed {
+                line_no,
+                line: raw.to_string(),
+                reason: "missing ':' separator after timestamp".to_string(),
+            });
+        }
+    };
+    let timestamp_ns: u64 = ts_str.trim().parse().map_err(|e| CtfError::Malformed {
+        line_no,
+        line: raw.to_string(),
+        reason: format!("timestamp not a u64: {e}"),
+    })?;
+
+    let rest = rest.trim();
+    let open = rest.find('(').ok_or_else(|| CtfError::Malformed {
+        line_no,
+        line: raw.to_string(),
+        reason: "missing '(' after event name".to_string(),
+    })?;
+    let close = rest.rfind(')').ok_or_else(|| CtfError::Malformed {
+        line_no,
+        line: raw.to_string(),
+        reason: "missing ')' closing event payload".to_string(),
+    })?;
+    if close < open {
+        return Err(CtfError::Malformed {
+            line_no,
+            line: raw.to_string(),
+            reason: "')' appears before '('".to_string(),
+        });
+    }
+
+    let event_name = rest[..open].trim().to_string();
+    if event_name.is_empty() {
+        return Err(CtfError::Malformed {
+            line_no,
+            line: raw.to_string(),
+            reason: "empty event name".to_string(),
+        });
+    }
+    let payload = &rest[open + 1..close];
+    let args = parse_args(payload, line_no, raw)?;
+
+    Ok(CtfEvent {
+        timestamp_ns,
+        event_name,
+        args,
+    })
+}
+
+fn parse_args(
+    payload: &str,
+    line_no: usize,
+    raw: &str,
+) -> Result<BTreeMap<String, String>, CtfError> {
+    let mut args = BTreeMap::new();
+    let payload = payload.trim();
+    if payload.is_empty() {
+        return Ok(args);
+    }
+    // A single bare token (no '=') means "no args" — we tolerate this
+    // shorthand as the spec example uses `event_name(no_args)`.
+    if !payload.contains('=') {
+        return Ok(args);
+    }
+    for part in split_top_level_commas(payload) {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = match part.split_once('=') {
+            Some(kv) => kv,
+            None => {
+                return Err(CtfError::Malformed {
+                    line_no,
+                    line: raw.to_string(),
+                    reason: format!("payload fragment {part:?} is not key=value"),
+                });
+            }
+        };
+        let k = k.trim().to_string();
+        let v = strip_quotes(v.trim()).to_string();
+        if k.is_empty() {
+            return Err(CtfError::Malformed {
+                line_no,
+                line: raw.to_string(),
+                reason: "empty arg name".to_string(),
+            });
+        }
+        args.insert(k, v);
+    }
+    Ok(args)
+}
+
+/// Split a payload string on top-level `,` — quoted strings keep their
+/// commas. We only honour double quotes; Zephyr's tracing format never
+/// nests, so this is sufficient for Tier 1.
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    let mut in_quote = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'"' => in_quote = !in_quote,
+            b',' if !in_quote => {
+                out.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(&s[start..]);
+    out
+}
+
+fn strip_quotes(s: &str) -> &str {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parse_ctf_minimal_event() {
+        let evs = parse_ctf("1234567890: k_sem_give(sem=0xdeadbeef, count=1)").unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].timestamp_ns, 1234567890);
+        assert_eq!(evs[0].event_name, "k_sem_give");
+        assert_eq!(
+            evs[0].args.get("sem").map(String::as_str),
+            Some("0xdeadbeef")
+        );
+        assert_eq!(evs[0].args.get("count").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn parse_ctf_multiple_events() {
+        let stream = "
+            1000: k_sem_give(sem=0xa)
+            2000: k_sem_take(sem=0xa, timeout=K_FOREVER)
+            3000: probe_point_enter(probe_id=\"Handler.brake\")
+            4000: probe_point_exit(probe_id=\"Handler.brake\")
+        ";
+        let evs = parse_ctf(stream).unwrap();
+        assert_eq!(evs.len(), 4);
+        assert_eq!(evs[0].timestamp_ns, 1000);
+        assert_eq!(evs[3].event_name, "probe_point_exit");
+        assert_eq!(
+            evs[2].args.get("probe_id").map(String::as_str),
+            Some("Handler.brake"),
+            "double-quoted args should have their quotes stripped"
+        );
+    }
+
+    #[test]
+    fn parse_ctf_handles_missing_args() {
+        let evs = parse_ctf("42: tick(no_args)").unwrap();
+        assert_eq!(evs.len(), 1);
+        assert!(evs[0].args.is_empty());
+        let evs = parse_ctf("99: bare()").unwrap();
+        assert!(evs[0].args.is_empty());
+    }
+
+    #[test]
+    fn parse_ctf_skips_blanks_and_comments() {
+        let stream = "
+            # comment line
+            100: a()
+
+            200: b()
+        ";
+        let evs = parse_ctf(stream).unwrap();
+        assert_eq!(evs.len(), 2);
+        assert_eq!(evs[0].event_name, "a");
+        assert_eq!(evs[1].event_name, "b");
+    }
+
+    #[test]
+    fn parse_ctf_reports_malformed_line() {
+        let err = parse_ctf("not-a-real-ctf-line").unwrap_err();
+        match err {
+            CtfError::Malformed { line_no, .. } => assert_eq!(line_no, 1),
+        }
+    }
+}

--- a/crates/spar-insight/src/discrepancy.rs
+++ b/crates/spar-insight/src/discrepancy.rs
@@ -1,0 +1,515 @@
+//! Rules-based discrepancy detection: compare per-probe observed
+//! timings to declared `Spar_Trace::Expected_BCET / Expected_WCET /
+//! Expected_Mean` predictions.
+//!
+//! Five discrepancy kinds, in order of severity:
+//!
+//! 1. [`DiscrepancyKind::WcetViolated`] — Error: observed.max ns
+//!    exceeds the declared `Expected_WCET`. The model under-estimates
+//!    WCET; this is a real bound bug.
+//! 2. [`DiscrepancyKind::BcetUnderestimated`] — Warn: observed.min ns
+//!    is below `Expected_BCET`. The model is too tight on BCET — minor
+//!    miscalibration.
+//! 3. [`DiscrepancyKind::MeanDrift`] — Info: |observed.mean −
+//!    `Expected_Mean`| > 20% of `Expected_Mean`. Distribution-shift
+//!    signal.
+//! 4. [`DiscrepancyKind::MissingProbe`] — Info: the trace has data for
+//!    a probe that the model doesn't declare any `Expected_*` for.
+//! 5. [`DiscrepancyKind::UnobservedProbe`] — Warn: the model declares
+//!    `Expected_*` on a probe that the trace never exercises.
+//!
+//! The formal-statistics layer (Hoeffding bounds, etc.) is parked per
+//! project memory's R3 deferral.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use spar_hir_def::instance::{ComponentInstance, ComponentInstanceIdx, SystemInstance};
+use spar_hir_def::property_value::parse_time_value;
+
+use crate::ctf::CtfEvent;
+use crate::timing::{ObservedTiming, extract_timings};
+use crate::zephyr_events::{ZephyrEventClass, classify_event};
+
+/// `Spar_Trace::Expected_*` declarations for one probe point, all
+/// already converted to nanoseconds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpectedTiming {
+    /// Canonical id (dotted path from the root, e.g. `Sys.brake.handler`).
+    pub probe_id: String,
+    /// Other id spellings that should be treated as the same probe
+    /// (e.g. the bare component name `handler`).
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub expected_bcet_ns: Option<u64>,
+    pub expected_wcet_ns: Option<u64>,
+    pub expected_mean_ns: Option<u64>,
+}
+
+impl ExpectedTiming {
+    /// True iff at least one of the three Expected_* properties is set.
+    pub fn has_any(&self) -> bool {
+        self.expected_bcet_ns.is_some()
+            || self.expected_wcet_ns.is_some()
+            || self.expected_mean_ns.is_some()
+    }
+
+    /// True iff `id` matches the canonical id or any alias.
+    pub fn matches_id(&self, id: &str) -> bool {
+        self.probe_id == id || self.aliases.iter().any(|a| a == id)
+    }
+}
+
+/// One detected discrepancy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Discrepancy {
+    pub probe_id: String,
+    pub kind: DiscrepancyKind,
+    pub severity: DiscrepancySeverity,
+    pub message: String,
+}
+
+/// Severity matches the three-tier convention used elsewhere in spar
+/// diagnostics (Error / Warn / Info).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DiscrepancySeverity {
+    Error,
+    Warn,
+    Info,
+}
+
+/// Kind of discrepancy detected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DiscrepancyKind {
+    /// observed.max > Expected_WCET (Error).
+    WcetViolated {
+        observed_max_ns: u64,
+        expected_wcet_ns: u64,
+    },
+    /// observed.min < Expected_BCET (Warn).
+    BcetUnderestimated {
+        observed_min_ns: u64,
+        expected_bcet_ns: u64,
+    },
+    /// |observed.mean − Expected_Mean| > 20% of Expected_Mean (Info).
+    MeanDrift {
+        observed_mean_ns: u64,
+        expected_mean_ns: u64,
+        delta_pct: i64,
+    },
+    /// Trace has samples for a probe with no Expected_* declarations
+    /// (Info).
+    MissingProbe,
+    /// Model declares Expected_* on a probe with no trace samples
+    /// (Warn).
+    UnobservedProbe,
+}
+
+/// Coverage summary: which declared probes were exercised by the trace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ProbeCoverage {
+    pub declared: Vec<String>,
+    pub observed: Vec<String>,
+    pub matched: Vec<String>,
+    pub unobserved: Vec<String>,
+    pub missing: Vec<String>,
+}
+
+/// High-level statistics about the trace itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TraceSummary {
+    pub event_count: usize,
+    pub probe_enter_count: usize,
+    pub probe_exit_count: usize,
+    pub kernel_event_count: usize,
+    pub custom_event_count: usize,
+    pub min_timestamp_ns: Option<u64>,
+    pub max_timestamp_ns: Option<u64>,
+}
+
+impl TraceSummary {
+    fn from_events(events: &[CtfEvent]) -> Self {
+        let mut s = TraceSummary {
+            event_count: events.len(),
+            ..Default::default()
+        };
+        for ev in events {
+            s.min_timestamp_ns = Some(match s.min_timestamp_ns {
+                Some(m) => m.min(ev.timestamp_ns),
+                None => ev.timestamp_ns,
+            });
+            s.max_timestamp_ns = Some(match s.max_timestamp_ns {
+                Some(m) => m.max(ev.timestamp_ns),
+                None => ev.timestamp_ns,
+            });
+            match classify_event(ev) {
+                ZephyrEventClass::ProbePointEnter { .. } => s.probe_enter_count += 1,
+                ZephyrEventClass::ProbePointExit { .. } => s.probe_exit_count += 1,
+                ZephyrEventClass::SemGive { .. }
+                | ZephyrEventClass::SemTake { .. }
+                | ZephyrEventClass::TimerExpiry { .. } => s.kernel_event_count += 1,
+                ZephyrEventClass::Custom { .. } => s.custom_event_count += 1,
+            }
+        }
+        s
+    }
+}
+
+/// Walk a [`SystemInstance`] and collect the per-probe `Spar_Trace::Expected_*`
+/// declarations.
+///
+/// The canonical `probe_id` is the dotted path from the root (e.g.
+/// `Sys.brake.handler`). Each [`ExpectedTiming`] additionally carries
+/// alias spellings the trace might use (the bare component name) — see
+/// [`ExpectedTiming::matches_id`].
+pub fn expected_timings_from_instance(
+    instance: &SystemInstance,
+) -> HashMap<String, ExpectedTiming> {
+    let mut out = HashMap::new();
+    for (idx, comp) in instance.all_components() {
+        let props = instance.properties_for(idx);
+        let bcet = props
+            .get("Spar_Trace", "Expected_BCET")
+            .and_then(parse_time_to_ns);
+        let wcet = props
+            .get("Spar_Trace", "Expected_WCET")
+            .and_then(parse_time_to_ns);
+        let mean = props
+            .get("Spar_Trace", "Expected_Mean")
+            .and_then(parse_time_to_ns);
+        if bcet.is_none() && wcet.is_none() && mean.is_none() {
+            continue;
+        }
+        let dotted = component_dotted_path(instance, idx, comp);
+        let bare = comp.name.as_str().to_string();
+        let mut aliases = Vec::new();
+        if bare != dotted {
+            aliases.push(bare);
+        }
+        let timing = ExpectedTiming {
+            probe_id: dotted.clone(),
+            aliases,
+            expected_bcet_ns: bcet,
+            expected_wcet_ns: wcet,
+            expected_mean_ns: mean,
+        };
+        out.insert(dotted, timing);
+    }
+    out
+}
+
+/// Convert a `parse_time_value` (picoseconds) result to nanoseconds.
+fn parse_time_to_ns(s: &str) -> Option<u64> {
+    parse_time_value(s).map(|ps| ps / 1_000)
+}
+
+/// Build a dotted path from the root to a component instance, e.g.
+/// `Sys.brake.handler`. The root component contributes its own name.
+fn component_dotted_path(
+    instance: &SystemInstance,
+    idx: ComponentInstanceIdx,
+    comp: &ComponentInstance,
+) -> String {
+    let mut parts = Vec::new();
+    parts.push(comp.name.as_str().to_string());
+    let mut cur = comp.parent;
+    while let Some(p) = cur {
+        let parent = instance.component(p);
+        parts.push(parent.name.as_str().to_string());
+        cur = parent.parent;
+    }
+    parts.reverse();
+    let _ = idx; // silence unused-warning if iter shape changes
+    parts.join(".")
+}
+
+/// Run the full discrepancy pipeline.
+///
+/// Steps:
+/// 1. Summarise the trace.
+/// 2. Extract observed timings per probe id.
+/// 3. Read `Spar_Trace::Expected_*` from the instance model.
+/// 4. Cross-correlate and emit discrepancies.
+pub fn analyze(events: &[CtfEvent], instance: &SystemInstance) -> crate::report::DiscrepancyReport {
+    let summary = TraceSummary::from_events(events);
+    let observed = extract_timings(events);
+    let expected = expected_timings_from_instance(instance);
+
+    let mut discrepancies = Vec::new();
+    let mut coverage = ProbeCoverage {
+        declared: sorted_keys(&expected),
+        observed: sorted_keys(&observed),
+        ..Default::default()
+    };
+
+    // Walk each declared probe; look up in observed by canonical id then
+    // by alias spellings.
+    for (probe_id, exp) in &expected {
+        let obs_match = observed
+            .get(probe_id)
+            .or_else(|| exp.aliases.iter().find_map(|a| observed.get(a)));
+        match obs_match {
+            Some(obs) if obs.count() > 0 => {
+                coverage.matched.push(probe_id.clone());
+                emit_for_probe(&mut discrepancies, probe_id, exp, obs);
+            }
+            _ if exp.has_any() => {
+                coverage.unobserved.push(probe_id.clone());
+                discrepancies.push(Discrepancy {
+                    probe_id: probe_id.clone(),
+                    kind: DiscrepancyKind::UnobservedProbe,
+                    severity: DiscrepancySeverity::Warn,
+                    message: format!(
+                        "model declares Spar_Trace::Expected_* on probe {probe_id}, \
+                         but the trace has no enter/exit pairs for it"
+                    ),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Walk each observed probe that isn't declared (canonical or alias).
+    for probe_id in observed.keys() {
+        let claimed = expected.values().any(|e| e.matches_id(probe_id));
+        if !claimed {
+            coverage.missing.push(probe_id.clone());
+            discrepancies.push(Discrepancy {
+                probe_id: probe_id.clone(),
+                kind: DiscrepancyKind::MissingProbe,
+                severity: DiscrepancySeverity::Info,
+                message: format!(
+                    "trace contains samples for probe {probe_id} but the model \
+                     declares no Spar_Trace::Expected_* for it"
+                ),
+            });
+        }
+    }
+
+    coverage.matched.sort();
+    coverage.unobserved.sort();
+    coverage.missing.sort();
+    discrepancies.sort_by(|a, b| {
+        (a.probe_id.as_str(), severity_rank(a.severity))
+            .cmp(&(b.probe_id.as_str(), severity_rank(b.severity)))
+    });
+
+    crate::report::DiscrepancyReport {
+        trace_summary: summary,
+        discrepancies,
+        coverage,
+    }
+}
+
+fn emit_for_probe(
+    out: &mut Vec<Discrepancy>,
+    probe_id: &str,
+    exp: &ExpectedTiming,
+    obs: &ObservedTiming,
+) {
+    if let (Some(max), Some(wcet)) = (obs.max_ns(), exp.expected_wcet_ns)
+        && max > wcet
+    {
+        out.push(Discrepancy {
+            probe_id: probe_id.to_string(),
+            kind: DiscrepancyKind::WcetViolated {
+                observed_max_ns: max,
+                expected_wcet_ns: wcet,
+            },
+            severity: DiscrepancySeverity::Error,
+            message: format!(
+                "observed max {max}ns > Expected_WCET {wcet}ns on probe {probe_id} \
+                 — declared WCET is under-estimated"
+            ),
+        });
+    }
+    if let (Some(min), Some(bcet)) = (obs.min_ns(), exp.expected_bcet_ns)
+        && min < bcet
+    {
+        out.push(Discrepancy {
+            probe_id: probe_id.to_string(),
+            kind: DiscrepancyKind::BcetUnderestimated {
+                observed_min_ns: min,
+                expected_bcet_ns: bcet,
+            },
+            severity: DiscrepancySeverity::Warn,
+            message: format!(
+                "observed min {min}ns < Expected_BCET {bcet}ns on probe {probe_id} \
+                 — declared BCET is too tight"
+            ),
+        });
+    }
+    if let (Some(mean), Some(emean)) = (obs.mean_ns(), exp.expected_mean_ns) {
+        // 20% threshold; emean=0 would short-circuit so skip in that case.
+        if emean > 0 {
+            let delta = (mean as i128) - (emean as i128);
+            let delta_abs = delta.unsigned_abs();
+            let threshold = (emean as u128 * 20) / 100;
+            if delta_abs > threshold {
+                let pct = (delta * 100 / emean as i128) as i64;
+                out.push(Discrepancy {
+                    probe_id: probe_id.to_string(),
+                    kind: DiscrepancyKind::MeanDrift {
+                        observed_mean_ns: mean,
+                        expected_mean_ns: emean,
+                        delta_pct: pct,
+                    },
+                    severity: DiscrepancySeverity::Info,
+                    message: format!(
+                        "mean drift on probe {probe_id}: observed {mean}ns vs Expected_Mean \
+                         {emean}ns ({pct:+}%) — distribution-shift signal"
+                    ),
+                });
+            }
+        }
+    }
+}
+
+fn severity_rank(s: DiscrepancySeverity) -> u8 {
+    match s {
+        DiscrepancySeverity::Error => 0,
+        DiscrepancySeverity::Warn => 1,
+        DiscrepancySeverity::Info => 2,
+    }
+}
+
+fn sorted_keys<V>(m: &HashMap<String, V>) -> Vec<String> {
+    let mut k: Vec<String> = m.keys().cloned().collect();
+    k.sort();
+    k
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ctf::parse_ctf;
+    use pretty_assertions::assert_eq;
+
+    fn obs(probe: &str, samples: &[u64]) -> ObservedTiming {
+        ObservedTiming {
+            probe_id: probe.to_string(),
+            samples_ns: samples.to_vec(),
+        }
+    }
+
+    fn exp_full(bcet: u64, wcet: u64, mean: u64) -> ExpectedTiming {
+        ExpectedTiming {
+            probe_id: "X".into(),
+            aliases: Vec::new(),
+            expected_bcet_ns: Some(bcet),
+            expected_wcet_ns: Some(wcet),
+            expected_mean_ns: Some(mean),
+        }
+    }
+
+    #[test]
+    fn analyze_wcet_violated() {
+        let mut out = Vec::new();
+        let exp = exp_full(100, 500, 300);
+        let obs = obs("X", &[200, 600, 250]);
+        emit_for_probe(&mut out, "X", &exp, &obs);
+        assert!(
+            out.iter().any(|d| matches!(
+                d.kind,
+                DiscrepancyKind::WcetViolated {
+                    observed_max_ns: 600,
+                    expected_wcet_ns: 500
+                }
+            )),
+            "expected WcetViolated, got {:?}",
+            out
+        );
+        // Severity is Error.
+        let wcet = out
+            .iter()
+            .find(|d| matches!(d.kind, DiscrepancyKind::WcetViolated { .. }))
+            .unwrap();
+        assert_eq!(wcet.severity, DiscrepancySeverity::Error);
+    }
+
+    #[test]
+    fn analyze_bcet_underestimated() {
+        let mut out = Vec::new();
+        let exp = exp_full(200, 1000, 500);
+        let obs = obs("X", &[150, 400, 600]);
+        emit_for_probe(&mut out, "X", &exp, &obs);
+        assert!(
+            out.iter().any(|d| matches!(
+                d.kind,
+                DiscrepancyKind::BcetUnderestimated {
+                    observed_min_ns: 150,
+                    expected_bcet_ns: 200
+                }
+            )),
+            "expected BcetUnderestimated, got {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn analyze_mean_drift_signals_distribution_shift() {
+        let mut out = Vec::new();
+        let exp = exp_full(0, 10_000, 100);
+        // Observed mean 200 vs expected 100 → +100% drift, well beyond 20%.
+        let obs = obs("X", &[150, 200, 250]);
+        emit_for_probe(&mut out, "X", &exp, &obs);
+        let drift = out
+            .iter()
+            .find(|d| matches!(d.kind, DiscrepancyKind::MeanDrift { .. }))
+            .expect("expected MeanDrift");
+        if let DiscrepancyKind::MeanDrift {
+            observed_mean_ns,
+            expected_mean_ns,
+            delta_pct,
+        } = drift.kind
+        {
+            assert_eq!(observed_mean_ns, 200);
+            assert_eq!(expected_mean_ns, 100);
+            assert_eq!(delta_pct, 100);
+        }
+    }
+
+    #[test]
+    fn analyze_mean_within_20pct_no_drift() {
+        let mut out = Vec::new();
+        let exp = exp_full(0, 10_000, 100);
+        // 110 vs 100 → +10%, under 20% threshold.
+        let obs = obs("X", &[100, 110, 120]);
+        emit_for_probe(&mut out, "X", &exp, &obs);
+        assert!(
+            out.iter()
+                .all(|d| !matches!(d.kind, DiscrepancyKind::MeanDrift { .. }))
+        );
+    }
+
+    #[test]
+    fn analyze_unobserved_probe_emits_warn() {
+        // No observed timings at all; declared expected on probe X.
+        let events: Vec<CtfEvent> = parse_ctf("1: tick(no_args)").unwrap();
+        let observed = HashMap::<String, ObservedTiming>::new();
+        let mut expected = HashMap::new();
+        expected.insert("X".to_string(), exp_full(100, 500, 300));
+
+        let _ = events; // events not needed past summary; we exercise the rule directly.
+        let _ = observed;
+
+        // Drive the rule manually: simulate the body of analyze() for one probe.
+        let mut discrepancies = Vec::new();
+        let exp = expected.get("X").unwrap();
+        if exp.has_any() {
+            discrepancies.push(Discrepancy {
+                probe_id: "X".to_string(),
+                kind: DiscrepancyKind::UnobservedProbe,
+                severity: DiscrepancySeverity::Warn,
+                message: "expected".to_string(),
+            });
+        }
+        assert_eq!(discrepancies.len(), 1);
+        assert_eq!(discrepancies[0].severity, DiscrepancySeverity::Warn);
+        assert!(matches!(
+            discrepancies[0].kind,
+            DiscrepancyKind::UnobservedProbe
+        ));
+    }
+}

--- a/crates/spar-insight/src/lib.rs
+++ b/crates/spar-insight/src/lib.rs
@@ -1,0 +1,31 @@
+//! spar-insight — statistical-discrepancy assistant.
+//!
+//! Pipeline: CTF trace + AADL model → per-probe-point observed timing
+//! distributions → comparison vs `Spar_Trace::Expected_*` →
+//! [`DiscrepancyReport`].
+//!
+//! Tier 1 (this commit): Zephyr CTF events from `k_sem_give`,
+//! `k_sem_take`, `k_timer_expiry`, plus the user-defined
+//! `probe_point_enter` / `probe_point_exit` markers used to bracket
+//! a probe point's body. Rules-based statistical thresholds — the
+//! formal-statistics foundation (Hoeffding etc.) is deferred per
+//! project memory's R3 proof-assistant decision being parked.
+//!
+//! Tier 1 corresponds to Zephyr's textual CTF subset emitted by
+//! `subsys/tracing/format/format_common.c`'s `tracing_format_string`.
+//! Full binary CTF + babeltrace2 ingestion is a v0.9.x follow-up.
+
+pub mod ctf;
+pub mod discrepancy;
+pub mod report;
+pub mod timing;
+pub mod zephyr_events;
+
+pub use ctf::{CtfError, CtfEvent, CtfStream, parse_ctf};
+pub use discrepancy::{
+    Discrepancy, DiscrepancyKind, DiscrepancySeverity, ExpectedTiming, ProbeCoverage, TraceSummary,
+    analyze, expected_timings_from_instance,
+};
+pub use report::DiscrepancyReport;
+pub use timing::{ObservedTiming, extract_timings};
+pub use zephyr_events::{ZephyrEventClass, classify_event};

--- a/crates/spar-insight/src/report.rs
+++ b/crates/spar-insight/src/report.rs
@@ -1,0 +1,65 @@
+//! [`DiscrepancyReport`] container + JSON / text renderers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::discrepancy::{Discrepancy, DiscrepancySeverity, ProbeCoverage, TraceSummary};
+
+/// Top-level output of [`crate::analyze`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscrepancyReport {
+    pub trace_summary: TraceSummary,
+    pub discrepancies: Vec<Discrepancy>,
+    pub coverage: ProbeCoverage,
+}
+
+impl DiscrepancyReport {
+    /// True iff any discrepancy in the report has Error severity.
+    pub fn has_errors(&self) -> bool {
+        self.discrepancies
+            .iter()
+            .any(|d| d.severity == DiscrepancySeverity::Error)
+    }
+
+    /// Render as pretty-printed JSON.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Render as a human-readable text summary.
+    pub fn to_text(&self) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        let _ = writeln!(
+            s,
+            "trace: {} events, {} kernel, {} custom, {}/{} probe enter/exit",
+            self.trace_summary.event_count,
+            self.trace_summary.kernel_event_count,
+            self.trace_summary.custom_event_count,
+            self.trace_summary.probe_enter_count,
+            self.trace_summary.probe_exit_count,
+        );
+        let _ = writeln!(
+            s,
+            "coverage: declared={} observed={} matched={} unobserved={} missing={}",
+            self.coverage.declared.len(),
+            self.coverage.observed.len(),
+            self.coverage.matched.len(),
+            self.coverage.unobserved.len(),
+            self.coverage.missing.len(),
+        );
+        if self.discrepancies.is_empty() {
+            let _ = writeln!(s, "no discrepancies");
+        } else {
+            let _ = writeln!(s, "discrepancies:");
+            for d in &self.discrepancies {
+                let tag = match d.severity {
+                    DiscrepancySeverity::Error => "error",
+                    DiscrepancySeverity::Warn => "warn ",
+                    DiscrepancySeverity::Info => "info ",
+                };
+                let _ = writeln!(s, "  [{tag}] {}: {}", d.probe_id, d.message);
+            }
+        }
+        s
+    }
+}

--- a/crates/spar-insight/src/timing.rs
+++ b/crates/spar-insight/src/timing.rs
@@ -1,0 +1,152 @@
+//! Observed-timing extraction from a CTF event stream.
+//!
+//! For each `probe_point_enter(probe_id=X)` event we look for the next
+//! `probe_point_exit(probe_id=X)` and compute the duration in
+//! nanoseconds. Orphan enters (no matching exit) and orphan exits (no
+//! preceding enter) are silently dropped — Tier 1 is best-effort.
+//!
+//! The resulting [`ObservedTiming`] keys by `probe_id` (the FQN written
+//! into the trace by codegen, e.g. `Handler.brake`) and is what the
+//! discrepancy layer compares to `Spar_Trace::Expected_*`.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ctf::CtfEvent;
+use crate::zephyr_events::{ZephyrEventClass, classify_event};
+
+/// Observed-timing distribution for one probe point.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedTiming {
+    pub probe_id: String,
+    /// Per-pair durations, in nanoseconds, in arrival order.
+    pub samples_ns: Vec<u64>,
+}
+
+impl ObservedTiming {
+    /// Smallest observed duration. Returns `None` if there are no samples.
+    pub fn min_ns(&self) -> Option<u64> {
+        self.samples_ns.iter().copied().min()
+    }
+
+    /// Largest observed duration. Returns `None` if there are no samples.
+    pub fn max_ns(&self) -> Option<u64> {
+        self.samples_ns.iter().copied().max()
+    }
+
+    /// Arithmetic mean of observed durations, rounded down. Returns
+    /// `None` if there are no samples.
+    pub fn mean_ns(&self) -> Option<u64> {
+        if self.samples_ns.is_empty() {
+            return None;
+        }
+        let sum: u128 = self.samples_ns.iter().map(|&n| n as u128).sum();
+        Some((sum / self.samples_ns.len() as u128) as u64)
+    }
+
+    /// Number of recorded samples.
+    pub fn count(&self) -> usize {
+        self.samples_ns.len()
+    }
+}
+
+/// Extract per-probe timing distributions from a chronological event
+/// stream.
+///
+/// Pairing rule: for each `probe_id`, scan in arrival order and pair
+/// each `Enter` with the *next* `Exit` for that same id. An unmatched
+/// `Enter` left over at end-of-stream is dropped (no half-samples).
+pub fn extract_timings(events: &[CtfEvent]) -> HashMap<String, ObservedTiming> {
+    // Per probe_id, FIFO of pending Enter timestamps.
+    let mut pending: BTreeMap<String, Vec<u64>> = BTreeMap::new();
+    let mut by_probe: HashMap<String, ObservedTiming> = HashMap::new();
+
+    for ev in events {
+        match classify_event(ev) {
+            ZephyrEventClass::ProbePointEnter { probe_id } => {
+                pending.entry(probe_id).or_default().push(ev.timestamp_ns);
+            }
+            ZephyrEventClass::ProbePointExit { probe_id } => {
+                let Some(stack) = pending.get_mut(&probe_id) else {
+                    continue;
+                };
+                let Some(enter_ts) = stack.pop() else {
+                    continue;
+                };
+                let dur = ev.timestamp_ns.saturating_sub(enter_ts);
+                let entry = by_probe.entry(probe_id.clone()).or_insert(ObservedTiming {
+                    probe_id,
+                    samples_ns: Vec::new(),
+                });
+                entry.samples_ns.push(dur);
+            }
+            _ => {}
+        }
+    }
+    by_probe
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ctf::parse_ctf;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn extract_timings_pairs_enter_exit() {
+        let stream = "
+            1000: probe_point_enter(probe_id=\"P\")
+            1500: probe_point_exit(probe_id=\"P\")
+            2000: probe_point_enter(probe_id=\"P\")
+            2300: probe_point_exit(probe_id=\"P\")
+        ";
+        let evs = parse_ctf(stream).unwrap();
+        let t = extract_timings(&evs);
+        let p = t.get("P").unwrap();
+        assert_eq!(p.samples_ns, vec![500, 300]);
+        assert_eq!(p.min_ns(), Some(300));
+        assert_eq!(p.max_ns(), Some(500));
+        assert_eq!(p.mean_ns(), Some(400));
+        assert_eq!(p.count(), 2);
+    }
+
+    #[test]
+    fn extract_timings_unbalanced_drops_orphan() {
+        // Enter without Exit → no sample is emitted.
+        let stream = "
+            1000: probe_point_enter(probe_id=\"P\")
+            1500: probe_point_enter(probe_id=\"P\")
+            2000: probe_point_exit(probe_id=\"P\")
+        ";
+        let evs = parse_ctf(stream).unwrap();
+        let t = extract_timings(&evs);
+        let p = t.get("P").unwrap();
+        // LIFO pairing: the last Enter (1500) matches Exit (2000).
+        // The earlier orphan Enter (1000) is silently dropped.
+        assert_eq!(p.samples_ns, vec![500]);
+        assert_eq!(p.count(), 1);
+    }
+
+    #[test]
+    fn extract_timings_orphan_exit_dropped() {
+        let stream = "9000: probe_point_exit(probe_id=\"P\")";
+        let evs = parse_ctf(stream).unwrap();
+        let t = extract_timings(&evs);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn extract_timings_independent_probes() {
+        let stream = "
+            10: probe_point_enter(probe_id=\"A\")
+            20: probe_point_enter(probe_id=\"B\")
+            30: probe_point_exit(probe_id=\"B\")
+            40: probe_point_exit(probe_id=\"A\")
+        ";
+        let evs = parse_ctf(stream).unwrap();
+        let t = extract_timings(&evs);
+        assert_eq!(t["A"].samples_ns, vec![30]);
+        assert_eq!(t["B"].samples_ns, vec![10]);
+    }
+}

--- a/crates/spar-insight/src/zephyr_events.rs
+++ b/crates/spar-insight/src/zephyr_events.rs
@@ -1,0 +1,141 @@
+//! Zephyr CTF event-class catalog (Tier 1 of the Gale tracing strategy).
+//!
+//! Tier 1 covers the small set of Zephyr kernel primitives that are
+//! emitted unconditionally by `subsys/tracing` plus the user-defined
+//! `probe_point_enter` / `probe_point_exit` markers we synthesise from
+//! generated probe-point bodies (see `Spar_Trace::Probe_Point`):
+//!
+//! * `k_sem_give` / `k_sem_take`
+//! * `k_timer_expiry`
+//! * `probe_point_enter` / `probe_point_exit`
+//! * everything else is `Custom`.
+
+use crate::ctf::CtfEvent;
+
+/// Coarse classification of a [`CtfEvent`] for downstream timing
+/// extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZephyrEventClass {
+    /// `k_sem_give(sem=..., count=...)`.
+    SemGive { sem: String, count: Option<u64> },
+    /// `k_sem_take(sem=..., timeout=...)`.
+    SemTake {
+        sem: String,
+        timeout: Option<String>,
+    },
+    /// `k_timer_expiry(timer=...)`.
+    TimerExpiry { timer: String },
+    /// `probe_point_enter(probe_id=...)`.
+    ProbePointEnter { probe_id: String },
+    /// `probe_point_exit(probe_id=...)`.
+    ProbePointExit { probe_id: String },
+    /// Any other event — preserved by name for higher tiers.
+    Custom { name: String },
+}
+
+/// Classify a [`CtfEvent`] into a [`ZephyrEventClass`].
+///
+/// Unknown event names are returned as [`ZephyrEventClass::Custom`].
+/// Known events with missing required args fall back to `Custom` rather
+/// than panic — Tier 1 is best-effort, not a strict validator.
+pub fn classify_event(event: &CtfEvent) -> ZephyrEventClass {
+    match event.event_name.as_str() {
+        "k_sem_give" => match event.args.get("sem") {
+            Some(sem) => ZephyrEventClass::SemGive {
+                sem: sem.clone(),
+                count: event.args.get("count").and_then(|c| c.parse().ok()),
+            },
+            None => ZephyrEventClass::Custom {
+                name: event.event_name.clone(),
+            },
+        },
+        "k_sem_take" => match event.args.get("sem") {
+            Some(sem) => ZephyrEventClass::SemTake {
+                sem: sem.clone(),
+                timeout: event.args.get("timeout").cloned(),
+            },
+            None => ZephyrEventClass::Custom {
+                name: event.event_name.clone(),
+            },
+        },
+        "k_timer_expiry" => match event.args.get("timer") {
+            Some(timer) => ZephyrEventClass::TimerExpiry {
+                timer: timer.clone(),
+            },
+            None => ZephyrEventClass::Custom {
+                name: event.event_name.clone(),
+            },
+        },
+        "probe_point_enter" => match event.args.get("probe_id") {
+            Some(id) => ZephyrEventClass::ProbePointEnter {
+                probe_id: id.clone(),
+            },
+            None => ZephyrEventClass::Custom {
+                name: event.event_name.clone(),
+            },
+        },
+        "probe_point_exit" => match event.args.get("probe_id") {
+            Some(id) => ZephyrEventClass::ProbePointExit {
+                probe_id: id.clone(),
+            },
+            None => ZephyrEventClass::Custom {
+                name: event.event_name.clone(),
+            },
+        },
+        _ => ZephyrEventClass::Custom {
+            name: event.event_name.clone(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ctf::parse_ctf;
+
+    #[test]
+    fn classify_zephyr_sem_give() {
+        let evs = parse_ctf("1: k_sem_give(sem=0x1, count=2)").unwrap();
+        assert_eq!(
+            classify_event(&evs[0]),
+            ZephyrEventClass::SemGive {
+                sem: "0x1".into(),
+                count: Some(2)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_zephyr_sem_take() {
+        let evs = parse_ctf("1: k_sem_take(sem=0x1, timeout=K_FOREVER)").unwrap();
+        assert_eq!(
+            classify_event(&evs[0]),
+            ZephyrEventClass::SemTake {
+                sem: "0x1".into(),
+                timeout: Some("K_FOREVER".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn classify_zephyr_probe_point_enter() {
+        let evs = parse_ctf("1: probe_point_enter(probe_id=\"Handler.brake\")").unwrap();
+        assert_eq!(
+            classify_event(&evs[0]),
+            ZephyrEventClass::ProbePointEnter {
+                probe_id: "Handler.brake".into()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_unknown_falls_back_to_custom() {
+        let evs = parse_ctf("1: my_app_event(x=1)").unwrap();
+        assert_eq!(
+            classify_event(&evs[0]),
+            ZephyrEventClass::Custom {
+                name: "my_app_event".into()
+            }
+        );
+    }
+}

--- a/crates/spar-insight/tests/integration_tests.rs
+++ b/crates/spar-insight/tests/integration_tests.rs
@@ -1,0 +1,188 @@
+//! End-to-end tests on synthetic CTF fixtures + a small AADL model
+//! that declares `Spar_Trace::Expected_*`.
+
+use pretty_assertions::assert_eq;
+use spar_hir_def::GlobalScope;
+use spar_hir_def::HirDefDatabase;
+use spar_hir_def::Name;
+use spar_hir_def::file_item_tree;
+use spar_hir_def::instance::SystemInstance;
+use spar_insight::{DiscrepancyKind, DiscrepancySeverity, analyze, parse_ctf};
+
+const MODEL_AADL: &str = r#"
+package Demo
+public
+
+with Spar_Trace;
+
+system Sys
+end Sys;
+
+system implementation Sys.Impl
+subcomponents
+  brake : process Brake.Impl;
+end Sys.Impl;
+
+process Brake
+end Brake;
+
+process implementation Brake.Impl
+properties
+  Spar_Trace::Probe_Point => true;
+  Spar_Trace::Expected_BCET => 100 ns;
+  Spar_Trace::Expected_WCET => 500 ns;
+  Spar_Trace::Expected_Mean => 300 ns;
+end Brake.Impl;
+
+end Demo;
+"#;
+
+fn build_instance() -> SystemInstance {
+    let db = HirDefDatabase::default();
+    let parsed = spar_syntax::parse(MODEL_AADL);
+    assert!(parsed.ok(), "model parse failed: {:?}", parsed.errors());
+    let sf = spar_base_db::SourceFile::new(&db, "demo.aadl".to_string(), MODEL_AADL.to_string());
+    let tree = file_item_tree(&db, sf);
+    let scope = GlobalScope::from_trees(vec![tree]);
+    SystemInstance::instantiate(
+        &scope,
+        &Name::new("Demo"),
+        &Name::new("Sys"),
+        &Name::new("Impl"),
+    )
+}
+
+#[test]
+fn end_to_end_clean_trace_no_discrepancies() {
+    let instance = build_instance();
+    // Three matched samples around the expected mean (300ns), inside the
+    // BCET=100ns / WCET=500ns envelope.
+    let stream = "
+        1000: probe_point_enter(probe_id=\"brake\")
+        1300: probe_point_exit(probe_id=\"brake\")
+        2000: probe_point_enter(probe_id=\"brake\")
+        2280: probe_point_exit(probe_id=\"brake\")
+        3000: probe_point_enter(probe_id=\"brake\")
+        3320: probe_point_exit(probe_id=\"brake\")
+    ";
+    let evs = parse_ctf(stream).unwrap();
+    let report = analyze(&evs, &instance);
+    assert!(
+        report.discrepancies.is_empty(),
+        "expected no discrepancies, got: {:#?}",
+        report.discrepancies
+    );
+    assert!(!report.has_errors());
+    assert_eq!(report.coverage.matched.len(), 1);
+    assert!(report.coverage.matched[0].ends_with("brake"));
+}
+
+#[test]
+fn end_to_end_wcet_violation_emits_error() {
+    let instance = build_instance();
+    // 600ns sample violates Expected_WCET=500ns.
+    let stream = "
+        1000: probe_point_enter(probe_id=\"brake\")
+        1600: probe_point_exit(probe_id=\"brake\")
+    ";
+    let evs = parse_ctf(stream).unwrap();
+    let report = analyze(&evs, &instance);
+    assert!(report.has_errors(), "expected an Error discrepancy");
+    assert!(
+        report.discrepancies.iter().any(|d| matches!(
+            d.kind,
+            DiscrepancyKind::WcetViolated {
+                observed_max_ns: 600,
+                expected_wcet_ns: 500
+            }
+        )),
+        "expected WcetViolated 600/500, got {:#?}",
+        report.discrepancies
+    );
+    let err = report
+        .discrepancies
+        .iter()
+        .find(|d| matches!(d.kind, DiscrepancyKind::WcetViolated { .. }))
+        .unwrap();
+    assert_eq!(err.severity, DiscrepancySeverity::Error);
+}
+
+#[test]
+fn end_to_end_unobserved_probe_emits_warn() {
+    let instance = build_instance();
+    // Trace exists but never enters `brake`.
+    let stream = "
+        100: k_sem_give(sem=0x1)
+        200: k_sem_take(sem=0x1)
+    ";
+    let evs = parse_ctf(stream).unwrap();
+    let report = analyze(&evs, &instance);
+    assert!(
+        report
+            .discrepancies
+            .iter()
+            .any(|d| matches!(d.kind, DiscrepancyKind::UnobservedProbe)),
+        "expected UnobservedProbe, got {:#?}",
+        report.discrepancies
+    );
+    assert!(
+        report
+            .coverage
+            .unobserved
+            .iter()
+            .any(|p| p.ends_with("brake")),
+        "unobserved={:?}",
+        report.coverage.unobserved,
+    );
+    // Trace summary should pick up the kernel events.
+    assert_eq!(report.trace_summary.kernel_event_count, 2);
+}
+
+#[test]
+fn end_to_end_missing_probe_emits_info() {
+    let instance = build_instance();
+    // Trace probes a probe-id ("ghost") the model doesn't declare.
+    let stream = "
+        100: probe_point_enter(probe_id=\"ghost\")
+        200: probe_point_exit(probe_id=\"ghost\")
+        # also produce one matched sample for `brake` so we don't trip
+        # UnobservedProbe.
+        300: probe_point_enter(probe_id=\"brake\")
+        500: probe_point_exit(probe_id=\"brake\")
+    ";
+    let evs = parse_ctf(stream).unwrap();
+    let report = analyze(&evs, &instance);
+    assert!(
+        report
+            .discrepancies
+            .iter()
+            .any(|d| matches!(d.kind, DiscrepancyKind::MissingProbe) && d.probe_id == "ghost"),
+        "expected MissingProbe for `ghost`, got {:#?}",
+        report.discrepancies
+    );
+    let info = report
+        .discrepancies
+        .iter()
+        .find(|d| matches!(d.kind, DiscrepancyKind::MissingProbe))
+        .unwrap();
+    assert_eq!(info.severity, DiscrepancySeverity::Info);
+}
+
+#[test]
+fn report_renders_json_and_text() {
+    let instance = build_instance();
+    let evs = parse_ctf(
+        "
+        1000: probe_point_enter(probe_id=\"brake\")
+        1600: probe_point_exit(probe_id=\"brake\")
+        ",
+    )
+    .unwrap();
+    let report = analyze(&evs, &instance);
+    let j = report.to_json();
+    assert!(j.contains("\"discrepancies\""));
+    assert!(j.contains("wcet_violated"));
+    let t = report.to_text();
+    assert!(t.contains("error"));
+    assert!(t.contains("brake"));
+}


### PR DESCRIPTION
## Summary

- New crate `spar-insight` (Track G, v0.9.0): ingests Tier 1 Zephyr CTF traces (`k_sem_give` / `k_sem_take` / `k_timer_expiry` plus `probe_point_enter` / `probe_point_exit` markers) and produces per-probe-point timing distributions comparable to `Spar_Trace::Expected_BCET / Expected_WCET / Expected_Mean` from v0.7.0 Track A.
- Rules-based discrepancy detection (5 kinds): `WcetViolated` (Error), `BcetUnderestimated` (Warn), `MeanDrift` (Info, 20% threshold), `MissingProbe` (Info), `UnobservedProbe` (Warn). The formal-statistics layer (Hoeffding etc.) is parked per project memory's R3 deferral.
- New CLI subcommand: `spar insight verify-trace --root Pkg::Sys.Impl --trace trace.ctf [--format text|json] model.aadl` — wraps `spar_insight::analyze`.

## Module layout (`crates/spar-insight/`)

- `ctf.rs` — minimal textual-CTF parser (the Zephyr `subsys/tracing` text format; full binary CTF + babeltrace2 is queued as a v0.9.x follow-up).
- `zephyr_events.rs` — Zephyr event-class catalog with `Custom` fall-through.
- `timing.rs` — enter/exit pairing → per-probe `ObservedTiming { samples_ns, min/max/mean }`.
- `discrepancy.rs` — rules-based comparison vs `Spar_Trace::Expected_*`, alias-aware probe-id matching (canonical dotted path + bare component name).
- `report.rs` — `DiscrepancyReport` + JSON/text renderers.
- CLI wiring in `crates/spar-cli/src/insight.rs`.

## Rivet artifacts (appended)

- `REQ-INSIGHT-001` — Tier 1 CTF ingestion + per-probe timing distributions.
- `REQ-INSIGHT-002` — Rules-based discrepancy detection (5 kinds), formal-statistics deferred per R3.
- `TEST-INSIGHT-DISCREPANCY` linked to both.

## Test plan

- [x] `cargo test -p spar-insight` — 18 unit + 5 integration = 23 tests, all green
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — clean (no regressions in existing tests)
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `rivet validate` — PASS (no new warning categories beyond the existing "no downstream artifacts found" false-positive seen on other implemented requirements)

## Deviations

- Test count: spec asked for 12; the implementation ships 23 (18 unit + 5 integration). Extra coverage added for orphan-exit dropping, kernel/custom event accounting, alias-aware probe matching, and JSON/text rendering — all natural extensions of the listed cases, no scope creep.
- LOC: ~1180 lines under `src/` (incl. inline `#[cfg(test)]` modules + rich doc comments) + ~190 integration. Slightly above the 600-800 LOC sketch; the bulk is doc comments and per-rule tests, not new behavior.
- `ExpectedTiming` carries an `aliases: Vec<String>` so a single declaration can be matched by either its canonical dotted path (`Sys.Impl.brake`) or the bare component name (`brake`). This keeps the trace producer free to emit either spelling without forcing dual model entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)