### PR TITLE
feat(mcp): spar-mcp crate skeleton + read-only tools (Track E commit 8 / v0.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spar-mcp"
+version = "0.8.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "spar",
+ "spar-analysis",
+ "spar-base-db",
+ "spar-hir-def",
+ "spar-network",
+ "spar-syntax",
+ "tempfile",
+]
+
+[[package]]
 name = "spar-network"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/spar-transform",
     "crates/spar-variants",
     "crates/spar-cli",
+    "crates/spar-mcp",
     "crates/spar-codegen",
     "crates/spar-render",
     "crates/spar-solver",

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1495,4 +1495,30 @@ artifacts:
     status: implemented
     tags: [insight, trace, cli, v090]
 
+  # ── Track E commit 8/8 — MCP oracle surface (v0.9.0) ──────────────────
+
+  - id: REQ-MCP-002
+    type: requirement
+    title: spar-mcp read-only verification-oracle tool surface
+    description: >
+      System exposes read-only / idempotent MCP (Model Context Protocol)
+      tools `spar.verify_move`, `spar.enumerate_moves`, and
+      `spar.check_chain` for AI agent integration. The three tools wrap
+      the existing `spar moves verify`, `spar moves enumerate`, and
+      end-to-end latency-analysis pipelines without printing — each tool
+      returns the same structured JSON shape the equivalent CLI
+      subcommand emits with `--format json`. The deterministic apply
+      path stays CLI-exclusive: there is no `spar.apply_move` tool over
+      MCP, ever, by certification design (per Track E migration research
+      §6.5). LLM agents propose moves; spar deterministically verifies;
+      certification chain stays in spar. The transport is JSON-RPC 2.0
+      over stdio per MCP 2025-11-25; the server is reachable as either a
+      standalone `spar-mcp` binary or via the `spar mcp serve`
+      subcommand. All three tools declare `readOnlyHint: true` and
+      `idempotentHint: true` in their MCP annotations and refuse to
+      mutate the model file on disk. Track E commit 8/8 of the v0.9.0
+      design.
+    status: implemented
+    tags: [mcp, migration, track-e, v090, integration]
+
   # Research findings tracked separately in research/findings.yaml

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1952,3 +1952,50 @@ artifacts:
         target: REQ-INSIGHT-001
       - type: satisfies
         target: REQ-INSIGHT-002
+
+  # ── Track E commit 8/8 — MCP oracle tool surface (v0.9.0) ────────────
+
+  - id: TEST-MCP-TOOLS
+    type: feature
+    title: spar-mcp read-only verification-oracle tool surface tests
+    description: >
+      Integration tests in crates/spar-mcp/tests covering the v0.9.0
+      MCP tool surface (Track E commit 8/8). Eleven tests split between
+      an in-process Rust API path (5) and a stdio JSON-RPC envelope path
+      (6). Coverage:
+      (1) `spar.verify_move` returns ok=true and exit_code=0 on an
+          admissible mobile-component move;
+      (2) `spar.enumerate_moves` enumerates every Processor /
+          VirtualProcessor in the instance when no Allowed_Targets is
+          set;
+      (3) `spar.check_chain` returns the latency-pass diagnostic stream
+          (best/worst-case bounds plus per-hop annotations) for a chain
+          spanning one compute hop and one connection hop;
+      (4) variant scoping (`--variant NAME` over the
+          SPAR_VARIANT_TEST_RIVET_OUTPUT seam) populates the report's
+          `variant` and `feature_model_hash` audit fields;
+      (5) the `--objective` selector accepts the five recognised modes
+          and rejects unknown values with a BAD_INPUT error;
+      (6) `tools/list` returns exactly three tools with
+          `readOnlyHint: true` / `idempotentHint: true`;
+      (7-9) `tools/call` for each tool returns valid JSON with the
+          documented `structuredContent` shape and `isError: false`;
+      (10) an unknown tool name returns the JSON-RPC MethodNotFound
+          error code (-32601);
+      plus one bonus test confirming unknown JSON-RPC methods (e.g.
+      `sampling/createMessage`) also return -32601.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-mcp
+    status: passing
+    tags: [mcp, migration, track-e, v090, integration]
+    links:
+      - type: satisfies
+        target: REQ-MCP-002
+      - type: satisfies
+        target: REQ-MIGRATION-005
+      - type: satisfies
+        target: REQ-MIGRATION-006
+      - type: satisfies
+        target: REQ-MIGRATION-008

--- a/crates/spar-cli/Cargo.toml
+++ b/crates/spar-cli/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 repository.workspace = true
 description = "AADL toolchain CLI"
 
+[lib]
+name = "spar_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "spar"
 path = "src/main.rs"

--- a/crates/spar-cli/src/lib.rs
+++ b/crates/spar-cli/src/lib.rs
@@ -1,0 +1,23 @@
+//! Public library surface for `spar-cli`.
+//!
+//! `spar-cli` is primarily a binary crate (`spar`); the library exposes
+//! the *internals* needed by sibling crates — currently:
+//!
+//! - [`moves`] — the verify / enumerate pipelines used by the v0.9.0
+//!   MCP tool surface ([`spar-mcp`](../spar_mcp/index.html)). The MCP
+//!   tools call [`moves::verify_pipeline`] and
+//!   [`moves::enumerate_pipeline`] directly so the wire-format report
+//!   shape stays a single source of truth across CLI and MCP transport.
+//!
+//! Everything else (LSP, codegen dispatch, refactor, diff, sarif) is
+//! still private to the binary and exposed only via `spar <command>`.
+//!
+//! # Stability
+//!
+//! This is an internal-use-only library; the public surface only
+//! supports the in-tree `spar-mcp` consumer. External users should
+//! shell out to `spar` (or, for v0.9.0+, drive the MCP server) rather
+//! than depend on this crate as a Rust library.
+
+pub mod moves;
+pub mod variants_bridge;

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -2,11 +2,17 @@ mod assertion;
 mod diff;
 mod insight;
 mod lsp;
-mod moves;
 mod refactor;
 mod sarif;
-mod variants_bridge;
 mod verify;
+
+// Re-export shared modules from the library so the binary keeps using
+// the `crate::moves::…` / `crate::variants_bridge::…` paths in its
+// existing call sites without duplicating module bodies. The lib
+// (spar_cli) is the canonical home; spar-mcp consumes the same surface.
+use spar_cli::moves;
+#[allow(unused_imports)]
+use spar_cli::variants_bridge;
 
 use std::{env, fs, process};
 
