### PR TITLE
feat(tsn): TAS (802.1Qbv) gate-window service curve (v0.8.1 c2/5)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1459,6 +1459,32 @@ artifacts:
     status: planned
     tags: [network, tsn, wctt, v081]
 
+  - id: REQ-TSN-002
+    type: requirement
+    title: TAS (802.1Qbv) gate-window service curve in WCTT analysis
+    description: >
+      System provides a Time-Aware Shaper (IEEE 802.1Qbv) gate-window
+      service curve for TSN-typed switches and dispatches it from the
+      WCTT analysis when both the bus carries a parsed
+      Spar_TSN::Gate_Control_List and the stream carries a
+      Spar_TSN::Class_of_Service. spar-network::tsn parses the
+      gate-control list "offset_ns:duration_ns:cos_mask;..." blob into
+      a GateSchedule, validates that windows tile the cycle period
+      without gaps or overlaps, and exposes (a) the average open
+      fraction ρ_K = open_time_K / cycle_period and (b) the
+      worst-case gate latency T_K = longest contiguous closed run for
+      class K (with wrap-around). tas_residual_service then derives
+      β_K(t) = (R_link · ρ_K) · max(0, t − T_K) from those quantities.
+      Hops dispatched through the TAS curve emit a new Info
+      diagnostic, WcttTasGated, carrying stream id, class-of-service,
+      open fraction (percent) and gate latency (ps); when either the
+      Gate_Control_List or the Class_of_Service is missing the
+      analysis falls back to the v0.8.0 WcttDeferred path. Discharges
+      docs/designs/track-d-tsn-wctt-research.md §5.3 and the v0.8.1
+      Track D Phase 2 commit 2 milestone.
+    status: planned
+    tags: [network, tsn, wctt, v081]
+
   # ── Track G: spar-insight discrepancy assistant (v0.9.0) ──────────
 
   - id: REQ-INSIGHT-001

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1924,6 +1924,43 @@ artifacts:
       - type: satisfies
         target: REQ-NETWORK-001
 
+  - id: TEST-TSN-TAS
+    type: feature
+    title: TAS (802.1Qbv) gate-window service curve dispatch in WCTT
+    description: >
+      Verifies the v0.8.1 commit 2 TAS service-curve math and its
+      dispatch from the WCTT analysis. spar-network::tsn unit tests
+      cover the Gate_Control_List parser (single-window, two-window
+      50/50 split, eight-window per-class round-robin, overlap
+      rejection, gap rejection, malformed entry rejection), the
+      ρ_K / T_K derivation (open fraction by mask, max contiguous
+      closed run including wrap-around, permanently-closed gates),
+      the tas_residual_service helper (50%-open at 1 Gbps gives
+      500 Mbps and the cycle's worst-case gate latency, full-open
+      preserves link rate with zero latency, never-open gives rate=0
+      latency=cycle), and the get_gate_schedule property-map
+      accessor. spar-analysis WCTT tests cover the dispatch into the
+      TAS service curve when both Spar_TSN::Gate_Control_List and
+      Spar_TSN::Class_of_Service are present (single-hop bound matches
+      T_K + σ/(R_link·ρ_K) closed-form), the strict ordering between
+      the gated and ungated bounds at the same line rate (29 us > 12
+      us at 50% open), and the two negative paths where the analysis
+      falls back to the existing WcttDeferred Info diagnostic
+      (Gate_Control_List missing on the bus; Class_of_Service missing
+      on the stream).
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-network --lib -- tsn
+        - run: cargo test -p spar-analysis --lib -- wctt
+    status: passing
+    tags: [v0.8.1, network, tsn, wctt, tas]
+    links:
+      - type: satisfies
+        target: REQ-TSN-002
+      - type: satisfies
+        target: REQ-NETWORK-006
+
   - id: TEST-INSIGHT-DISCREPANCY
     type: feature
     title: spar-insight CTF parser + 5-kind discrepancy detection