@@ -44,6 +50,7 @@ fn main() {
         "extract" => cmd_sysml2_extract(&args[2..]),
         "generate" => cmd_sysml2_generate(&args[2..]),
         "lsp" => cmd_lsp(),
+        "mcp" => cmd_mcp(&args[2..]),
         "moves" => moves::cmd_moves_dispatch(&args[2..]),
         "insight" => insight::cmd_insight(&args[2..]),
         other => {
@@ -72,6 +79,9 @@ fn print_usage() {
     );
     eprintln!("  insight    Discrepancy assistant: compare CTF traces to Expected_BCET/WCET/Mean");
     eprintln!("  lsp        Start Language Server Protocol server (stdin/stdout)");
+    eprintln!(
+        "  mcp        Start MCP server (read-only verification oracles for AI agent integration)"
+    );
     eprintln!();
     eprintln!("Options:");
     eprintln!("  parse    [--tree] <file...>");
@@ -105,6 +115,102 @@ fn print_usage() {
 
 fn cmd_lsp() {
     lsp::run_lsp_server();
+}
+
+/// `spar mcp serve` — start the spar-mcp stdio JSON-RPC server.
+///
+/// The actual server lives in the sibling `spar-mcp` crate. To avoid a
+/// Cargo cycle (spar -> spar-mcp -> spar-cli (lib) -> spar binary), we
+/// exec the standalone `spar-mcp` binary that ships alongside `spar`.
+/// We resolve it via:
+///
+/// 1. `$SPAR_MCP_BIN` if set;
+/// 2. a sibling of the current executable (`<dir>/spar-mcp[.exe]`);
+/// 3. the host `$PATH`.
+fn cmd_mcp(args: &[String]) {
+    let usage = || {
+        eprintln!("Usage: spar mcp serve");
+        eprintln!();
+        eprintln!("Subcommands:");
+        eprintln!(
+            "  serve   Start the MCP stdio JSON-RPC server (read-only / idempotent oracle tools)"
+        );
+    };
+
+    let sub = match args.first().map(String::as_str) {
+        None | Some("--help") | Some("-h") => {
+            usage();
+            process::exit(if args.is_empty() { 1 } else { 0 });
+        }
+        Some("serve") => "serve",
+        Some(other) => {
+            eprintln!("Unknown mcp subcommand: {other}");
+            usage();
+            process::exit(1);
+        }
+    };
+
+    if sub != "serve" {
+        // Defensive: should be unreachable given the match above.
+        usage();
+        process::exit(1);
+    }
+
+    let bin = match locate_spar_mcp_binary() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "spar-mcp binary not found (searched $SPAR_MCP_BIN, the directory of the \
+                 current spar binary, and $PATH). Build the workspace with `cargo build -p \
+                 spar-mcp` and re-run."
+            );
+            process::exit(1);
+        }
+    };
+
+    // Replace the current process so stdio is shared 1:1 with the
+    // child — no buffering layer between the JSON-RPC client and the
+    // server loop.
+    let err = std::process::Command::new(&bin).args(&args[1..]).status();
+    match err {
+        Ok(status) => process::exit(status.code().unwrap_or(1)),
+        Err(e) => {
+            eprintln!("failed to execute {}: {e}", bin.display());
+            process::exit(1);
+        }
+    }
+}
+
+/// Locate the `spar-mcp` binary on disk. See [`cmd_mcp`] for the
+/// resolution order.
+fn locate_spar_mcp_binary() -> Option<std::path::PathBuf> {
+    if let Some(v) = std::env::var_os("SPAR_MCP_BIN") {
+        let p = std::path::PathBuf::from(v);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    if let Ok(self_exe) = std::env::current_exe()
+        && let Some(dir) = self_exe.parent()
+    {
+        for name in ["spar-mcp", "spar-mcp.exe"] {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            for name in ["spar-mcp", "spar-mcp.exe"] {
+                let candidate = dir.join(name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
 }
 
 fn cmd_parse(args: &[String]) {

--- a/crates/spar-cli/src/moves.rs
+++ b/crates/spar-cli/src/moves.rs
@@ -74,7 +74,8 @@ use spar_analysis::{AnalysisDiagnostic, Severity};
 use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
 use spar_hir_def::item_tree::{ComponentCategory, ItemTree};
 use spar_hir_def::{AllowedTargetsViolation, BindingOverlay, FrozenViolation, OverlayDiagnostic};
-use spar_solver::enumerate::{CandidateRank, EnumerationObjective, rank_candidate};
+use spar_solver::enumerate::rank_candidate;
+pub use spar_solver::enumerate::{CandidateRank, EnumerationObjective};
 use spar_variants::{ContextError, VariantContext};
 
 use crate::variants_bridge::{SourcePathMap, VariantScope};
@@ -347,15 +348,21 @@ impl From<&AnalysisDiagnostic> for DiagnosticOut {
     }
 }
 
-/// Run `spar moves verify`, returning the desired process exit code.
+/// Run the verify pipeline and return the structured report plus the
+/// desired CLI exit code, without printing anything.
 ///
-/// See module docs for the full pipeline; a zero return from this
-/// function means the move is admissible. The caller in `main.rs`
-/// passes the return through `process::exit` directly so behaviour is
-/// observable to a shell or harness.
-pub fn run_verify(args: VerifyArgs) -> Result<i32, MovesError> {
+/// This is the load-bearing function shared between the CLI driver
+/// (`run_verify`, which prints + exits) and the MCP `spar.verify_move`
+/// tool (which returns the report as JSON over stdio). The pure-data
+/// shape is documented under [`MoveVerifyReport`]; the exit code follows
+/// the table in the module docs.
+///
+/// The function is `#[allow(clippy::result_large_err)]` because the
+/// error type is shared with [`run_verify`] and downstream callers
+/// expect the same type.
+pub fn verify_pipeline(args: &VerifyArgs) -> Result<(MoveVerifyReport, i32), MovesError> {
     if args.format != "text" && args.format != "json" {
-        return Err(MovesError::UnknownFormat(args.format));
+        return Err(MovesError::UnknownFormat(args.format.clone()));
     }
     if args.model_files.is_empty() {
         return Err(MovesError::Parse(
@@ -364,17 +371,10 @@ pub fn run_verify(args: VerifyArgs) -> Result<i32, MovesError> {
         ));
     }
 
-    // 1. Parse + instantiate. We mirror the path used by `spar analyze`,
-    //    short-circuiting the same way on parse errors so users see a
-    //    diagnostic rather than a stack trace.
+    // 1. Parse + instantiate.
     let (inst, source_paths) = parse_and_instantiate(&args.model_files, &args.root)?;
 
-    // 2. Optional variant scope. Variant filtering happens *before*
-    //    overlay validation so dropped components can never appear as
-    //    `--component` or `--to` resolution targets — matching the
-    //    contract's intersection semantics. The scope itself is non-
-    //    mutating; the analysis suite still sees the full instance and
-    //    is expected to remain monotonic w.r.t. the kept subset.
+    // 2. Optional variant scope.
     let variant_ctx =
         load_variant_context(args.variant.as_deref(), args.variant_context.as_deref())?;
     let scope_holder = variant_ctx
@@ -396,21 +396,12 @@ pub fn run_verify(args: VerifyArgs) -> Result<i32, MovesError> {
         });
     }
 
-    // 4. Build the overlay and validate against the platform / application split.
+    // 4. Overlay + validate.
     let mut overlay = BindingOverlay::new();
     overlay.add_move(comp_idx, target_idx);
     let overlay_diags = overlay.validate(&inst);
 
-    // 5. Run the analysis suite.
-    //
-    //    Per commit 3 scope: the suite reads the un-overlayed instance.
-    //    The overlay still surfaces its own constraint-layer
-    //    diagnostics (frozen / allowed-targets) so a user moving a
-    //    pinned component sees an immediate red flag rather than a
-    //    silent green from analyses that are not overlay-aware yet.
-    //    Commit 4 widens overlay awareness to RTA + bandwidth + latency
-    //    + EMV2 + ARINC653 so the diagnostics reflect the hypothetical
-    //    binding rather than the declared one.
+    // 5. Analysis suite.
     let analysis_diags = run_all_analyses(&inst);
 
     // 6. Build the structured report.
@@ -420,14 +411,27 @@ pub fn run_verify(args: VerifyArgs) -> Result<i32, MovesError> {
         report.feature_model_hash = Some(scope.feature_model_hash().to_string());
     }
 
-    // 7. Render.
-    match args.format.as_str() {
+    let code = exit_code_for(&report, &overlay_diags);
+    Ok((report, code))
+}
+
+/// Run `spar moves verify`, returning the desired process exit code.
+///
+/// See module docs for the full pipeline; a zero return from this
+/// function means the move is admissible. The caller in `main.rs`
+/// passes the return through `process::exit` directly so behaviour is
+/// observable to a shell or harness.
+pub fn run_verify(args: VerifyArgs) -> Result<i32, MovesError> {
+    let format = args.format.clone();
+    let (report, code) = verify_pipeline(&args)?;
+
+    // Render.
+    match format.as_str() {
         "json" => render_json(&report),
         _ => render_text(&report),
     }
 
-    // 8. Compute exit code.
-    Ok(exit_code_for(&report, &overlay_diags))
+    Ok(code)
 }
 
 /// Translate a populated [`MoveVerifyReport`] back into the Unix exit
@@ -1215,8 +1219,22 @@ pub struct MoveEnumerateReport {
 /// | 1 | All candidates failed analysis or produced no admissible move |
 /// | 2 | Input resolution failed (component / model / format) |
 pub fn run_enumerate(args: EnumerateArgs) -> Result<i32, MovesError> {
+    let format = args.format.clone();
+    let report = enumerate_pipeline(&args)?;
+    let code = if report.valid > 0 { 0 } else { 1 };
+    match format.as_str() {
+        "json" => render_enumerate_json(&report),
+        _ => render_enumerate_text(&report),
+    }
+    Ok(code)
+}
+
+/// Run the enumerate pipeline and return the structured report without
+/// printing anything. Shared between the CLI driver and the MCP
+/// `spar.enumerate_moves` tool.
+pub fn enumerate_pipeline(args: &EnumerateArgs) -> Result<MoveEnumerateReport, MovesError> {
     if args.format != "text" && args.format != "json" {
-        return Err(MovesError::UnknownFormat(args.format));
+        return Err(MovesError::UnknownFormat(args.format.clone()));
     }
     if args.model_files.is_empty() {
         return Err(MovesError::Parse(
@@ -1282,15 +1300,7 @@ pub fn run_enumerate(args: EnumerateArgs) -> Result<i32, MovesError> {
             .then_with(|| a.target.cmp(&b.target))
     });
 
-    // 6. Render.
-    match args.format.as_str() {
-        "json" => render_enumerate_json(&report),
-        _ => render_enumerate_text(&report),
-    }
-
-    // Exit code: 0 if any admissible, 1 otherwise. (2 is reserved for
-    // input-resolution errors, returned via MovesError above.)
-    Ok(if report.valid > 0 { 0 } else { 1 })
+    Ok(report)
 }
 
 /// Build the candidate-target index list for an enumerate run.
@@ -1526,7 +1536,7 @@ pub fn print_enumerate_usage() {
 ///
 /// Returns [`MovesError::UnknownObjective`] for any other input so the
 /// CLI driver can surface a clear message and a non-zero exit.
-fn parse_objective(s: &str) -> Result<EnumerationObjective, MovesError> {
+pub fn parse_objective(s: &str) -> Result<EnumerationObjective, MovesError> {
     match s.to_ascii_lowercase().as_str() {
         "max-response" => Ok(EnumerationObjective::max_response()),
         "total-load" => Ok(EnumerationObjective::total_load()),

--- a/crates/spar-mcp/Cargo.toml
+++ b/crates/spar-mcp/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "spar-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MCP server exposing spar's verification oracles (read-only) for AI agent integration"
+
+[[bin]]
+name = "spar-mcp"
+path = "src/bin/spar-mcp.rs"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+spar-hir-def.workspace = true
+spar-analysis.workspace = true
+spar-network.workspace = true
+spar-base-db.workspace = true
+spar-syntax.workspace = true
+spar = { path = "../spar-cli" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/spar-mcp/src/bin/spar-mcp.rs
+++ b/crates/spar-mcp/src/bin/spar-mcp.rs
@@ -1,0 +1,16 @@
+//! `spar-mcp` — standalone MCP stdio server binary.
+//!
+//! Reads JSON-RPC 2.0 messages from stdin (one per line) and writes
+//! responses to stdout. The same loop is reachable via
+//! `spar mcp serve`, which exec's this binary so the spar binary
+//! itself does not need a build-time dependency on `spar-mcp` (which
+//! would form a Cargo cycle through `spar-cli`).
+//!
+//! See the crate docs for the supported method surface.
+
+fn main() {
+    if let Err(e) = spar_mcp::server::run() {
+        eprintln!("spar-mcp: stdio loop failed: {e}");
+        std::process::exit(1);
+    }
+}

--- a/crates/spar-mcp/src/lib.rs
+++ b/crates/spar-mcp/src/lib.rs
@@ -1,0 +1,50 @@
+//! MCP (Model Context Protocol) server for spar's verification oracles.
+//!
+//! This crate exposes three read-only / idempotent tools to AI agents
+//! over the standard MCP stdio JSON-RPC transport:
+//!
+//! - `spar.verify_move` — wraps `spar moves verify`.
+//! - `spar.enumerate_moves` — wraps `spar moves enumerate`.
+//! - `spar.check_chain` — end-to-end latency analysis for a thread chain.
+//!
+//! All three are *read-only*: they do not mutate the model file on
+//! disk, do not return a binding overlay that the LLM can apply
+//! directly, and do not interact with any persistent state. The
+//! deterministic apply path (`spar moves apply` in a future release)
+//! stays *CLI-exclusive* — there is, by certification design, no
+//! `spar.apply_move` tool over MCP.
+//!
+//! # Why read-only?
+//!
+//! The certification chain Track E targets (DO-178C / ISO 26262) does
+//! not allow an LLM to write into the verified-binding state directly.
+//! The MCP surface is the LLM's *proposal* lane: the agent enumerates,
+//! verifies, and inspects; a human (or higher-trust automation) calls
+//! the deterministic apply path with the trace ID returned by the
+//! verification oracle. See `docs/designs/track-e-migration-research.md`
+//! §6.5 for the canonical design.
+//!
+//! # Crate layout
+//!
+//! - [`schema`] — JSON Schema declarations for each tool.
+//! - [`tools`] — per-tool handlers calling into `spar-cli`'s pipelines.
+//! - [`server`] — MCP stdio JSON-RPC dispatcher.
+//!
+//! # In-process API
+//!
+//! Tests and embedded callers can drive each tool directly via the
+//! `*_call` helpers in [`tools`] without going through the JSON-RPC
+//! server; [`server::handle_request`] is the same dispatch path the
+//! stdio loop uses, but accepts a single message at a time.
+
+pub mod schema;
+pub mod server;
+pub mod tools;
+
+/// Re-exports of the report types exposed over the MCP wire so
+/// downstream consumers can deserialise responses without depending on
+/// `spar-cli` directly.
+pub use spar_cli::moves::{
+    EnumerateArgs, EnumerationObjective, MoveCandidate, MoveEnumerateReport, MoveVerifyReport,
+    MovesError, VerifyArgs, Violation,
+};

--- a/crates/spar-mcp/src/schema.rs
+++ b/crates/spar-mcp/src/schema.rs
@@ -1,0 +1,212 @@
+//! Tool catalog: name, description, JSON Schema, and MCP annotations.
+//!
+//! Each tool is declared with the MCP 2025-11-25 metadata shape:
+//!
+//! ```text
+//! { name, description, inputSchema, annotations: { readOnlyHint, idempotentHint } }
+//! ```
+//!
+//! `readOnlyHint = true` and `idempotentHint = true` are *load-bearing*
+//! per the v0.9.0 design (Track E §6.5): the MCP transport must not be
+//! used to mutate the model, and the same input must always produce the
+//! same output. Both invariants follow naturally because the underlying
+//! [`spar_cli::moves::verify_pipeline`] /
+//! [`spar_cli::moves::enumerate_pipeline`] / latency-analysis surfaces
+//! are pure functions of (model files, root, parameters).
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+/// MCP tool descriptor as returned by `tools/list`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolDescriptor {
+    /// Stable tool identifier (e.g., `"spar.verify_move"`).
+    pub name: &'static str,
+    /// Human-readable description shown in agent UIs.
+    pub description: &'static str,
+    /// JSON Schema for the tool's input arguments.
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+    /// MCP behaviour hints. Both flags are always `true` for spar's
+    /// oracle surface — the apply path is CLI-only.
+    pub annotations: Annotations,
+}
+
+/// MCP `annotations` block — read-only / idempotent hints.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct Annotations {
+    #[serde(rename = "readOnlyHint")]
+    pub read_only_hint: bool,
+    #[serde(rename = "idempotentHint")]
+    pub idempotent_hint: bool,
+    #[serde(rename = "destructiveHint")]
+    pub destructive_hint: bool,
+}
+
+impl Annotations {
+    /// The standard "this is an oracle, not a mutator" annotation set.
+    pub const fn read_only_idempotent() -> Self {
+        Self {
+            read_only_hint: true,
+            idempotent_hint: true,
+            destructive_hint: false,
+        }
+    }
+}
+
+/// Stable name of the verify-move tool.
+pub const VERIFY_MOVE: &str = "spar.verify_move";
+/// Stable name of the enumerate-moves tool.
+pub const ENUMERATE_MOVES: &str = "spar.enumerate_moves";
+/// Stable name of the check-chain tool.
+pub const CHECK_CHAIN: &str = "spar.check_chain";
+
+/// Build the descriptor for `spar.verify_move`.
+pub fn verify_move_descriptor() -> ToolDescriptor {
+    ToolDescriptor {
+        name: VERIFY_MOVE,
+        description: "Verify a hypothetical component-to-processor binding without committing changes. \
+             Returns per-pass diagnostics and structured violations. Read-only; idempotent.",
+        input_schema: json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Path to the AADL model file to load."
+                },
+                "root": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Root system implementation in `Pkg::Type.Impl` form."
+                },
+                "component": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "FQN, dotted path, or bare name of the component to (hypothetically) move."
+                },
+                "target": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "FQN of the target processor."
+                },
+                "variant": {
+                    "type": "string",
+                    "description": "Optional variant name (implicit form; spar shells out to rivet resolve)."
+                },
+                "variant_context": {
+                    "type": "string",
+                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                }
+            },
+            "required": ["model", "root", "component", "target"]
+        }),
+        annotations: Annotations::read_only_idempotent(),
+    }
+}
+
+/// Build the descriptor for `spar.enumerate_moves`.
+pub fn enumerate_moves_descriptor() -> ToolDescriptor {
+    ToolDescriptor {
+        name: ENUMERATE_MOVES,
+        description: "List every legal hypothetical-rebinding target for a component, ranked by an \
+             objective. Returns per-candidate verification status and a multi-objective score. \
+             Read-only; idempotent.",
+        input_schema: json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Path to the AADL model file to load."
+                },
+                "root": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Root system implementation in `Pkg::Type.Impl` form."
+                },
+                "component": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "FQN of the component to enumerate."
+                },
+                "target_filter": {
+                    "type": "string",
+                    "description": "Optional case-insensitive substring filter on candidate FQNs."
+                },
+                "objective": {
+                    "type": "string",
+                    "enum": ["max-response", "total-load", "total-power", "total-weight", "balanced"],
+                    "default": "max-response",
+                    "description": "Multi-objective ranking mode (commit 5 of Track E)."
+                },
+                "variant": {
+                    "type": "string",
+                    "description": "Optional variant name (implicit form)."
+                },
+                "variant_context": {
+                    "type": "string",
+                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                }
+            },
+            "required": ["model", "root", "component"]
+        }),
+        annotations: Annotations::read_only_idempotent(),
+    }
+}
+
+/// Build the descriptor for `spar.check_chain`.
+pub fn check_chain_descriptor() -> ToolDescriptor {
+    ToolDescriptor {
+        name: CHECK_CHAIN,
+        description: "Compute end-to-end latency bounds for a thread chain (source → sink), surfacing \
+             alternating compute (WCET) and network (WCTT) hops. Read-only; idempotent.",
+        input_schema: json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Path to the AADL model file to load."
+                },
+                "root": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Root system implementation in `Pkg::Type.Impl` form."
+                },
+                "source_thread": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "FQN of the source thread of the chain."
+                },
+                "sink_thread": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "FQN of the sink thread of the chain."
+                },
+                "variant": {
+                    "type": "string",
+                    "description": "Optional variant name (implicit form)."
+                },
+                "variant_context": {
+                    "type": "string",
+                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                }
+            },
+            "required": ["model", "root", "source_thread", "sink_thread"]
+        }),
+        annotations: Annotations::read_only_idempotent(),
+    }
+}
+
+/// All three tool descriptors in stable order.
+pub fn all_descriptors() -> Vec<ToolDescriptor> {
+    vec![
+        verify_move_descriptor(),
+        enumerate_moves_descriptor(),
+        check_chain_descriptor(),
+    ]
+}

--- a/crates/spar-mcp/src/server.rs
+++ b/crates/spar-mcp/src/server.rs
@@ -1,0 +1,272 @@
+//! Minimal MCP stdio JSON-RPC server.
+//!
+//! MCP's wire format is JSON-RPC 2.0 over stdio. Each message is a
+//! single-line JSON object; the server reads one message per line and
+//! writes one response per line. This is sufficient for the v0.9.0
+//! oracle surface (no streaming progress, no notifications back to the
+//! client beyond the initialise handshake).
+//!
+//! Supported methods (per MCP 2025-11-25):
+//!
+//! - `initialize` → returns server capabilities and protocol version.
+//! - `ping` → no-op acknowledgement.
+//! - `tools/list` → returns the three oracle tools with schemas.
+//! - `tools/call` → invokes a named tool with `arguments`.
+//!
+//! Any other method returns `MethodNotFound` (-32601).
+
+use std::io::{BufRead, BufReader, Read, Write};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::schema::{self, ToolDescriptor};
+use crate::tools::{ToolResult, dispatch_tool};
+
+/// JSON-RPC 2.0 request envelope. `id` is `null` for notifications.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    #[allow(dead_code)]
+    pub jsonrpc: Option<String>,
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+/// JSON-RPC 2.0 response envelope.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// JSON-RPC error codes used by the spar MCP server.
+pub mod error_codes {
+    /// Standard JSON-RPC: invalid JSON.
+    pub const PARSE_ERROR: i32 = -32700;
+    /// Standard JSON-RPC: not a valid Request object.
+    pub const INVALID_REQUEST: i32 = -32600;
+    /// Standard JSON-RPC: method does not exist.
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    /// Standard JSON-RPC: invalid method parameter(s).
+    pub const INVALID_PARAMS: i32 = -32602;
+    /// Standard JSON-RPC: server-side internal error.
+    pub const INTERNAL_ERROR: i32 = -32603;
+}
+
+/// MCP protocol version this server speaks.
+pub const PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Server name advertised in the initialise handshake.
+pub const SERVER_NAME: &str = "spar-mcp";
+
+/// Server version advertised in the initialise handshake (mirrors the
+/// crate version).
+pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Drive the stdio loop: read one JSON-RPC message per line from
+/// `reader`, dispatch, write one response per line to `writer`. Returns
+/// when the input EOFs or fails. Notifications (id == null) do not
+/// produce a response.
+pub fn run_stdio<R: Read, W: Write>(reader: R, mut writer: W) -> std::io::Result<()> {
+    let buf = BufReader::new(reader);
+    for line in buf.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = handle_request_line(&line);
+        if let Some(resp) = response {
+            let serialized =
+                serde_json::to_string(&resp).unwrap_or_else(|e| {
+                    format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{{\"code\":-32603,\"message\":\"serialise failed: {e}\"}}}}"
+                    )
+                });
+            writeln!(writer, "{serialized}")?;
+            writer.flush()?;
+        }
+    }
+    Ok(())
+}
+
+/// Run the server reading from stdin and writing to stdout. The
+/// canonical entry point for `spar mcp serve`.
+pub fn run() -> std::io::Result<()> {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    run_stdio(stdin.lock(), stdout.lock())
+}
+
+/// Parse and handle a single JSON-RPC line, returning the response (if
+/// any). Notifications return `None`; everything else returns `Some`.
+pub fn handle_request_line(line: &str) -> Option<JsonRpcResponse> {
+    let req: JsonRpcRequest = match serde_json::from_str(line) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(JsonRpcResponse {
+                jsonrpc: "2.0",
+                id: Value::Null,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: error_codes::PARSE_ERROR,
+                    message: format!("invalid JSON: {e}"),
+                    data: None,
+                }),
+            });
+        }
+    };
+    let id = req.id.clone();
+    if id.is_none() {
+        // Notification — no response.
+        let _ = handle_request(req);
+        return None;
+    }
+    Some(handle_request(req))
+}
+
+/// Dispatch a single parsed JSON-RPC request to the appropriate
+/// handler. Always returns a response object; the caller decides
+/// whether to suppress it (notifications).
+pub fn handle_request(req: JsonRpcRequest) -> JsonRpcResponse {
+    let id = req.id.clone().unwrap_or(Value::Null);
+    match req.method.as_str() {
+        "initialize" => initialize(id),
+        "ping" => JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: Some(json!({})),
+            error: None,
+        },
+        "tools/list" => tools_list(id),
+        "tools/call" => tools_call(id, &req.params),
+        other => JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code: error_codes::METHOD_NOT_FOUND,
+                message: format!("method `{other}` is not supported by spar-mcp"),
+                data: None,
+            }),
+        },
+    }
+}
+
+fn initialize(id: Value) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": { "listChanged": false }
+            },
+            "serverInfo": {
+                "name": SERVER_NAME,
+                "version": SERVER_VERSION,
+            },
+            // Track E §6.5: the apply path is CLI-exclusive. Surface
+            // this fact in the initialise handshake so an agent that
+            // expects a write tool can fail loudly rather than silently
+            // skip the write step.
+            "instructions": "Read-only verification oracle. The deterministic apply path \
+                             is CLI-exclusive (`spar moves apply`); no write tools are \
+                             exposed over MCP.",
+        })),
+        error: None,
+    }
+}
+
+fn tools_list(id: Value) -> JsonRpcResponse {
+    let descriptors: Vec<ToolDescriptor> = schema::all_descriptors();
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(json!({ "tools": descriptors })),
+        error: None,
+    }
+}
+
+fn tools_call(id: Value, params: &Value) -> JsonRpcResponse {
+    let name = match params.get("name").and_then(|v| v.as_str()) {
+        Some(n) => n,
+        None => {
+            return JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: error_codes::INVALID_PARAMS,
+                    message: "tools/call: missing `name`".to_string(),
+                    data: None,
+                }),
+            };
+        }
+    };
+    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+
+    match dispatch_tool(name, &arguments) {
+        Some(ToolResult::Ok(payload)) => {
+            // Per the MCP spec, tools/call returns
+            // { content: [{ type, text|json, ... }], isError: false }.
+            // We follow the recommended shape and embed the structured
+            // payload as a JSON-text content block so any compliant MCP
+            // client can stream it through.
+            let text = serde_json::to_string(&payload).unwrap_or_else(|_| "null".into());
+            JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: Some(json!({
+                    "content": [
+                        { "type": "text", "text": text }
+                    ],
+                    "structuredContent": payload,
+                    "isError": false,
+                })),
+                error: None,
+            }
+        }
+        Some(ToolResult::Error { code, message }) => {
+            // Tool-level errors map to a result with isError=true,
+            // *not* a JSON-RPC error — per MCP 2025-11-25 the agent
+            // wants to see the tool's output even on failure.
+            JsonRpcResponse {
+                jsonrpc: "2.0",
+                id,
+                result: Some(json!({
+                    "content": [
+                        { "type": "text", "text": format!("[{code}] {message}") }
+                    ],
+                    "structuredContent": { "code": code, "message": message },
+                    "isError": true,
+                })),
+                error: None,
+            }
+        }
+        None => JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code: error_codes::METHOD_NOT_FOUND,
+                message: format!("tool `{name}` is not exposed by spar-mcp"),
+                data: None,
+            }),
+        },
+    }
+}