--- a/crates/spar-analysis/src/wctt.rs
+++ b/crates/spar-analysis/src/wctt.rs
@@ -55,6 +55,9 @@ use spar_network::curves::{
 use spar_network::extract::{
     extract_network_graph, read_forwarding_latency_ps, read_output_rate_bps, read_queue_depth,
 };
+use spar_network::tsn::{
+    ClassOfService, GateSchedule, get_class_of_service, get_gate_schedule, tas_residual_service,
+};
 use spar_network::types::{NetworkGraph, NodeKind, SwitchType};
 
 use crate::{Analysis, AnalysisDiagnostic, Severity, component_path};
@@ -110,6 +113,16 @@ impl WcttAnalysis {
         let mut service_for_bus: FxHashMap<ComponentInstanceIdx, ServiceCurve> =
             FxHashMap::default();
         let mut budget_ps_for_bus: FxHashMap<ComponentInstanceIdx, u64> = FxHashMap::default();
+        // Per-bus TAS gate schedule, when present on a TSN-typed bus.
+        // Used to dispatch [`tas_residual_service`] in the per-hop walk
+        // below.
+        let mut gate_schedule_for_bus: FxHashMap<ComponentInstanceIdx, GateSchedule> =
+            FxHashMap::default();
+        // Per-bus link rate (bits per second) — kept separately because
+        // `tas_residual_service` rebuilds the service curve from the raw
+        // R_link rather than the rate-latency form already in
+        // `service_for_bus`.
+        let mut link_rate_for_bus: FxHashMap<ComponentInstanceIdx, u64> = FxHashMap::default();
         for node in graph.switches() {
             if let NodeKind::Switch { switch_type: st } = node.kind {
                 switch_type.insert(node.idx, st);
@@ -120,8 +133,16 @@ impl WcttAnalysis {
             let rate_bps = read_output_rate_bps(props).unwrap_or(0);
             let (_bcet_ps, wcet_ps) = read_forwarding_latency_ps(props).unwrap_or((0, 0));
             service_for_bus.insert(node.idx, ServiceCurve::rate_latency(rate_bps, wcet_ps));
+            link_rate_for_bus.insert(node.idx, rate_bps);
             if let Some(budget) = read_wctt_budget_ps(props) {
                 budget_ps_for_bus.insert(node.idx, budget);
+            }
+            // Spar_TSN::Gate_Control_List on the bus enables the TAS
+            // service-curve dispatch below (v0.8.1 commit 2). Malformed
+            // GCL strings are silently treated as "no schedule" — the
+            // existing WcttDeferred path handles that fall-through.
+            if let Some(schedule) = get_gate_schedule(props) {
+                gate_schedule_for_bus.insert(node.idx, schedule);
             }
         }
 
@@ -199,37 +220,83 @@ impl WcttAnalysis {
             for (hop_idx, sw_idx) in stream.hops.iter().enumerate() {
                 let st = switch_type.get(sw_idx).copied().unwrap_or(SwitchType::Fifo);
 
-                // TSN switches are opaque in Phase 1: we emit a
-                // deferral diagnostic for the first such hop and
-                // skip the per-hop delay contribution. Subsequent TSN
-                // hops on the same stream stay silent to avoid noise.
-                if matches!(st, SwitchType::Tsn) {
-                    if !deferred_emitted {
-                        diags.push(AnalysisDiagnostic {
-                            severity: Severity::Info,
-                            message: format!(
-                                "WcttDeferred: stream '{}' traverses TSN switch '{}' at hop {}; \
-                                 TAS/CBS-shaped service curves are deferred to Phase 2 \
-                                 (tracked in docs/designs/track-d-tsn-wctt-research.md §5.5)",
-                                stream_name,
-                                graph
-                                    .node(*sw_idx)
-                                    .map(|n| n.name.as_str())
-                                    .unwrap_or("<unknown>"),
-                                hop_idx,
-                            ),
-                            path: stream_path.clone(),
-                            analysis: self.name().to_string(),
-                        });
-                        deferred_emitted = true;
+                // TSN switches: prefer the TAS gate-window service
+                // curve when both the bus has a parsed Gate_Control_List
+                // and the stream carries a Spar_TSN::Class_of_Service.
+                // When either is missing, fall back to the v0.8.0
+                // WcttDeferred Info diagnostic and skip the hop's
+                // contribution.
+                let svc = if matches!(st, SwitchType::Tsn) {
+                    match (gate_schedule_for_bus.get(sw_idx), stream.cos) {
+                        (Some(schedule), Some(cos)) => {
+                            let link_rate = link_rate_for_bus.get(sw_idx).copied().unwrap_or(0);
+                            let tas_svc = tas_residual_service(schedule, cos, link_rate);
+                            let (open_ps, cycle_ps) = schedule.open_fraction(cos);
+                            // open_fraction is reported as a percentage
+                            // (integer-rounded toward zero) for human
+                            // readability in the diagnostic message.
+                            let open_pct = if cycle_ps == 0 {
+                                0
+                            } else {
+                                ((open_ps as u128) * 100 / (cycle_ps as u128)) as u64
+                            };
+                            let gate_latency_ps = schedule.worst_case_latency(cos);
+                            diags.push(AnalysisDiagnostic {
+                                severity: Severity::Info,
+                                message: format!(
+                                    "WcttTasGated: stream '{}' (CoS {}) on TSN switch '{}' at \
+                                     hop {}: open fraction {}% gate latency {} ps",
+                                    stream_name,
+                                    cos.0,
+                                    graph
+                                        .node(*sw_idx)
+                                        .map(|n| n.name.as_str())
+                                        .unwrap_or("<unknown>"),
+                                    hop_idx,
+                                    open_pct,
+                                    gate_latency_ps,
+                                ),
+                                path: stream_path.clone(),
+                                analysis: self.name().to_string(),
+                            });
+                            tas_svc
+                        }
+                        _ => {
+                            // No gate schedule or no CoS — fall back to
+                            // the v0.8.0 deferred path. We deliberately
+                            // emit at most one WcttDeferred per stream
+                            // (the diagnostic noise floor matches Phase
+                            // 1's behaviour).
+                            if !deferred_emitted {
+                                diags.push(AnalysisDiagnostic {
+                                    severity: Severity::Info,
+                                    message: format!(
+                                        "WcttDeferred: stream '{}' traverses TSN switch '{}' at \
+                                         hop {}; TAS/CBS-shaped service curves are deferred to \
+                                         Phase 2 (tracked in \
+                                         docs/designs/track-d-tsn-wctt-research.md §5.5)",
+                                        stream_name,
+                                        graph
+                                            .node(*sw_idx)
+                                            .map(|n| n.name.as_str())
+                                            .unwrap_or("<unknown>"),
+                                        hop_idx,
+                                    ),
+                                    path: stream_path.clone(),
+                                    analysis: self.name().to_string(),
+                                });
+                                deferred_emitted = true;
+                            }
+                            continue;
+                        }
                     }
-                    continue;
-                }
-
-                let svc = match service_for_bus.get(sw_idx) {
-                    Some(s) => *s,
-                    None => continue,
+                } else {
+                    match service_for_bus.get(sw_idx) {
+                        Some(s) => *s,
+                        None => continue,
+                    }
                 };
+
                 if svc.rate_bps == 0 {
                     // No bandwidth declared — without a finite service
                     // rate we cannot bound delay; skip the hop with
@@ -682,6 +749,11 @@ struct Stream {
     hops: Vec<ComponentInstanceIdx>,
     /// Source-side arrival curve.
     alpha: ArrivalCurve,
+    /// Stream's `Spar_TSN::Class_of_Service` when annotated. Required
+    /// for the TAS service-curve dispatch on TSN switches; streams
+    /// without a CoS fall back to the [`Severity::Info`]-emitting
+    /// `WcttDeferred` path.
+    cos: Option<ClassOfService>,
 }
 
 impl Stream {
@@ -780,6 +852,16 @@ fn collect_streams(
                 .unwrap_or(DEFAULT_BURST_BYTES);
 
             let alpha = ArrivalCurve::affine(burst_bytes, rate_bps);
+            // Stream's class-of-service drives the TAS service-curve
+            // dispatch on TSN-typed switches. The lookup follows the
+            // same precedence as the typed/string accessor in
+            // spar-network::tsn — we read from the source end station
+            // because Spar_TSN::Class_of_Service applies to ports /
+            // connections; the closest reachable carrier in the
+            // current property model is the source device's
+            // PropertyMap, which the existing rate / queue-depth reads
+            // already use.
+            let cos = get_class_of_service(src_props);
 
             streams.push(Stream {
                 name: conn.name.as_str().to_string(),
@@ -787,6 +869,7 @@ fn collect_streams(
                 sink_idx: dst_idx,
                 hops,
                 alpha,
+                cos,
             });
         }
     }
@@ -1517,5 +1600,334 @@ end Net;
             "unswitched bus must not produce Wctt* diagnostics: {:#?}",
             diags
         );
+    }
+
+    // ── Test 11: TAS service curve dispatch (v0.8.1 commit 2) ───────
+    #[test]
+    fn tsn_with_gcl_and_cos_dispatches_tas_service_curve() {
+        // 1 Gbps TSN switch carrying a Gate_Control_List that opens
+        // CoS 7 for 50% of the cycle; the source device declares
+        // Class_of_Service=7. Expect a `WcttTasGated` Info diagnostic
+        // (not `WcttDeferred`) and a finite `WcttBound` whose value
+        // reflects the half-bandwidth, gate-latency-shifted service
+        // curve.
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Gate_Control_List      => "0:5000:0x80;5000:5000:0x7F";
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  device src_d
+    features
+      net : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end src_d;
+  device implementation src_d.impl
+  end src_d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      a  : device src_d.impl;
+      b  : device d.impl;
+    connections
+      c_sw_a : bus access sw -> a.net;
+      c_sw_b : bus access sw -> b.net;
+      data1  : port a.out_p -> b.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+
+        // We must see a WcttTasGated Info, not WcttDeferred.
+        let tas_gated = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttTasGated"))
+            .unwrap_or_else(|| panic!("expected WcttTasGated: {:#?}", diags));
+        assert!(tas_gated.severity == Severity::Info);
+        assert!(tas_gated.message.contains("CoS 7"));
+        assert!(tas_gated.message.contains("50%"));
+
+        let deferred = diags.iter().find(|d| d.message.starts_with("WcttDeferred"));
+        assert!(
+            deferred.is_none(),
+            "WcttDeferred should not fire when GCL+CoS are present: {:#?}",
+            diags
+        );
+
+        // Bound: D = T_K + σ/R_K. With T_K = 5 us, σ = 1500 bytes,
+        // R_K = 500 Mbps: σ/R_K = 1500·8·10^12 / 500·10^6 = 24·10^6 ps =
+        // 24 us. Total = 29 us.
+        let bound = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttBound"))
+            .unwrap_or_else(|| panic!("expected WcttBound: {:#?}", diags));
+        assert!(
+            bound.message.contains("29000000 ps"),
+            "expected 29 us TAS bound, got: {}",
+            bound.message
+        );
+    }
+
+    // ── Test 12: TAS bound is strictly larger than ungated ─────────
+    #[test]
+    fn tas_gated_bound_exceeds_ungated_bound_at_half_bandwidth() {
+        // Comparison: a 1 Gbps line-rate, ungated, gives D = 12 us
+        // (single-hop test 2 above). Same topology under TAS with 50%
+        // open and 5 us gate latency gives D = 5 us (latency) + 24 us
+        // (σ/R_K at 500 Mbps) = 29 us. The TAS bound must be strictly
+        // larger than the ungated bound: gate shaping is always at
+        // least as restrictive as line-rate service.
+        let ungated_src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => FIFO;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      a  : device d.impl;
+      b  : device d.impl;
+    connections
+      c_sw_a : bus access sw -> a.net;
+      c_sw_b : bus access sw -> b.net;
+      data1  : port a.out_p -> b.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let ungated = instantiate(ungated_src, "Net", "Sys", "impl");
+        let ungated_diags = WcttAnalysis.analyze(&ungated);
+        let ungated_bound = ungated_diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttBound"))
+            .unwrap();
+        // 12 us = 12_000_000 ps for the ungated single hop.
+        assert!(ungated_bound.message.contains("12000000 ps"));
+
+        // Same model, but with TSN+GCL applied (50% open for CoS 7).
+        // The bound must exceed the ungated 12 us.
+        let gated_src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Gate_Control_List      => "0:5000:0x80;5000:5000:0x7F";
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  device src_d
+    features
+      net : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end src_d;
+  device implementation src_d.impl
+  end src_d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      a  : device src_d.impl;
+      b  : device d.impl;
+    connections
+      c_sw_a : bus access sw -> a.net;
+      c_sw_b : bus access sw -> b.net;
+      data1  : port a.out_p -> b.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let gated = instantiate(gated_src, "Net", "Sys", "impl");
+        let gated_diags = WcttAnalysis.analyze(&gated);
+        let gated_bound = gated_diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttBound"))
+            .unwrap();
+        assert!(gated_bound.message.contains("29000000 ps"));
+
+        // Strictly: 29 us > 12 us — the gated bound is more pessimistic
+        // (and correctly so) than the ungated line-rate bound.
+    }
+
+    // ── Test 13: TSN switch without GCL still defers ────────────────
+    #[test]
+    fn tsn_switch_without_gcl_keeps_deferred_path() {
+        // TSN switch but no Gate_Control_List declared on the bus.
+        // The dispatch must fall back to the v0.8.0 WcttDeferred path
+        // (no TAS service curve; no per-hop contribution).
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      a  : device d.impl;
+      b  : device d.impl;
+    connections
+      c_sw_a : bus access sw -> a.net;
+      c_sw_b : bus access sw -> b.net;
+      data1  : port a.out_p -> b.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+        let deferred = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttDeferred"))
+            .unwrap_or_else(|| panic!("expected WcttDeferred: {:#?}", diags));
+        assert!(deferred.severity == Severity::Info);
+        assert!(
+            diags.iter().all(|d| !d.message.starts_with("WcttTasGated")),
+            "WcttTasGated should not fire when GCL is absent: {:#?}",
+            diags
+        );
+    }
+
+    // ── Test 14: TSN switch with GCL but stream lacks CoS defers ────
+    #[test]
+    fn tsn_with_gcl_but_no_stream_cos_still_defers() {
+        // Bus has a Gate_Control_List, but the source device does not
+        // declare Spar_TSN::Class_of_Service. Without the CoS we
+        // cannot pick a window mask; fall back to WcttDeferred.
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Gate_Control_List      => "0:5000:0x80;5000:5000:0x7F";
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      a  : device d.impl;
+      b  : device d.impl;
+    connections
+      c_sw_a : bus access sw -> a.net;
+      c_sw_b : bus access sw -> b.net;
+      data1  : port a.out_p -> b.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+        let deferred = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttDeferred"))
+            .unwrap_or_else(|| panic!("expected WcttDeferred: {:#?}", diags));
+        assert!(deferred.severity == Severity::Info);
     }
 }

--- a/crates/spar-network/src/lib.rs
+++ b/crates/spar-network/src/lib.rs
@@ -53,5 +53,8 @@ pub use curves::{
     ArrivalCurve, NcError, ServiceCurve, backlog_bound, delay_bound, output_bound, residual_service,
 };
 pub use extract::extract_network_graph;
-pub use tsn::{ClassOfService, CreditPool, GateWindow};
+pub use tsn::{
+    ClassOfService, CreditPool, GateSchedule, GateScheduleError, GateWindow, get_gate_schedule,
+    tas_residual_service,
+};
 pub use types::{NetworkGraph, NetworkLink, NetworkNode, NodeKind, SwitchType};

--- a/crates/spar-network/src/tsn.rs
+++ b/crates/spar-network/src/tsn.rs
@@ -1,15 +1,22 @@
-//! Time-Sensitive Networking (TSN) primitives — placeholder.
+//! Time-Sensitive Networking (TSN) primitives.
 //!
-//! Phase 2 (v0.8.x) will implement TAS gate-window service curves
+//! Phase 2 (v0.8.x) implements TAS gate-window service curves
 //! (802.1Qbv), CBS credit-pool tracking (802.1Qav), and frame preemption
-//! (802.1Qbu). v0.8.1 commit 1 ships only the type surface and
-//! `Spar_TSN::*` property reader; subsequent commits add the math.
+//! (802.1Qbu). v0.8.1 commit 1 shipped the type surface and
+//! `Spar_TSN::*` property readers; commit 2 (this commit) adds the TAS
+//! service-curve math (parser for [`Gate_Control_List`], the open-fraction
+//! and worst-case gate-latency derivation, and [`tas_residual_service`]).
 //!
 //! See `docs/designs/track-d-tsn-wctt-research.md` §5.1 (property-set
-//! design) and §5.2 (switch modeling) for the design rationale.
+//! design), §5.2 (switch modeling), and §5.3 (TAS / 802.1Qbv shaping) for
+//! the design rationale.
+//!
+//! [`Gate_Control_List`]: get_gate_control_list_raw
 
 use spar_hir_def::item_tree::PropertyExpr;
 use spar_hir_def::properties::PropertyMap;
+
+use crate::curves::ServiceCurve;
 
 const SPAR_TSN: &str = "Spar_TSN";
 
@@ -226,6 +233,306 @@ fn parse_size_bytes(s: &str) -> Option<u64> {
     s.parse::<u64>().ok()
 }
 
+// ── TAS (802.1Qbv) gate-window service curve ─────────────────────────
+//
+// Time-Aware Shaper math kernel (v0.8.1 commit 2). Derives the
+// rate-latency [`ServiceCurve`] offered to a single class-of-service by
+// a TAS-gated egress port from its gate-control list.
+//
+// Per Le Boudec & Thiran "Network Calculus" (Springer 2001) chapter 1
+// and the design discussion in
+// `docs/designs/track-d-tsn-wctt-research.md` §5.3:
+//
+// Let cycle_period = ∑ window.duration over the GCL, and let the open
+// time for class K be sum_K_open = ∑ window.duration over windows whose
+// cos_mask has bit K set. Then:
+//
+//   ρ_K  = sum_K_open / cycle_period            (average open fraction)
+//   T_K  = max contiguous closed duration       (worst-case gate latency)
+//   β_K(t) = (R_link · ρ_K) · max(0, t − T_K)   (rate-latency form)
+//
+// The "max contiguous closed duration" includes wrap-around across the
+// cycle boundary so the bound is correct for arbitrary GCL phasing
+// (single-window, multi-window, or gap-only schedules).
+
+/// A parsed TAS gate-control list — a periodic schedule of
+/// [`GateWindow`] entries that tile the cycle period without gaps or
+/// overlaps.
+///
+/// Constructed by [`GateSchedule::parse`]. The `cycle_ps` field is the
+/// sum of all window durations and is also the GCL cycle period.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GateSchedule {
+    /// Windows in declaration order. Successive windows abut: the
+    /// `(offset_ps, duration_ps)` pairs tile `[0, cycle_ps)`.
+    pub windows: Vec<GateWindow>,
+    /// Total cycle period, picoseconds. Equal to `sum(windows.duration_ps)`.
+    pub cycle_ps: u64,
+}
+
+/// Errors returned by [`GateSchedule::parse`] when the
+/// `Gate_Control_List` blob is structurally invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateScheduleError {
+    /// The string parsed to zero windows.
+    Empty,
+    /// A window entry could not be split into the three required
+    /// `offset:duration:cos_mask` fields.
+    Malformed(String),
+    /// The numeric component (`offset`, `duration`, or `cos_mask`) of an
+    /// entry could not be parsed.
+    ParseInt(String),
+    /// A window's `[offset, offset+duration)` range overlaps the next
+    /// window's range.
+    Overlap {
+        /// Index of the first window in the overlapping pair.
+        index: usize,
+    },
+    /// A window's `[offset, offset+duration)` range leaves a gap before
+    /// the next window's `offset`.
+    Gap {
+        /// Index of the window before the gap.
+        index: usize,
+    },
+    /// A window's `duration_ns` is zero (would make ρ_K division
+    /// degenerate and the schedule meaningless).
+    ZeroDuration {
+        /// Index of the offending window.
+        index: usize,
+    },
+}
+
+impl core::fmt::Display for GateScheduleError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty gate-control list"),
+            Self::Malformed(s) => write!(f, "malformed gate window entry: {:?}", s),
+            Self::ParseInt(s) => write!(f, "could not parse integer in gate window entry: {:?}", s),
+            Self::Overlap { index } => {
+                write!(f, "gate window {} overlaps the next window", index)
+            }
+            Self::Gap { index } => {
+                write!(f, "gap between gate window {} and the next window", index)
+            }
+            Self::ZeroDuration { index } => {
+                write!(f, "gate window {} has zero duration", index)
+            }
+        }
+    }
+}
+
+impl core::error::Error for GateScheduleError {}
+
+impl GateSchedule {
+    /// Parse a `Gate_Control_List` blob into a structured
+    /// [`GateSchedule`].
+    ///
+    /// Format: `"offset_ns:duration_ns:cos_mask;offset_ns:duration_ns:cos_mask;..."`
+    /// where each field is a non-negative decimal integer (the
+    /// `cos_mask` may also be expressed in hex with a `0x`/`0X` prefix
+    /// so the canonical 802.1Q PCP bitmask form `0x80` is accepted).
+    /// Window time units are nanoseconds; the parser converts to
+    /// picoseconds (matching the [`GateWindow::offset_ps`] /
+    /// [`duration_ps`](GateWindow::duration_ps) representation).
+    ///
+    /// Trailing semicolons and surrounding whitespace are tolerated.
+    /// Validates that the windows tile the cycle period without gaps
+    /// or overlaps, returning a [`GateScheduleError`] otherwise.
+    pub fn parse(blob: &str) -> Result<Self, GateScheduleError> {
+        let trimmed = blob.trim();
+        if trimmed.is_empty() {
+            return Err(GateScheduleError::Empty);
+        }
+
+        let mut windows: Vec<GateWindow> = Vec::new();
+        for entry in trimmed.split(';') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            let parts: Vec<&str> = entry.split(':').collect();
+            if parts.len() != 3 {
+                return Err(GateScheduleError::Malformed(entry.to_string()));
+            }
+            let offset_ns = parse_decimal_u64(parts[0].trim())
+                .ok_or_else(|| GateScheduleError::ParseInt(entry.to_string()))?;
+            let duration_ns = parse_decimal_u64(parts[1].trim())
+                .ok_or_else(|| GateScheduleError::ParseInt(entry.to_string()))?;
+            let cos_mask = parse_cos_mask(parts[2].trim())
+                .ok_or_else(|| GateScheduleError::ParseInt(entry.to_string()))?;
+            windows.push(GateWindow {
+                offset_ps: offset_ns.saturating_mul(1_000),
+                duration_ps: duration_ns.saturating_mul(1_000),
+                allowed_cos_mask: cos_mask,
+            });
+        }
+        if windows.is_empty() {
+            return Err(GateScheduleError::Empty);
+        }
+
+        // Validate: windows must tile [0, cycle_ps) in declaration order.
+        // We deliberately rely on declaration order rather than sorting:
+        // the GCL semantics are sequential and a misordered list is a
+        // configuration error (not silently fixable).
+        let mut expected_offset: u64 = 0;
+        for (i, w) in windows.iter().enumerate() {
+            if w.duration_ps == 0 {
+                return Err(GateScheduleError::ZeroDuration { index: i });
+            }
+            match w.offset_ps.cmp(&expected_offset) {
+                core::cmp::Ordering::Less => return Err(GateScheduleError::Overlap { index: i }),
+                core::cmp::Ordering::Greater => return Err(GateScheduleError::Gap { index: i }),
+                core::cmp::Ordering::Equal => {}
+            }
+            expected_offset = w.offset_ps.saturating_add(w.duration_ps);
+        }
+
+        Ok(GateSchedule {
+            windows,
+            cycle_ps: expected_offset,
+        })
+    }
+
+    /// Average open fraction for class `cos`, expressed as a numerator
+    /// and denominator in picoseconds.
+    ///
+    /// Returns `(open_time_ps, cycle_ps)`. The fraction is
+    /// `open_time_ps / cycle_ps`. Computing the raw ratio is left to
+    /// callers so they can carry it in `u128` accumulators where
+    /// needed; [`tas_residual_service`] uses this to derive the
+    /// `R_link · ρ_K` rate without dropping precision.
+    pub fn open_fraction(&self, cos: ClassOfService) -> (u64, u64) {
+        let bit = 1u8 << cos.0;
+        let mut open_ps: u64 = 0;
+        for w in &self.windows {
+            if w.allowed_cos_mask & bit != 0 {
+                open_ps = open_ps.saturating_add(w.duration_ps);
+            }
+        }
+        (open_ps, self.cycle_ps)
+    }
+
+    /// Worst-case gate latency for class `cos`, picoseconds.
+    ///
+    /// Defined as the maximum contiguous closed (gate-shut-for-`cos`)
+    /// duration in the cycle, taken with wrap-around. Equivalently, the
+    /// longest stretch of time during which a frame waiting at the
+    /// queue cannot egress because no window in the GCL has bit
+    /// `cos.0` set.
+    ///
+    /// Returns `cycle_ps` if no window opens for `cos` (the gate is
+    /// permanently closed; all of `cycle_ps` is the closed gap, which
+    /// drives `tas_residual_service` to the unservable `(rate=0,
+    /// latency=cycle_ps)` form).
+    pub fn worst_case_latency(&self, cos: ClassOfService) -> u64 {
+        let bit = 1u8 << cos.0;
+        // Walk windows once and accumulate the longest run of closed
+        // duration. Wrap-around is handled by walking *twice* and
+        // recording the longest run that does not exceed `cycle_ps` —
+        // this captures a closed run that straddles the cycle boundary.
+        let mut max_closed: u64 = 0;
+        let mut current_closed: u64 = 0;
+        let any_open = self.windows.iter().any(|w| w.allowed_cos_mask & bit != 0);
+        if !any_open {
+            return self.cycle_ps;
+        }
+        // Two passes so a closed run that straddles the cycle boundary
+        // is captured. Cap at `cycle_ps` so we never report a latency
+        // greater than the period.
+        for _ in 0..2 {
+            for w in &self.windows {
+                if w.allowed_cos_mask & bit != 0 {
+                    if current_closed > max_closed {
+                        max_closed = current_closed;
+                    }
+                    current_closed = 0;
+                } else {
+                    current_closed = current_closed.saturating_add(w.duration_ps);
+                }
+            }
+        }
+        if current_closed > max_closed {
+            max_closed = current_closed;
+        }
+        max_closed.min(self.cycle_ps)
+    }
+}
+
+/// Derive the rate-latency [`ServiceCurve`] offered to a single
+/// class-of-service by a TAS-gated egress port.
+///
+/// Inputs:
+/// - `schedule` — the parsed gate-control list.
+/// - `cos` — the class-of-service whose service curve is requested.
+/// - `link_rate_bps` — the underlying link rate (`R_link`, in bits per
+///   second), typically read from `Spar_Network::Output_Rate` on the
+///   bus.
+///
+/// Output: `β_K(t) = (R_link · ρ_K) · max(0, t − T_K)` where ρ_K is
+/// [`GateSchedule::open_fraction`] and T_K is
+/// [`GateSchedule::worst_case_latency`].
+///
+/// `link_rate_bps · open_time_ps / cycle_ps` is computed in `u128` to
+/// avoid overflow (a 100 Gbps link yields a u128 product of ~10²² for
+/// millisecond-scale cycles, which still fits). The result is
+/// truncated to `u64` (saturating to `u64::MAX`), matching the
+/// rounding convention in [`crate::curves`].
+///
+/// When `cos` never opens in the schedule, the returned curve is
+/// `(rate=0, latency=cycle_ps)` — semantically "no service" — which
+/// the WCTT pass surfaces via the existing
+/// [`crate::curves::NcError::UnservableFlow`] path.
+pub fn tas_residual_service(
+    schedule: &GateSchedule,
+    cos: ClassOfService,
+    link_rate_bps: u64,
+) -> ServiceCurve {
+    let (open_ps, cycle_ps) = schedule.open_fraction(cos);
+    let latency_ps = schedule.worst_case_latency(cos);
+
+    // R_link · ρ_K = link_rate_bps · open_ps / cycle_ps, in u128 to
+    // avoid overflow on realistic inputs.
+    let rate_bps = if cycle_ps == 0 || open_ps == 0 {
+        0
+    } else {
+        let product = (link_rate_bps as u128).saturating_mul(open_ps as u128);
+        let r = product / (cycle_ps as u128);
+        if r > u64::MAX as u128 {
+            u64::MAX
+        } else {
+            r as u64
+        }
+    };
+    ServiceCurve::rate_latency(rate_bps, latency_ps)
+}
+
+/// Parse [`Spar_TSN::Gate_Control_List`] from a [`PropertyMap`] into a
+/// structured [`GateSchedule`].
+///
+/// Returns `None` when the property is unset or the value cannot be
+/// parsed (the latter case is converted to `None` for callers that
+/// already emit a model-level diagnostic at the WCTT pass; deeper
+/// diagnostic surfacing through [`GateScheduleError`] lands in a
+/// follow-up commit alongside the TAS-aware diagnostic kind).
+///
+/// [`Spar_TSN::Gate_Control_List`]: get_gate_control_list_raw
+pub fn get_gate_schedule(props: &PropertyMap) -> Option<GateSchedule> {
+    let raw = get_gate_control_list_raw(props)?;
+    GateSchedule::parse(&raw).ok()
+}
+
+fn parse_decimal_u64(s: &str) -> Option<u64> {
+    s.parse::<u64>().ok()
+}
+
+fn parse_cos_mask(s: &str) -> Option<u8> {
+    if let Some(stripped) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u8::from_str_radix(stripped, 16).ok()
+    } else {
+        s.parse::<u8>().ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -338,5 +645,194 @@ mod tests {
         // String fallback path.
         let props_str = make_props(SPAR_TSN, "Class_of_Service", "5", None);
         assert_eq!(get_class_of_service(&props_str), Some(ClassOfService(5)));
+    }
+
+    // ── TAS gate-window service curve tests (v0.8.1 commit 2) ────────
+
+    /// 1 Gbps in bits per second.
+    const TAS_GBPS: u64 = 1_000_000_000;
+
+    #[test]
+    fn parse_single_window_gcl() {
+        // One window covering the whole cycle, mask=0xFF (all classes
+        // open). Each unit is ns; offset 0, 10 us cycle.
+        let s = GateSchedule::parse("0:10000:0xFF").expect("valid GCL");
+        assert_eq!(s.windows.len(), 1);
+        assert_eq!(s.cycle_ps, 10_000 * 1_000); // 10 us in ps
+        assert_eq!(s.windows[0].offset_ps, 0);
+        assert_eq!(s.windows[0].duration_ps, 10_000_000);
+        assert_eq!(s.windows[0].allowed_cos_mask, 0xFF);
+    }
+
+    #[test]
+    fn parse_two_window_gcl_50_50() {
+        // 5 us only CoS 7 open; 5 us all other CoS open. Standard
+        // motivating example from the commit brief.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").expect("valid GCL");
+        assert_eq!(s.windows.len(), 2);
+        assert_eq!(s.cycle_ps, 10_000_000); // 10 us
+        assert_eq!(s.windows[0].offset_ps, 0);
+        assert_eq!(s.windows[0].duration_ps, 5_000_000);
+        assert_eq!(s.windows[0].allowed_cos_mask, 0x80);
+        assert_eq!(s.windows[1].offset_ps, 5_000_000);
+        assert_eq!(s.windows[1].duration_ps, 5_000_000);
+        assert_eq!(s.windows[1].allowed_cos_mask, 0x7F);
+    }
+
+    #[test]
+    fn parse_eight_window_gcl_round_trip_preserves_order() {
+        // 8 successive 1 us windows opening one CoS at a time, in
+        // 7,6,5,4,3,2,1,0 order. The parser must preserve order.
+        let blob = "0:1000:0x80;1000:1000:0x40;2000:1000:0x20;3000:1000:0x10;\
+                    4000:1000:0x08;5000:1000:0x04;6000:1000:0x02;7000:1000:0x01";
+        let s = GateSchedule::parse(blob).expect("valid 8-window GCL");
+        assert_eq!(s.windows.len(), 8);
+        assert_eq!(s.cycle_ps, 8_000_000); // 8 us
+        let masks: Vec<u8> = s.windows.iter().map(|w| w.allowed_cos_mask).collect();
+        assert_eq!(masks, vec![0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn parse_overlap_rejected() {
+        // Second window starts at 4000 ns but first runs to 5000 ns —
+        // overlap by 1 us.
+        let err = GateSchedule::parse("0:5000:0x80;4000:5000:0x7F").unwrap_err();
+        assert!(matches!(err, GateScheduleError::Overlap { index: 1 }));
+    }
+
+    #[test]
+    fn parse_gap_rejected() {
+        // Second window starts at 6000 ns, first ends at 5000 ns —
+        // 1 us gap.
+        let err = GateSchedule::parse("0:5000:0x80;6000:5000:0x7F").unwrap_err();
+        assert!(matches!(err, GateScheduleError::Gap { index: 1 }));
+    }
+
+    #[test]
+    fn parse_malformed_rejected() {
+        // Missing the third field.
+        assert!(matches!(
+            GateSchedule::parse("0:5000"),
+            Err(GateScheduleError::Malformed(_))
+        ));
+        // Non-numeric offset.
+        assert!(matches!(
+            GateSchedule::parse("xyz:5000:0x80"),
+            Err(GateScheduleError::ParseInt(_))
+        ));
+        // Empty blob.
+        assert_eq!(GateSchedule::parse(""), Err(GateScheduleError::Empty));
+        assert_eq!(GateSchedule::parse("   "), Err(GateScheduleError::Empty));
+        // Trailing semicolon is tolerated (does not produce an empty
+        // entry in the parser); a single semicolon-only blob is empty.
+        assert!(GateSchedule::parse("0:5000:0x80;").is_ok());
+    }
+
+    #[test]
+    fn open_fraction_two_window_50_50() {
+        // CoS 7 open in window 1 only (5 us / 10 us cycle = 50%).
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        let (open_ps, cycle_ps) = s.open_fraction(cos7);
+        assert_eq!(open_ps, 5_000_000);
+        assert_eq!(cycle_ps, 10_000_000);
+
+        // CoS 0 open in window 2 only (also 50%).
+        let cos0 = ClassOfService::new(0).unwrap();
+        let (open0, _) = s.open_fraction(cos0);
+        assert_eq!(open0, 5_000_000);
+    }
+
+    #[test]
+    fn worst_case_latency_two_window() {
+        // CoS 7 open for the first 5 us, closed for the next 5 us. The
+        // longest closed run is 5 us — straight through window 2.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        assert_eq!(s.worst_case_latency(cos7), 5_000_000);
+
+        // CoS 0 closed for the first 5 us, open for the next 5 us. Same
+        // worst-case latency by symmetry.
+        let cos0 = ClassOfService::new(0).unwrap();
+        assert_eq!(s.worst_case_latency(cos0), 5_000_000);
+    }
+
+    #[test]
+    fn worst_case_latency_wrap_around() {
+        // Three windows: closed-open-closed for a particular CoS. The
+        // closed runs straddling the cycle boundary should be combined.
+        // Layout: [0..2us closed for CoS 7][2..4us open for CoS 7][4..10us closed for CoS 7]
+        // Closed runs: window 0 (2 us) + window 2 (6 us). With wrap-around
+        // the longest is window 2 followed by window 0 = 6 + 2 = 8 us.
+        let s = GateSchedule::parse("0:2000:0x7F;2000:2000:0x80;4000:6000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        assert_eq!(s.worst_case_latency(cos7), 8_000_000);
+    }
+
+    #[test]
+    fn worst_case_latency_permanently_closed() {
+        // CoS 0 never opens (no mask has bit 0 set). worst_case_latency
+        // returns the full cycle period — the gate is permanently shut.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0xFE").unwrap();
+        let cos0 = ClassOfService::new(0).unwrap();
+        assert_eq!(s.worst_case_latency(cos0), 10_000_000);
+    }
+
+    #[test]
+    fn tas_residual_service_50_percent_open() {
+        // 50% open, 1 Gbps link → service rate = 500 Mbps.
+        // Latency = 5 us = 5_000_000 ps.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        let svc = tas_residual_service(&s, cos7, TAS_GBPS);
+        assert_eq!(svc.rate_bps, 500_000_000);
+        assert_eq!(svc.latency_ps, 5_000_000);
+    }
+
+    #[test]
+    fn tas_residual_service_full_open() {
+        // Single window covering the whole cycle, all CoS open. Service
+        // rate = link rate; latency = 0 (gate is never closed).
+        let s = GateSchedule::parse("0:10000:0xFF").unwrap();
+        let cos3 = ClassOfService::new(3).unwrap();
+        let svc = tas_residual_service(&s, cos3, TAS_GBPS);
+        assert_eq!(svc.rate_bps, TAS_GBPS);
+        assert_eq!(svc.latency_ps, 0);
+    }
+
+    #[test]
+    fn tas_residual_service_unservable_when_class_never_opens() {
+        // CoS 0 never opens → rate = 0, latency = cycle. The wctt pass
+        // surfaces this as an UnservableFlow downstream.
+        let s = GateSchedule::parse("0:10000:0x80").unwrap();
+        let cos0 = ClassOfService::new(0).unwrap();
+        let svc = tas_residual_service(&s, cos0, TAS_GBPS);
+        assert_eq!(svc.rate_bps, 0);
+        assert_eq!(svc.latency_ps, 10_000_000);
+    }
+
+    #[test]
+    fn get_gate_schedule_reads_property_map() {
+        // String-fallback path: the typed PropertyExpr is None, so the
+        // accessor walks the raw blob through GateSchedule::parse.
+        let props = make_props(
+            SPAR_TSN,
+            "Gate_Control_List",
+            "0:5000:0x80;5000:5000:0x7F",
+            None,
+        );
+        let s = get_gate_schedule(&props).expect("schedule parses");
+        assert_eq!(s.windows.len(), 2);
+        assert_eq!(s.cycle_ps, 10_000_000);
+
+        // Missing property returns None.
+        let empty = PropertyMap::new();
+        assert!(get_gate_schedule(&empty).is_none());
+
+        // Malformed blob returns None (full structured-error surfacing
+        // is a follow-up commit; today's caller emits a model-level
+        // diagnostic at the WCTT pass when this returns None).
+        let bad = make_props(SPAR_TSN, "Gate_Control_List", "not a gcl", None);
+        assert!(get_gate_schedule(&bad).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Implements the IEEE 802.1Qbv Time-Aware Shaper as a TSN-shaped service
curve in `spar-network` and dispatches it from the WCTT analysis. Wave 2
of the v0.8.1 Track D Phase 2 series; sibling PRs CBS / frame-preemption
remain orthogonal in scope.

## What's new

- **`spar-network::tsn`** — `GateSchedule` (parsed `Gate_Control_List`),
  `GateScheduleError`, `GateSchedule::open_fraction` (ρ_K), and
  `GateSchedule::worst_case_latency` (T_K with wrap-around). New
  closed-form `tas_residual_service(schedule, cos, link_rate_bps)` builds
  `β_K(t) = (R_link · ρ_K) · max(0, t − T_K)` per Le Boudec & Thiran NC
  chapter 1. New `get_gate_schedule` typed/string-fallback PropertyMap
  accessor.
- **`spar-analysis::wctt` dispatch** — TSN-typed switches now check for
  both a parsed `Gate_Control_List` on the bus and a
  `Spar_TSN::Class_of_Service` on the source stream. When both are
  present the per-hop service curve becomes the TAS curve and the
  analysis emits a new Info diagnostic `WcttTasGated` carrying
  (`stream_id`, `cos`, `open_fraction%`, `gate_latency_ps`); otherwise
  the v0.8.0 `WcttDeferred` path is preserved.
- **Artifacts** — `REQ-TSN-002` (requirements.yaml) and `TEST-TSN-TAS`
  (verification.yaml) added; the latter links to `REQ-TSN-002` and
  `REQ-NETWORK-006`.

## Files

| File | Δ LOC |
|------|------:|
| `crates/spar-network/src/tsn.rs` | +506 |
| `crates/spar-analysis/src/wctt.rs` | +470 / −35 |
| `artifacts/verification.yaml` | +37 |
| `artifacts/requirements.yaml` | +26 |
| `crates/spar-network/src/lib.rs` | +5 / −1 |

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p spar-network` — 46 lib + 6 integration tests pass
      (14 new TAS tests for parser, ρ_K/T_K, `tas_residual_service`,
      `get_gate_schedule`)
- [x] `cargo test -p spar-analysis --lib -- wctt` — 17 tests pass
      (4 new: TAS dispatch produces `WcttTasGated` + 29 µs bound at
      50% open on 1 Gbps; gated 29 µs strictly exceeds ungated 12 µs;
      missing GCL keeps `WcttDeferred`; missing CoS keeps `WcttDeferred`)
- [x] `cargo test --workspace` no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS

## Coordination

Append-only additions in `tsn.rs` and `wctt.rs` to keep merges with
sibling CBS / frame-preemption PRs trivial. No CBS / Qbu logic was
touched (only the existing `CreditPool` skeleton from #177 is left
alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)