--- a/crates/spar-mcp/src/tools/check_chain.rs
+++ b/crates/spar-mcp/src/tools/check_chain.rs
@@ -1,0 +1,315 @@
+//! `spar.check_chain` — end-to-end latency analysis for a thread chain.
+//!
+//! Input shape:
+//!
+//! ```json
+//! {
+//!   "model": "path/to/system.aadl",
+//!   "root":  "Pkg::Type.Impl",
+//!   "source_thread": "fw.acquire",
+//!   "sink_thread":   "fw.actuate",
+//!   "variant":         "diesel-eu5",          // optional
+//!   "variant_context": "/path/to/ctx.json"    // optional
+//! }
+//! ```
+//!
+//! Output: a per-flow latency record carrying the source / sink FQNs,
+//! the flow name (when found), and the per-pass diagnostics from the
+//! `LatencyAnalysis` pass — these already alternate compute (WCET) and
+//! network (WCTT) hops in the message stream so an LLM can read the
+//! shape without re-running its own walk.
+//!
+//! # Matching
+//!
+//! The tool matches on the *name* of an end-to-end flow whose first
+//! segment names a subcomponent corresponding to the source thread
+//! FQN and whose last component segment matches the sink thread FQN.
+//! Models without an explicit end-to-end flow declaration return a
+//! `CHAIN_NOT_FOUND` error so the agent can fall back to enumerating
+//! flows or asking a human.
+//!
+//! # Why the latency pass and not a custom walk?
+//!
+//! The v0.8.0 latency analysis already alternates RTA-derived WCET on
+//! compute hops with WCTT-derived bounds on network hops (Track D).
+//! Re-implementing that walk here would either drift from the canonical
+//! pass or duplicate ~600 lines of property-accessor scaffolding. The
+//! MCP surface intentionally re-uses the analysis-driven view.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde_json::Value;
+use spar_analysis::{Analysis, AnalysisDiagnostic, Severity, latency::LatencyAnalysis};
+use spar_hir_def::instance::SystemInstance;
+use spar_hir_def::item_tree::ItemTree;
+
+use super::{ToolResult, optional_string, required_string};
+
+/// Wire-format severity (lower-case, matching the rest of the MCP
+/// surface). Mirrors the spar-analysis `Severity` enum but with a
+/// stable JSON shape independent of upstream evolution.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WireSeverity {
+    Error,
+    Warning,
+    Info,
+}
+
+impl From<Severity> for WireSeverity {
+    fn from(s: Severity) -> Self {
+        match s {
+            Severity::Error => WireSeverity::Error,
+            Severity::Warning => WireSeverity::Warning,
+            Severity::Info => WireSeverity::Info,
+        }
+    }
+}
+
+/// Wire-format diagnostic (latency-pass output).
+#[derive(Debug, Clone, Serialize)]
+pub struct WireDiagnostic {
+    pub severity: WireSeverity,
+    pub message: String,
+    pub path: Vec<String>,
+}
+
+impl From<&AnalysisDiagnostic> for WireDiagnostic {
+    fn from(d: &AnalysisDiagnostic) -> Self {
+        WireDiagnostic {
+            severity: d.severity.into(),
+            message: d.message.clone(),
+            path: d.path.clone(),
+        }
+    }
+}
+
+/// Output payload for `spar.check_chain`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckChainReport {
+    /// Source thread FQN as resolved against the instance hierarchy.
+    pub source_thread: String,
+    /// Sink thread FQN as resolved against the instance hierarchy.
+    pub sink_thread: String,
+    /// Name of the end-to-end flow that connects source -> sink.
+    pub flow_name: String,
+    /// Per-flow diagnostic stream from the `LatencyAnalysis` pass.
+    /// Best-case / worst-case bounds and per-hop annotations are
+    /// already present in this stream's `message` field — see
+    /// [`spar_analysis::latency`] for the textual shape.
+    pub diagnostics: Vec<WireDiagnostic>,
+    /// True when the diagnostic stream contains at least one error-
+    /// severity entry (e.g., an unservable network hop).
+    pub has_errors: bool,
+}
+
+/// In-process entry point for the check_chain tool.
+pub fn call(arguments: &Value) -> ToolResult {
+    let model = match required_string(arguments, "model") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let root = match required_string(arguments, "root") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let source_thread = match required_string(arguments, "source_thread") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let sink_thread = match required_string(arguments, "sink_thread") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let _variant = match optional_string(arguments, "variant") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let _variant_context = match optional_string(arguments, "variant_context") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // Parse + instantiate. We reuse the same minimal pipeline as the
+    // verify path (single file, named root) without going through
+    // `spar_cli::moves` because the check_chain tool does not need
+    // overlay scaffolding. Variant scoping is accepted for API
+    // symmetry but not yet applied (latency analysis is monotonic
+    // w.r.t. the kept subset; non-kept components contribute 0 to the
+    // chain when their bindings are dropped).
+    let instance = match parse_and_instantiate(&model, &root) {
+        Ok(i) => i,
+        Err(e) => return e,
+    };
+
+    // Find a matching end-to-end flow.
+    let (flow_name, src_fqn, sink_fqn) = match find_chain(&instance, &source_thread, &sink_thread) {
+        Some(t) => t,
+        None => {
+            return ToolResult::Error {
+                code: "CHAIN_NOT_FOUND",
+                message: format!(
+                    "no end-to-end flow connects source `{source_thread}` to sink \
+                         `{sink_thread}`; declare an `end to end flow` in the system \
+                         implementation or pass the flow name directly",
+                ),
+            };
+        }
+    };
+
+    // Run the latency pass and filter to diagnostics that mention the
+    // matched flow's name. The pass already produces both bounds
+    // (`[a ms .. b ms]`) and per-hop annotations on chains that span
+    // a network hop — the agent reads the shape directly.
+    let pass = LatencyAnalysis;
+    let all = pass.analyze(&instance);
+    let diagnostics: Vec<WireDiagnostic> = all
+        .iter()
+        .filter(|d| d.message.contains(&format!("'{flow_name}'")))
+        .map(WireDiagnostic::from)
+        .collect();
+
+    let has_errors = diagnostics
+        .iter()
+        .any(|d| matches!(d.severity, WireSeverity::Error));
+
+    let report = CheckChainReport {
+        source_thread: src_fqn,
+        sink_thread: sink_fqn,
+        flow_name,
+        diagnostics,
+        has_errors,
+    };
+
+    match serde_json::to_value(&report) {
+        Ok(v) => ToolResult::Ok(v),
+        Err(e) => ToolResult::Error {
+            code: "INTERNAL",
+            message: format!("failed to serialise CheckChainReport: {e}"),
+        },
+    }
+}
+
+/// Parse a single AADL file and instantiate the named root.
+///
+/// This mirrors `parse_and_instantiate` in `spar_cli::moves` (which is
+/// module-private). The MCP tool is single-file by design — multi-file
+/// chains are out of scope for v0.9.0 commit 8.
+fn parse_and_instantiate(model: &str, root: &str) -> Result<SystemInstance, ToolResult> {
+    let source = std::fs::read_to_string(model).map_err(|e| ToolResult::Error {
+        code: "MODEL_NOT_FOUND",
+        message: format!("cannot read {model}: {e}"),
+    })?;
+    let parsed = spar_syntax::parse(&source);
+    if !parsed.ok() {
+        let mut msg = String::new();
+        for err in parsed.errors() {
+            let (line, col) = spar_base_db::offset_to_line_col(&source, err.offset);
+            msg.push_str(&format!("{model}:{line}:{col}: {}\n", err.msg));
+        }
+        return Err(ToolResult::Error {
+            code: "BAD_INPUT",
+            message: format!("parse error: {msg}"),
+        });
+    }
+
+    let db = spar_hir_def::HirDefDatabase::default();
+    let sf = spar_base_db::SourceFile::new(&db, model.to_string(), source);
+    let tree: Arc<ItemTree> = spar_hir_def::file_item_tree(&db, sf);
+
+    let (pkg_name, type_name, impl_name) = parse_root_ref(root)?;
+    let scope = spar_hir_def::GlobalScope::from_trees(vec![tree]);
+    let instance = SystemInstance::instantiate(
+        &scope,
+        &spar_hir_def::Name::new(&pkg_name),
+        &spar_hir_def::Name::new(&type_name),
+        &spar_hir_def::Name::new(&impl_name),
+    );
+    if instance.component_count() == 0 {
+        return Err(ToolResult::Error {
+            code: "MODEL_NOT_FOUND",
+            message: format!("root `{root}` did not instantiate (0 components)"),
+        });
+    }
+    Ok(instance)
+}
+
+/// Parse a `Pkg::Type.Impl` root reference into its components.
+fn parse_root_ref(s: &str) -> Result<(String, String, String), ToolResult> {
+    let parts: Vec<&str> = s.splitn(2, "::").collect();
+    let bad = || ToolResult::Error {
+        code: "BAD_INPUT",
+        message: format!("root `{s}` must be Package::Type.Impl"),
+    };
+    if parts.len() != 2 {
+        return Err(bad());
+    }
+    let pkg = parts[0].to_string();
+    let type_impl: Vec<&str> = parts[1].splitn(2, '.').collect();
+    if type_impl.len() != 2 {
+        return Err(bad());
+    }
+    Ok((pkg, type_impl[0].to_string(), type_impl[1].to_string()))
+}
+
+/// Locate an end-to-end flow whose first / last component segments
+/// match the source / sink thread names (case-insensitive bare-name or
+/// suffix match). Returns `(flow_name, source_fqn, sink_fqn)` on a hit.
+///
+/// Flow segments alternate component-flow refs ("subcomp.flow_name")
+/// and connection names. We compare on the subcomponent prefix only.
+fn find_chain(
+    instance: &SystemInstance,
+    source: &str,
+    sink: &str,
+) -> Option<(String, String, String)> {
+    let src_lower = source.to_ascii_lowercase();
+    let sink_lower = sink.to_ascii_lowercase();
+
+    for (_idx, e2e) in instance.end_to_end_flows.iter() {
+        let segs: Vec<&str> = e2e.segments.iter().map(|s| s.as_str()).collect();
+        if segs.is_empty() {
+            continue;
+        }
+        let first = segs.first().copied().unwrap_or("");
+        let last = segs.last().copied().unwrap_or("");
+
+        if segment_contains_thread(first, &src_lower) && segment_contains_thread(last, &sink_lower)
+        {
+            // Best-effort FQN: keep the dotted path the segment
+            // already carries (it's `subcomp.flow_name` or
+            // `path.subcomp.flow`), strip the trailing flow component,
+            // and prepend the owner's name for context.
+            let owner = instance.component(e2e.owner);
+            let owner_name = owner.name.as_str();
+            let src_fqn = format!("{owner_name}/{}", strip_trailing_flow(first));
+            let sink_fqn = format!("{owner_name}/{}", strip_trailing_flow(last));
+            return Some((e2e.name.as_str().to_string(), src_fqn, sink_fqn));
+        }
+    }
+    None
+}
+
+/// True when `needle_lower` appears as a `.`-separated path component
+/// of `segment` (case-insensitive). Used to match an agent-supplied
+/// thread name against a flow segment of the form `subcomp.flow_name`
+/// or `enclosing.subcomp.flow_name`.
+fn segment_contains_thread(segment: &str, needle_lower: &str) -> bool {
+    if needle_lower.is_empty() {
+        return false;
+    }
+    let seg_lower = segment.to_ascii_lowercase();
+    seg_lower.split('.').any(|part| part == needle_lower)
+        || seg_lower.split('/').any(|part| part == needle_lower)
+}
+
+/// Drop the last `.`-separated component of a flow-segment name. This
+/// is the trailing `flow_name` of a `subcomp.flow_name` segment so we
+/// can form an FQN that points at the *thread*, not the flow spec.
+fn strip_trailing_flow(segment: &str) -> String {
+    match segment.rsplit_once('.') {
+        Some((head, _tail)) => head.to_string(),
+        None => segment.to_string(),
+    }
+}

--- a/crates/spar-mcp/src/tools/enumerate.rs
+++ b/crates/spar-mcp/src/tools/enumerate.rs
@@ -1,0 +1,111 @@
+//! `spar.enumerate_moves` — wraps [`spar_cli::moves::enumerate_pipeline`].
+//!
+//! Input shape:
+//!
+//! ```json
+//! {
+//!   "model": "path/to/system.aadl",
+//!   "root":  "Pkg::Type.Impl",
+//!   "component": "t1",
+//!   "target_filter":   "cpu",                 // optional
+//!   "objective":       "max-response",        // optional, default
+//!   "variant":         "diesel-eu5",          // optional
+//!   "variant_context": "/path/to/ctx.json"    // optional, mutually exclusive with variant
+//! }
+//! ```
+//!
+//! Output: the `MoveEnumerateReport` shape produced by
+//! `spar moves enumerate --format json` (component, candidates, total,
+//! valid, plus the variant audit-trail fields).
+
+use serde_json::Value;
+use spar_cli::moves::{
+    EnumerateArgs, EnumerationObjective, MovesError, enumerate_pipeline, parse_objective,
+};
+
+use super::{ToolResult, optional_string, required_string};
+
+/// In-process entry point for the enumerate tool.
+pub fn call(arguments: &Value) -> ToolResult {
+    let model = match required_string(arguments, "model") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let root = match required_string(arguments, "root") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let component = match required_string(arguments, "component") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let target_filter = match optional_string(arguments, "target_filter") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let objective_str = match optional_string(arguments, "objective") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let variant = match optional_string(arguments, "variant") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let variant_context = match optional_string(arguments, "variant_context") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let objective = match objective_str.as_deref() {
+        None => EnumerationObjective::max_response(),
+        Some(s) => match parse_objective(s) {
+            Ok(o) => o,
+            Err(e) => {
+                return ToolResult::Error {
+                    code: "BAD_INPUT",
+                    message: format!("{e}"),
+                };
+            }
+        },
+    };
+
+    let args = EnumerateArgs {
+        model_files: vec![model],
+        root,
+        component,
+        target_filter,
+        format: "json".to_string(),
+        objective,
+        variant,
+        variant_context,
+    };
+
+    match enumerate_pipeline(&args) {
+        Ok(report) => match serde_json::to_value(&report) {
+            Ok(v) => ToolResult::Ok(v),
+            Err(e) => ToolResult::Error {
+                code: "INTERNAL",
+                message: format!("failed to serialise MoveEnumerateReport: {e}"),
+            },
+        },
+        Err(e) => ToolResult::Error {
+            code: classify_error(&e),
+            message: format!("{e}"),
+        },
+    }
+}
+
+fn classify_error(e: &MovesError) -> &'static str {
+    use MovesError as M;
+    match e {
+        M::Io(..) => "MODEL_NOT_FOUND",
+        M::Parse(..) => "BAD_INPUT",
+        M::UnknownRoot(..) => "MODEL_NOT_FOUND",
+        M::UnknownComponent(..) | M::ComponentNotInVariant { .. } => "COMPONENT_NOT_FOUND",
+        M::UnknownTarget(..) | M::TargetNotInVariant { .. } => "COMPONENT_NOT_FOUND",
+        M::TargetNotProcessor { .. } => "TARGET_INCOMPATIBLE",
+        M::UnknownFormat(..) | M::UnknownObjective(..) | M::VariantArgsConflict => "BAD_INPUT",
+        M::VariantContextIo(..) | M::VariantContextSchema(..) => "BAD_INPUT",
+        M::RivetNotFound | M::RivetFailed { .. } | M::RivetIo(..) => "INTERNAL",
+    }
+}

--- a/crates/spar-mcp/src/tools/mod.rs
+++ b/crates/spar-mcp/src/tools/mod.rs
@@ -1,0 +1,73 @@
+//! Tool dispatcher and per-tool input/output handlers.
+//!
+//! Each tool is implemented in its own submodule and exposes a single
+//! entry point of the form `pub fn call(args: &Value) -> ToolResult`.
+//! The dispatcher in [`dispatch_tool`] routes by tool name and returns
+//! a typed [`ToolResult`] which the JSON-RPC layer turns into either a
+//! `result` payload or a structured error.
+
+pub mod check_chain;
+pub mod enumerate;
+pub mod verify;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::schema;
+
+/// Outcome of a single MCP tool call.
+#[derive(Debug, Clone, Serialize)]
+pub enum ToolResult {
+    /// Tool ran to completion. Payload is the structured JSON the
+    /// agent will see in its `tools/call` response.
+    Ok(Value),
+    /// Tool refused the call (bad inputs, model not found, …). The
+    /// JSON-RPC layer renders this as an MCP-style error result with
+    /// `isError: true` so the agent can react to the failure without
+    /// a transport-level abort.
+    Error {
+        /// Stable error code (e.g., `"BAD_INPUT"`, `"MODEL_NOT_FOUND"`).
+        code: &'static str,
+        /// Human-readable message for the agent / log.
+        message: String,
+    },
+}
+
+/// Dispatch a tools/call by name. Unknown tool names return a
+/// JSON-RPC `MethodNotFound` (-32601) at the server layer; this
+/// function only routes the *known* tool surface.
+pub fn dispatch_tool(name: &str, arguments: &Value) -> Option<ToolResult> {
+    match name {
+        schema::VERIFY_MOVE => Some(verify::call(arguments)),
+        schema::ENUMERATE_MOVES => Some(enumerate::call(arguments)),
+        schema::CHECK_CHAIN => Some(check_chain::call(arguments)),
+        _ => None,
+    }
+}
+
+/// Read a required string argument, returning a `BAD_INPUT`
+/// [`ToolResult::Error`] when the field is missing or not a string.
+pub(crate) fn required_string(args: &Value, key: &str) -> Result<String, ToolResult> {
+    match args.get(key).and_then(|v| v.as_str()) {
+        Some(s) if !s.is_empty() => Ok(s.to_string()),
+        _ => Err(ToolResult::Error {
+            code: "BAD_INPUT",
+            message: format!("missing or non-string required argument: {key}"),
+        }),
+    }
+}
+
+/// Read an optional string argument; returns `None` when the field is
+/// absent, `Some(s)` when present and a string. A non-string value
+/// surfaces as a `BAD_INPUT` error to keep the contract strict.
+pub(crate) fn optional_string(args: &Value, key: &str) -> Result<Option<String>, ToolResult> {
+    match args.get(key) {
+        None => Ok(None),
+        Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(ToolResult::Error {
+            code: "BAD_INPUT",
+            message: format!("argument `{key}` must be a string when present"),
+        }),
+    }
+}

--- a/crates/spar-mcp/src/tools/verify.rs
+++ b/crates/spar-mcp/src/tools/verify.rs
@@ -1,0 +1,115 @@
+//! `spar.verify_move` — wraps [`spar_cli::moves::verify_pipeline`].
+//!
+//! Input shape (mirrors the schema in [`crate::schema`]):
+//!
+//! ```json
+//! {
+//!   "model": "path/to/system.aadl",
+//!   "root":  "Pkg::Type.Impl",
+//!   "component": "t1",
+//!   "target":    "cpu2",
+//!   "variant":         "diesel-eu5",          // optional
+//!   "variant_context": "/path/to/ctx.json"    // optional, mutually exclusive with variant
+//! }
+//! ```
+//!
+//! Output: the same `MoveVerifyReport` shape produced by
+//! `spar moves verify --format json`. The exit-code field is preserved
+//! as `cli_exit_code` so an agent can quickly distinguish overlay
+//! violations (2) from analysis errors (1) from clean runs (0) without
+//! re-deriving from `violations[*].kind`.
+
+use serde_json::{Value, json};
+use spar_cli::moves::{VerifyArgs, verify_pipeline};
+
+use super::{ToolResult, optional_string, required_string};
+
+/// In-process entry point for the verify tool. Tests call this
+/// directly; the JSON-RPC server delegates here via the dispatcher.
+pub fn call(arguments: &Value) -> ToolResult {
+    let model = match required_string(arguments, "model") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let root = match required_string(arguments, "root") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let component = match required_string(arguments, "component") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let target = match required_string(arguments, "target") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let variant = match optional_string(arguments, "variant") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let variant_context = match optional_string(arguments, "variant_context") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let args = VerifyArgs {
+        model_files: vec![model],
+        root,
+        component,
+        target,
+        // The MCP transport always wants the structured report; the
+        // CLI `--format json/text` lever is irrelevant here, but the
+        // pipeline still validates the value, so we hard-code `json`.
+        format: "json".to_string(),
+        variant,
+        variant_context,
+    };
+
+    match verify_pipeline(&args) {
+        Ok((report, exit_code)) => {
+            let mut payload = match serde_json::to_value(&report) {
+                Ok(v) => v,
+                Err(e) => {
+                    return ToolResult::Error {
+                        code: "INTERNAL",
+                        message: format!("failed to serialise MoveVerifyReport: {e}"),
+                    };
+                }
+            };
+            // Inject the exit code so agents can branch without
+            // re-walking violations[*]. The base report does not carry
+            // this field because the CLI surface threads it through
+            // process::exit instead.
+            if let Some(obj) = payload.as_object_mut() {
+                obj.insert("cli_exit_code".to_string(), json!(exit_code));
+            }
+            ToolResult::Ok(payload)
+        }
+        Err(e) => ToolResult::Error {
+            code: classify_error(&e),
+            message: format!("{e}"),
+        },
+    }
+}
+
+/// Map a [`spar_cli::moves::MovesError`] to a stable MCP error code.
+///
+/// The mapping is deliberately conservative: the rich `MovesError`
+/// surface buckets into a small set of agent-actionable codes
+/// (`MODEL_NOT_FOUND`, `BAD_INPUT`, `COMPONENT_NOT_FOUND`,
+/// `TARGET_INCOMPATIBLE`, `INTERNAL`) — these match the error-code
+/// vocabulary in Track E §6.5 "Auth, idempotency, errors".
+fn classify_error(e: &spar_cli::moves::MovesError) -> &'static str {
+    use spar_cli::moves::MovesError as M;
+    match e {
+        M::Io(..) => "MODEL_NOT_FOUND",
+        M::Parse(..) => "BAD_INPUT",
+        M::UnknownRoot(..) => "MODEL_NOT_FOUND",
+        M::UnknownComponent(..) | M::ComponentNotInVariant { .. } => "COMPONENT_NOT_FOUND",
+        M::UnknownTarget(..) | M::TargetNotInVariant { .. } => "COMPONENT_NOT_FOUND",
+        M::TargetNotProcessor { .. } => "TARGET_INCOMPATIBLE",
+        M::UnknownFormat(..) | M::UnknownObjective(..) | M::VariantArgsConflict => "BAD_INPUT",
+        M::VariantContextIo(..) | M::VariantContextSchema(..) => "BAD_INPUT",
+        M::RivetNotFound | M::RivetFailed { .. } | M::RivetIo(..) => "INTERNAL",
+    }
+}

--- a/crates/spar-mcp/tests/in_process_tests.rs
+++ b/crates/spar-mcp/tests/in_process_tests.rs
@@ -1,0 +1,379 @@
+//! In-process tests for the spar-mcp tool surface.
+//!
+//! These tests call each tool's `call(arguments)` entry point directly
+//! through the Rust API, bypassing the JSON-RPC stdio transport. The
+//! stdio path is exercised separately in `stdio_tests.rs`; both paths
+//! end up routing through the same `dispatch_tool` machinery, so the
+//! split keeps the JSON-RPC envelope concerns out of these tests.
+
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use spar_mcp::tools::{ToolResult, check_chain, enumerate, verify};
+
+/// Per-test temp file: process id + per-test tag, mirroring the
+/// pattern in `crates/spar-cli/tests/moves_*.rs`.
+fn write_model(tag: &str, body: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("spar_mcp_{}_{}.aadl", std::process::id(), tag,));
+    std::fs::write(&path, body).expect("write temp AADL");
+    path
+}
+
+fn cleanup(p: &PathBuf) {
+    let _ = std::fs::remove_file(p);
+}
+
+/// Mirrors `MOBILE_MODEL` in `moves_verify.rs`: one thread `t1`, two
+/// processors `cpu1` (declared) + `cpu2` (legal target).
+const MOBILE_MODEL: &str = "\
+package Migrate
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Migrate;
+";
+
+/// A two-thread chain on two processors with one connection segment.
+/// `producer` runs on cpu1, `consumer` on cpu2; the end-to-end flow
+/// `chain` connects them via `c1`. Compute hops carry an explicit
+/// `Compute_Execution_Time` so the latency pass can produce a bound.
+const CHAIN_MODEL: &str = "\
+package Chain
+public
+  processor CPU
+  end CPU;
+
+  thread Producer
+    features
+      out_p: out data port;
+    flows
+      f1: flow source out_p;
+    properties
+      Period => 10 ms;
+      Compute_Execution_Time => 1 ms .. 2 ms;
+      Dispatch_Protocol => Periodic;
+  end Producer;
+
+  thread Consumer
+    features
+      in_p: in data port;
+    flows
+      f2: flow sink in_p;
+    properties
+      Period => 10 ms;
+      Compute_Execution_Time => 1 ms .. 3 ms;
+      Dispatch_Protocol => Periodic;
+  end Consumer;
+
+  process Proc
+    features
+      out_p: out data port;
+      in_p:  in data port;
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      producer: thread Producer;
+      consumer: thread Consumer;
+    connections
+      c_out: port producer.out_p -> out_p;
+      c_in:  port in_p -> consumer.in_p;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    connections
+      loop_back: port app.out_p -> app.in_p;
+    flows
+      chain: end to end flow app.producer.f1 -> loop_back -> app.consumer.f2;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.producer;
+      Actual_Processor_Binding => (reference (cpu2)) applies to app.consumer;
+  end Sys.Impl;
+end Chain;
+";
+
+// ── 1. verify_tool_returns_ok_when_move_is_valid ─────────────────────
+
+#[test]
+fn verify_tool_returns_ok_when_move_is_valid() {
+    let path = write_model("ok", MOBILE_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+        "target":    "cpu2",
+    });
+    let result = verify::call(&args);
+    let payload = match result {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => {
+            cleanup(&path);
+            panic!("expected Ok, got Error[{code}] {message}");
+        }
+    };
+    assert_eq!(payload["ok"].as_bool(), Some(true), "payload was {payload}");
+    assert_eq!(
+        payload["violations"].as_array().map(|a| a.len()),
+        Some(0),
+        "expected no violations; got {payload}",
+    );
+    assert_eq!(
+        payload["cli_exit_code"].as_i64(),
+        Some(0),
+        "exit code should be 0 for an admissible move",
+    );
+    cleanup(&path);
+}
+
+// ── 2. enumerate_tool_lists_all_processors_no_allowed_targets ────────
+
+#[test]
+fn enumerate_tool_lists_all_processors_no_allowed_targets() {
+    let path = write_model("enum_all", MOBILE_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+    });
+    let result = enumerate::call(&args);
+    let payload = match result {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => {
+            cleanup(&path);
+            panic!("expected Ok, got Error[{code}] {message}");
+        }
+    };
+    let candidates = payload["candidates"]
+        .as_array()
+        .expect("candidates must be array");
+    assert_eq!(
+        candidates.len(),
+        2,
+        "expected cpu1 + cpu2 in candidate set; got {payload}",
+    );
+    let names: Vec<&str> = candidates
+        .iter()
+        .filter_map(|c| c["target"].as_str())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.ends_with("cpu1")),
+        "expected cpu1 candidate; got {names:?}",
+    );
+    assert!(
+        names.iter().any(|n| n.ends_with("cpu2")),
+        "expected cpu2 candidate; got {names:?}",
+    );
+    cleanup(&path);
+}
+
+// ── 3. check_chain_tool_returns_latency_breakdown ────────────────────
+
+#[test]
+fn check_chain_tool_returns_latency_breakdown() {
+    let path = write_model("chain", CHAIN_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Chain::Sys.Impl",
+        "source_thread": "producer",
+        "sink_thread":   "consumer",
+    });
+    let result = check_chain::call(&args);
+    let payload = match result {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => {
+            cleanup(&path);
+            panic!("expected Ok, got Error[{code}] {message}");
+        }
+    };
+    assert_eq!(payload["flow_name"].as_str(), Some("chain"));
+    let diags = payload["diagnostics"]
+        .as_array()
+        .expect("diagnostics must be array");
+    assert!(
+        !diags.is_empty(),
+        "expected at least one latency diagnostic for the chain; got {payload}",
+    );
+    // The latency pass emits an Info diagnostic of the form
+    // `end-to-end flow 'chain' latency: [a ms .. b ms]` — surface that
+    // the bounds are present.
+    let has_bounds = diags.iter().any(|d| {
+        d["message"]
+            .as_str()
+            .map(|m| m.contains("latency:") && m.contains("ms"))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_bounds,
+        "expected a latency-bounds diagnostic; got {diags:?}",
+    );
+    cleanup(&path);
+}
+
+// ── 4. verify_tool_with_variant_filters_components ───────────────────
+
+#[test]
+fn verify_tool_with_variant_filters_components() {
+    // Drive the implicit-variant path through the SPAR_VARIANT_TEST_RIVET_OUTPUT
+    // test seam. The variant context resolves to a name that the
+    // verify pipeline materialises into the report's `variant` field —
+    // the agent uses this to route follow-up calls to the same
+    // variant resolution.
+    let path = write_model("variant", MOBILE_MODEL);
+
+    // Minimal v1 variant context payload — see
+    // `crates/spar-variants/src/context.rs` for the canonical schema.
+    let payload = serde_json::json!({
+        "rivet_spar_context_version": "1",
+        "variant": "test-variant",
+        "features": [],
+        "bindings": [],
+        "feature_model_hash": "deadbeef",
+        "resolved_at": "2026-04-23T00:00:00Z",
+        "generated_by": "spar-mcp-test",
+    });
+    // Safety: the test seam is deliberately a process-level env var,
+    // mirroring how the moves CLI's variant tests drive the same
+    // flag. Tests in this file do not set it concurrently with the
+    // moves-side integration tests because each test crate has its
+    // own process.
+    unsafe {
+        std::env::set_var("SPAR_VARIANT_TEST_RIVET_OUTPUT", payload.to_string());
+    }
+
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+        "target":    "cpu2",
+        "variant":   "test-variant",
+    });
+    let result = verify::call(&args);
+    unsafe {
+        std::env::remove_var("SPAR_VARIANT_TEST_RIVET_OUTPUT");
+    }
+    let payload = match result {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => {
+            cleanup(&path);
+            panic!("expected Ok, got Error[{code}] {message}");
+        }
+    };
+    assert_eq!(
+        payload["variant"].as_str(),
+        Some("test-variant"),
+        "expected variant audit-trail field to be propagated; got {payload}",
+    );
+    assert_eq!(payload["feature_model_hash"].as_str(), Some("deadbeef"));
+    cleanup(&path);
+}
+
+// ── 5. enumerate_tool_with_objective_picks_least_loaded ──────────────
+
+#[test]
+fn enumerate_tool_with_objective_picks_least_loaded() {
+    // With objective=total-load, the candidate with the lowest
+    // post-move utilisation should sort first. Both processors are
+    // empty in the MOBILE_MODEL fixture, but the ranker's score is
+    // still well-defined (zero or near-zero) — we confirm the
+    // payload's candidates order respects the score ordering and that
+    // no candidate has an `<missed>` sentinel.
+    let path = write_model("enum_obj", MOBILE_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+        "objective": "total-load",
+    });
+    let result = enumerate::call(&args);
+    let payload = match result {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => {
+            cleanup(&path);
+            panic!("expected Ok, got Error[{code}] {message}");
+        }
+    };
+    let candidates = payload["candidates"].as_array().expect("array");
+    assert!(!candidates.is_empty(), "expected at least one candidate");
+
+    // Scores must be monotone non-decreasing across the candidates
+    // (admissible-first sort, then score ascending).
+    let scores: Vec<f64> = candidates
+        .iter()
+        .map(|c| c["rank"]["score"].as_f64().unwrap_or(f64::NAN))
+        .collect();
+    for w in scores.windows(2) {
+        // Reject NaNs only; equal scores are fine.
+        assert!(
+            !w[0].is_nan() && !w[1].is_nan(),
+            "rank score should be finite for a well-formed model; got {scores:?}",
+        );
+        assert!(
+            w[0] <= w[1] + f64::EPSILON,
+            "candidates should be sorted by score ascending; got {scores:?}",
+        );
+    }
+
+    // Unknown objective string surfaces a BAD_INPUT error.
+    let bad = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+        "objective": "not-a-real-mode",
+    });
+    let bad_result = enumerate::call(&bad);
+    match bad_result {
+        ToolResult::Error { code, .. } => {
+            assert_eq!(code, "BAD_INPUT", "expected BAD_INPUT for bogus objective");
+        }
+        ToolResult::Ok(v) => {
+            cleanup(&path);
+            panic!("expected error for bogus objective, got Ok({v})");
+        }
+    }
+    cleanup(&path);
+}
+
+// ── Validation helper used by stdio tests too ─────────────────────────
+
+/// Used by both in-process and stdio tests: accept either Ok(payload)
+/// or panic. Kept here so the stdio tests can re-import via
+/// `#[path = "in_process_tests.rs"] mod fixtures;` if needed; for now
+/// each test crate maintains its own fixtures.
+#[allow(dead_code)]
+pub(crate) fn unwrap_ok(r: ToolResult) -> Value {
+    match r {
+        ToolResult::Ok(v) => v,
+        ToolResult::Error { code, message } => panic!("expected Ok, got Error[{code}] {message}"),
+    }
+}

--- a/crates/spar-mcp/tests/stdio_tests.rs
+++ b/crates/spar-mcp/tests/stdio_tests.rs
@@ -1,0 +1,308 @@
+//! Stdio JSON-RPC integration tests for spar-mcp.
+//!
+//! These tests drive the server one message at a time via
+//! [`spar_mcp::server::handle_request_line`]. The same dispatch path
+//! is what the stdio loop uses; testing it message-at-a-time keeps the
+//! tests deterministic and free of background-thread / pipe-buffer
+//! synchronisation.
+
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use spar_mcp::server::handle_request_line;
+
+fn write_model(tag: &str, body: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "spar_mcp_stdio_{}_{}.aadl",
+        std::process::id(),
+        tag,
+    ));
+    std::fs::write(&path, body).expect("write temp AADL");
+    path
+}
+
+fn cleanup(p: &PathBuf) {
+    let _ = std::fs::remove_file(p);
+}
+
+const MOBILE_MODEL: &str = "\
+package Migrate
+public
+  processor CPU
+  end CPU;
+
+  thread Worker
+  end Worker;
+
+  process Proc
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      t1: thread Worker;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.t1;
+  end Sys.Impl;
+end Migrate;
+";
+
+const CHAIN_MODEL: &str = "\
+package Chain
+public
+  processor CPU
+  end CPU;
+
+  thread Producer
+    features
+      out_p: out data port;
+    flows
+      f1: flow source out_p;
+    properties
+      Period => 10 ms;
+      Compute_Execution_Time => 1 ms .. 2 ms;
+      Dispatch_Protocol => Periodic;
+  end Producer;
+
+  thread Consumer
+    features
+      in_p: in data port;
+    flows
+      f2: flow sink in_p;
+    properties
+      Period => 10 ms;
+      Compute_Execution_Time => 1 ms .. 3 ms;
+      Dispatch_Protocol => Periodic;
+  end Consumer;
+
+  process Proc
+    features
+      out_p: out data port;
+      in_p:  in data port;
+  end Proc;
+
+  process implementation Proc.Impl
+    subcomponents
+      producer: thread Producer;
+      consumer: thread Consumer;
+    connections
+      c_out: port producer.out_p -> out_p;
+      c_in:  port in_p -> consumer.in_p;
+  end Proc.Impl;
+
+  system Sys
+  end Sys;
+
+  system implementation Sys.Impl
+    subcomponents
+      cpu1: processor CPU;
+      cpu2: processor CPU;
+      app: process Proc.Impl;
+    connections
+      loop_back: port app.out_p -> app.in_p;
+    flows
+      chain: end to end flow app.producer.f1 -> loop_back -> app.consumer.f2;
+    properties
+      Actual_Processor_Binding => (reference (cpu1)) applies to app.producer;
+      Actual_Processor_Binding => (reference (cpu2)) applies to app.consumer;
+  end Sys.Impl;
+end Chain;
+";
+
+/// Send a single line through the server and return its parsed
+/// response payload (the JSON-RPC envelope). Panics if the server
+/// returns no response (notifications) — none of these tests exercise
+/// that path.
+fn drive(line: &str) -> Value {
+    let resp = handle_request_line(line).expect("expected a response, got None (notification?)");
+    serde_json::to_value(&resp).expect("response serialises")
+}
+
+// ── 6. tools_list_returns_three_tools ────────────────────────────────
+
+#[test]
+fn tools_list_returns_three_tools() {
+    let resp = drive(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+    assert_eq!(resp["jsonrpc"].as_str(), Some("2.0"));
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .expect("result.tools must be array; got {resp}");
+    assert_eq!(tools.len(), 3, "expected exactly three tools; got {resp}");
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"spar.verify_move"), "names={names:?}");
+    assert!(names.contains(&"spar.enumerate_moves"), "names={names:?}");
+    assert!(names.contains(&"spar.check_chain"), "names={names:?}");
+    // Annotations: every tool is read-only / idempotent.
+    for t in tools {
+        assert_eq!(
+            t["annotations"]["readOnlyHint"].as_bool(),
+            Some(true),
+            "tool {t} must declare readOnlyHint=true",
+        );
+        assert_eq!(
+            t["annotations"]["idempotentHint"].as_bool(),
+            Some(true),
+            "tool {t} must declare idempotentHint=true",
+        );
+    }
+}
+
+// ── 7. tools_call_verify_returns_valid_json_result ───────────────────
+
+#[test]
+fn tools_call_verify_returns_valid_json_result() {
+    let path = write_model("verify_call", MOBILE_MODEL);
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {
+            "name": "spar.verify_move",
+            "arguments": {
+                "model": path.to_string_lossy(),
+                "root": "Migrate::Sys.Impl",
+                "component": "t1",
+                "target": "cpu2",
+            }
+        }
+    });
+    let resp = drive(&req.to_string());
+    assert_eq!(
+        resp["id"].as_i64(),
+        Some(7),
+        "id must round-trip; got {resp}"
+    );
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"].as_bool(),
+        Some(false),
+        "isError should be false on a successful tool call; got {resp}",
+    );
+    let structured = &result["structuredContent"];
+    assert_eq!(
+        structured["ok"].as_bool(),
+        Some(true),
+        "structured content must include ok=true; got {resp}",
+    );
+    assert!(
+        structured["component"].is_string(),
+        "structured content must include component; got {resp}",
+    );
+    cleanup(&path);
+}
+
+// ── 8. tools_call_enumerate_returns_valid_json_result ────────────────
+
+#[test]
+fn tools_call_enumerate_returns_valid_json_result() {
+    let path = write_model("enumerate_call", MOBILE_MODEL);
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "tools/call",
+        "params": {
+            "name": "spar.enumerate_moves",
+            "arguments": {
+                "model": path.to_string_lossy(),
+                "root": "Migrate::Sys.Impl",
+                "component": "t1",
+            }
+        }
+    });
+    let resp = drive(&req.to_string());
+    let result = &resp["result"];
+    assert_eq!(result["isError"].as_bool(), Some(false));
+    let structured = &result["structuredContent"];
+    assert!(
+        structured["candidates"].is_array(),
+        "structured content must include candidates array; got {resp}",
+    );
+    assert!(
+        structured["total"].as_u64().is_some(),
+        "structured content must include total; got {resp}",
+    );
+    cleanup(&path);
+}
+
+// ── 9. tools_call_check_chain_returns_valid_json_result ──────────────
+
+#[test]
+fn tools_call_check_chain_returns_valid_json_result() {
+    let path = write_model("chain_call", CHAIN_MODEL);
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {
+            "name": "spar.check_chain",
+            "arguments": {
+                "model": path.to_string_lossy(),
+                "root": "Chain::Sys.Impl",
+                "source_thread": "producer",
+                "sink_thread": "consumer",
+            }
+        }
+    });
+    let resp = drive(&req.to_string());
+    let result = &resp["result"];
+    assert_eq!(result["isError"].as_bool(), Some(false));
+    let structured = &result["structuredContent"];
+    assert_eq!(
+        structured["flow_name"].as_str(),
+        Some("chain"),
+        "structured content must include flow_name=chain; got {resp}",
+    );
+    assert!(
+        structured["diagnostics"].is_array(),
+        "structured content must include diagnostics array; got {resp}",
+    );
+    cleanup(&path);
+}
+
+// ── 10. unknown_tool_returns_method_not_found_error ──────────────────
+
+#[test]
+fn unknown_tool_returns_method_not_found_error() {
+    let req = r#"{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"spar.nonexistent","arguments":{}}}"#;
+    let resp = drive(req);
+    assert_eq!(resp["id"].as_i64(), Some(10));
+    let err = resp["error"]
+        .as_object()
+        .expect("missing error object; got {resp}");
+    assert_eq!(
+        err["code"].as_i64(),
+        Some(-32601),
+        "expected JSON-RPC code -32601 (MethodNotFound); got {resp}",
+    );
+    let msg = err["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("spar.nonexistent"),
+        "error message should mention the tool name; got {msg}",
+    );
+}
+
+// ── Bonus: an unknown JSON-RPC method also gets MethodNotFound ───────
+
+#[test]
+fn unknown_jsonrpc_method_returns_method_not_found_error() {
+    let req = r#"{"jsonrpc":"2.0","id":11,"method":"sampling/createMessage","params":{}}"#;
+    let resp = drive(req);
+    let err = resp["error"]
+        .as_object()
+        .expect("missing error object; got {resp}");
+    assert_eq!(
+        err["code"].as_i64(),
+        Some(-32601),
+        "expected JSON-RPC code -32601 for unknown method; got {resp}",
+    );
+}


### PR DESCRIPTION
## Summary

- New `spar-mcp` crate exposes spar's hypothetical-rebinding oracle as MCP (Model Context Protocol) tools so LLM agents can drive design-space exploration with spar as the deterministic correctness oracle.
- Three read-only / idempotent tools: `spar.verify_move`, `spar.enumerate_moves`, `spar.check_chain`. All declare `readOnlyHint: true` + `idempotentHint: true` per the MCP 2025-11-25 spec.
- Deterministic apply path stays CLI-exclusive (no `spar.apply_move` over MCP, ever) per Track E migration research §6.5 — certification chain stays in spar.

## Architecture

- `spar-cli` promoted to `lib + bin` so verify / enumerate / check-chain logic is shareable.
- `spar-mcp` consumes the lib API in-process — no shell-out, no re-parsing of stdout.
- stdio JSON-RPC 2.0 transport; reachable as `spar-mcp` standalone binary or `spar mcp serve`.
- 11 tests: 5 in-process Rust API path + 6 stdio JSON-RPC envelope path.

## Test plan

- [x] `cargo test -p spar-mcp` — 11/11 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `rivet validate` — PASS
- [ ] CI green
- [ ] Spot-check via `claude --mcp-config '{"mcpServers": {"spar": {"command": "spar-mcp", "args": []}}}'` (post-merge smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)