### PR TITLE
feat(tsn): frame preemption (802.1Qbu) blocking term (v0.8.1 c4/5)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1485,6 +1485,32 @@ artifacts:
     status: planned
     tags: [network, tsn, wctt, v081]
 
+  - id: REQ-TSN-004
+    type: requirement
+    title: 802.1Qbu frame-preemption blocking term in WCTT analysis
+    description: >
+      System computes the IEEE 802.1Qbu frame-preemption blocking
+      term `B_pmt = (MIN_FRAGMENT_BYTES + PREEMPTION_HEADER_BYTES) /
+      link_rate` (with MIN_FRAGMENT_BYTES = 64 — IEEE 802.3 minimum
+      Ethernet frame — and PREEMPTION_HEADER_BYTES = 4 — IEEE 802.3br
+      §99.4.7 SMD-S/mCRC) and substitutes it for the legacy
+      `B_no_pmt = max_preemptable_frame_bytes / link_rate` blocking
+      term at TSN switches when both the bus and the source stream
+      declare `Spar_TSN::Frame_Preemption => true`. Express-stream
+      identification follows the explicit-then-default order:
+      `Spar_TSN::Frame_Preemption` on the stream port wins; otherwise
+      `Class_of_Service >= 6` defaults to express. The reduction in
+      blocking is surfaced via the `WcttPreemptionApplied` Info
+      diagnostic emitted per affected hop, carrying the legacy and
+      preempted blocking figures (in nanoseconds) so users can audit
+      the gain. Implemented as `preemption_blocking_term_ps` and
+      `is_express_stream` in `spar-network::tsn`, hooked into
+      `spar-analysis::wctt::WcttAnalysis` and
+      `compute_network_hop_latency`. Track D Phase 2 v0.8.1 commit 4.
+      Per docs/designs/track-d-tsn-wctt-research.md §5.2-5.3.
+    status: implemented
+    tags: [network, tsn, wctt, preemption, qbu, v081]
+
   # ── Track G: spar-insight discrepancy assistant (v0.9.0) ──────────
 
   - id: REQ-INSIGHT-001

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1961,6 +1961,42 @@ artifacts:
       - type: satisfies
         target: REQ-NETWORK-006
 
+  - id: TEST-TSN-PREEMPTION
+    type: feature
+    title: 802.1Qbu frame-preemption blocking term in WCTT analysis
+    description: >
+      Unit + integration tests covering v0.8.1 commit 4's
+      frame-preemption (802.1Qbu) hook into the WCTT analysis. The
+      spar-network::tsn module ships eight tests verifying the
+      preemption_blocking_term_ps helper (with-preemption fragment
+      term, without-preemption legacy max-frame term, zero-rate
+      pathology, ceiling-rounding pessimism) and the is_express_stream
+      classifier (explicit Frame_Preemption overrides the
+      Class_of_Service heuristic, CoS >= 6 defaults to express,
+      missing properties default to non-express). The
+      spar-analysis::wctt module ships four end-to-end fixtures
+      driving the WcttAnalysis pass against AADL models with TSN
+      switches: the express stream carrying explicit
+      `Spar_TSN::Frame_Preemption => true` on a bus that also enables
+      preemption produces a `WcttPreemptionApplied` Info diagnostic
+      reporting the legacy 1518 B blocking (≈121 µs at 100 Mbps) and
+      the preempted 68 B blocking (≈5.4 µs); a stream whose source
+      lacks Frame_Preemption and a bus that is silent both fall
+      through to the existing `WcttDeferred` Phase-1 placeholder; a
+      `Class_of_Service => 7` stream is express by default when the
+      bus enables preemption. Foundation for the c2/c3 sibling PRs
+      (TAS, CBS) which extend the same TSN dispatch.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-network --lib -- tsn
+        - run: cargo test -p spar-analysis --lib -- wctt
+    status: passing
+    tags: [v0.8.1, network, tsn, preemption, qbu, wctt]
+    links:
+      - type: satisfies
+        target: REQ-TSN-004
+
   - id: TEST-INSIGHT-DISCREPANCY
     type: feature
     title: spar-insight CTF parser + 5-kind discrepancy detection

--- a/crates/spar-analysis/src/wctt.rs
+++ b/crates/spar-analysis/src/wctt.rs
@@ -56,7 +56,8 @@ use spar_network::extract::{
     extract_network_graph, read_forwarding_latency_ps, read_output_rate_bps, read_queue_depth,
 };
 use spar_network::tsn::{
-    ClassOfService, GateSchedule, get_class_of_service, get_gate_schedule, tas_residual_service,
+    ClassOfService, GateSchedule, get_class_of_service, get_frame_preemption, get_gate_schedule,
+    is_express_stream, preemption_blocking_term_ps, tas_residual_service,
 };
 use spar_network::types::{NetworkGraph, NodeKind, SwitchType};
 
@@ -74,6 +75,16 @@ const DEFAULT_BURST_BYTES: u64 = 1500;
 /// Default frame size in bytes assumed by [`read_queue_depth`] when
 /// expressed in frames; we approximate one queue slot as one MTU.
 const FRAME_BYTES: u64 = 1500;
+
+/// Maximum preemptable Ethernet frame size in bytes used for the
+/// legacy blocking term (MTU + 14-byte Ethernet header + 4-byte FCS =
+/// 1518 bytes). This is the worst-case in-flight preemptable frame an
+/// express stream can be blocked behind on a TSN-capable port that
+/// has *not* enabled 802.1Qbu preemption — the value the legacy
+/// blocking term [`preemption_blocking_term_ps`] computes when called
+/// with `preemption_enabled = false`. See IEEE 802.1Qbu §6.7.2 and
+/// `docs/designs/track-d-tsn-wctt-research.md` §5.2-5.3.
+const FRAME_BYTES_PREEMPTION_LEGACY: u64 = 1518;
 
 /// WCTT analysis pass.
 ///
@@ -220,15 +231,32 @@ impl WcttAnalysis {
             for (hop_idx, sw_idx) in stream.hops.iter().enumerate() {
                 let st = switch_type.get(sw_idx).copied().unwrap_or(SwitchType::Fifo);
 
-                // TSN switches: prefer the TAS gate-window service
-                // curve when both the bus has a parsed Gate_Control_List
-                // and the stream carries a Spar_TSN::Class_of_Service.
-                // When either is missing, fall back to the v0.8.0
-                // WcttDeferred Info diagnostic and skip the hop's
-                // contribution.
+                // ── TSN switch dispatch ──────────────────────────
+                //
+                // Three-way dispatch order (see PR #180 + #181):
+                //   1. **TAS (802.1Qbv) gate-window service curve** —
+                //      when the bus has a parsed
+                //      `Spar_TSN::Gate_Control_List` *and* the stream
+                //      carries `Spar_TSN::Class_of_Service`. Use
+                //      `tas_residual_service` and emit `WcttTasGated`.
+                //   2. **Frame preemption (802.1Qbu) blocking term** —
+                //      when the bus has `Frame_Preemption => true` and
+                //      the stream is express (per `is_express_stream`).
+                //      Use the bus service curve with its forwarding
+                //      latency replaced by the fragment-blocking term;
+                //      emit `WcttPreemptionApplied` reporting the gain
+                //      relative to the legacy max-frame blocking.
+                //   3. **Deferred** — neither GCL+CoS nor (preemption +
+                //      express). Emit `WcttDeferred` once per stream
+                //      and skip the hop. v0.8.1 commits 2/3/4 are
+                //      filling in the per-shaper math; CBS is the next
+                //      milestone.
                 let svc = if matches!(st, SwitchType::Tsn) {
+                    let bus_props = instance.properties_for(*sw_idx);
+                    let bus_preemption = get_frame_preemption(bus_props).unwrap_or(false);
                     match (gate_schedule_for_bus.get(sw_idx), stream.cos) {
                         (Some(schedule), Some(cos)) => {
+                            // Path 1: TAS service curve.
                             let link_rate = link_rate_for_bus.get(sw_idx).copied().unwrap_or(0);
                             let tas_svc = tas_residual_service(schedule, cos, link_rate);
                             let (open_ps, cycle_ps) = schedule.open_fraction(cos);
@@ -262,32 +290,73 @@ impl WcttAnalysis {
                             tas_svc
                         }
                         _ => {
-                            // No gate schedule or no CoS — fall back to
-                            // the v0.8.0 deferred path. We deliberately
-                            // emit at most one WcttDeferred per stream
-                            // (the diagnostic noise floor matches Phase
-                            // 1's behaviour).
-                            if !deferred_emitted {
+                            // Path 2: frame preemption when bus enables
+                            // it and the stream is express.
+                            if bus_preemption && stream.is_express {
+                                let svc_base = match service_for_bus.get(sw_idx) {
+                                    Some(s) => *s,
+                                    None => continue,
+                                };
+                                if svc_base.rate_bps == 0 {
+                                    continue;
+                                }
+                                let blocking_legacy_ps = preemption_blocking_term_ps(
+                                    svc_base.rate_bps,
+                                    FRAME_BYTES_PREEMPTION_LEGACY,
+                                    false,
+                                );
+                                let blocking_pmt_ps = preemption_blocking_term_ps(
+                                    svc_base.rate_bps,
+                                    FRAME_BYTES_PREEMPTION_LEGACY,
+                                    true,
+                                );
                                 diags.push(AnalysisDiagnostic {
                                     severity: Severity::Info,
                                     message: format!(
-                                        "WcttDeferred: stream '{}' traverses TSN switch '{}' at \
-                                         hop {}; TAS/CBS-shaped service curves are deferred to \
-                                         Phase 2 (tracked in \
-                                         docs/designs/track-d-tsn-wctt-research.md §5.5)",
+                                        "WcttPreemptionApplied: stream '{}' at hop {} on TSN \
+                                         switch '{}': blocking shrinks from {} ns (legacy \
+                                         max-frame) to {} ns (802.1Qbu fragment + header)",
                                         stream_name,
+                                        hop_idx,
                                         graph
                                             .node(*sw_idx)
                                             .map(|n| n.name.as_str())
                                             .unwrap_or("<unknown>"),
-                                        hop_idx,
+                                        blocking_legacy_ps / 1_000,
+                                        blocking_pmt_ps / 1_000,
                                     ),
                                     path: stream_path.clone(),
                                     analysis: self.name().to_string(),
                                 });
-                                deferred_emitted = true;
+                                ServiceCurve::rate_latency(
+                                    svc_base.rate_bps,
+                                    svc_base.latency_ps.saturating_add(blocking_pmt_ps),
+                                )
+                            } else {
+                                // Path 3: deferred placeholder. Emit at
+                                // most one WcttDeferred per stream.
+                                if !deferred_emitted {
+                                    diags.push(AnalysisDiagnostic {
+                                        severity: Severity::Info,
+                                        message: format!(
+                                            "WcttDeferred: stream '{}' traverses TSN switch '{}' \
+                                             at hop {}; TAS/CBS-shaped service curves are \
+                                             deferred to Phase 2 (tracked in \
+                                             docs/designs/track-d-tsn-wctt-research.md §5.5)",
+                                            stream_name,
+                                            graph
+                                                .node(*sw_idx)
+                                                .map(|n| n.name.as_str())
+                                                .unwrap_or("<unknown>"),
+                                            hop_idx,
+                                        ),
+                                        path: stream_path.clone(),
+                                        analysis: self.name().to_string(),
+                                    });
+                                    deferred_emitted = true;
+                                }
+                                continue;
                             }
-                            continue;
                         }
                     }
                 } else {
@@ -551,15 +620,16 @@ pub fn compute_network_hop_latency(
         .as_ref()
         .and_then(|end| resolve_subcomponent(instance, owner_idx, &end.subcomponent));
 
-    let (rate_bps, burst_bytes) = if let Some(idx) = src_idx {
+    let (rate_bps, burst_bytes, src_is_express) = if let Some(idx) = src_idx {
         let src_props = instance.properties_for(idx);
         let rate = read_output_rate_bps(src_props).unwrap_or(0);
         let burst = read_queue_depth(src_props)
             .map(|q| q.saturating_mul(FRAME_BYTES))
             .unwrap_or(DEFAULT_BURST_BYTES);
-        (rate, burst)
+        let express = is_express_stream(src_props);
+        (rate, burst, express)
     } else {
-        (0, DEFAULT_BURST_BYTES)
+        (0, DEFAULT_BURST_BYTES, false)
     };
 
     let mut alpha = ArrivalCurve::affine(burst_bytes, rate_bps);
@@ -610,7 +680,8 @@ pub fn compute_network_hop_latency(
         let bus_props = instance.properties_for(*sw_idx);
         let rate = read_output_rate_bps(bus_props).unwrap_or(0);
         let (bcet_ps, wcet_ps) = read_forwarding_latency_ps(bus_props).unwrap_or((0, 0));
-        let svc = ServiceCurve::rate_latency(rate, wcet_ps);
+        let bus_preemption = get_frame_preemption(bus_props).unwrap_or(false);
+        let svc_base = ServiceCurve::rate_latency(rate, wcet_ps);
 
         // The min (best-case) bound is the BCET forwarding latency for
         // this hop — purely the propagation/forwarding floor, no
@@ -618,7 +689,7 @@ pub fn compute_network_hop_latency(
         // BCET is a lower bound.
         total_min_ps = total_min_ps.saturating_add(bcet_ps);
 
-        if svc.rate_bps == 0 {
+        if svc_base.rate_bps == 0 {
             // Without a finite service rate we cannot compute a worst-
             // case bound for this hop. Skip the queuing contribution
             // and trust BCET == WCET on the propagation floor.
@@ -626,15 +697,32 @@ pub fn compute_network_hop_latency(
             continue;
         }
 
-        // TSN switches: opaque in Phase 1. Skip queuing contribution
-        // (propagate the WCET floor only) — the WcttAnalysis pass also
-        // emits a `WcttDeferred` Info on the same switch.
+        // TSN switches: preemption-aware dispatch (v0.8.1 c4). When
+        // both the bus and the source stream declare
+        // `Frame_Preemption => true`, we replace the bus
+        // forwarding-latency floor with the small fragment-blocking
+        // term and continue with residual_service / delay_bound.
+        // Without preemption active we keep the v0.8.0 Phase 1 fallback
+        // (propagate the WCET floor only) — c2/c3 fill in TAS/CBS later.
+        let mut svc = svc_base;
         if let Some(node) = graph.node(*sw_idx)
             && let NodeKind::Switch { switch_type } = node.kind
             && matches!(switch_type, SwitchType::Tsn)
         {
-            total_max_ps = total_max_ps.saturating_add(wcet_ps);
-            continue;
+            if bus_preemption && src_is_express {
+                let blocking_pmt_ps = preemption_blocking_term_ps(
+                    svc_base.rate_bps,
+                    FRAME_BYTES_PREEMPTION_LEGACY,
+                    true,
+                );
+                svc = ServiceCurve::rate_latency(
+                    svc_base.rate_bps,
+                    svc_base.latency_ps.saturating_add(blocking_pmt_ps),
+                );
+            } else {
+                total_max_ps = total_max_ps.saturating_add(wcet_ps);
+                continue;
+            }
         }
 
         // Build the competing arrival curve for this hop.
@@ -754,6 +842,12 @@ struct Stream {
     /// without a CoS fall back to the [`Severity::Info`]-emitting
     /// `WcttDeferred` path.
     cos: Option<ClassOfService>,
+    /// Whether this stream qualifies as "express" for IEEE 802.1Qbu
+    /// preemption purposes (see [`is_express_stream`]). Express
+    /// streams pay only the preemption-fragment blocking at TSN ports
+    /// where the bus also enables `Frame_Preemption`; non-express
+    /// streams keep the legacy `max_frame / R` blocking term.
+    is_express: bool,
 }
 
 impl Stream {
@@ -863,6 +957,15 @@ fn collect_streams(
             // already use.
             let cos = get_class_of_service(src_props);
 
+            // Express-stream classification (IEEE 802.1Qbu). Read from
+            // the source-component's PropertyMap so that AADL fixtures
+            // can declare either `Spar_TSN::Frame_Preemption => true`
+            // explicitly or rely on the `Class_of_Service >= 6`
+            // default. A stream that is not express still walks TSN
+            // hops below; it just pays the legacy `max_frame / R`
+            // blocking term rather than the preemption-fragment term.
+            let is_express = is_express_stream(src_props);
+
             streams.push(Stream {
                 name: conn.name.as_str().to_string(),
                 src_idx,
@@ -870,6 +973,7 @@ fn collect_streams(
                 hops,
                 alpha,
                 cos,
+                is_express,
             });
         }
     }
@@ -1929,5 +2033,352 @@ end Net;
             .find(|d| d.message.starts_with("WcttDeferred"))
             .unwrap_or_else(|| panic!("expected WcttDeferred: {:#?}", diags));
         assert!(deferred.severity == Severity::Info);
+    }
+
+    // ── Test 15: TSN preemption shrinks the per-hop blocking term ────
+    #[test]
+    fn tsn_preemption_emits_applied_diagnostic_and_computes_bound() {
+        // 1-switch TSN network. Bus = 100 Mbps with
+        // `Frame_Preemption => true`; one express stream
+        // (`Frame_Preemption => true` on the source) and one
+        // preemptable stream (no `Frame_Preemption`, CoS = 0).
+        // The express stream must:
+        //   - get a `WcttPreemptionApplied` Info diagnostic
+        //   - get a finite `WcttBound` (no `WcttDeferred`)
+        // The preemptable stream stays opaque (`WcttDeferred`).
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 100000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Frame_Preemption       => true;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device d
+    features
+      net : requires bus access;
+      out_p : out data port;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  device express_d
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Frame_Preemption => true;
+  end express_d;
+  device implementation express_d.impl
+  end express_d.impl;
+
+  device pre_d
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 0;
+  end pre_d;
+  device implementation pre_d.impl
+  end pre_d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      ex : device express_d.impl;
+      pr : device pre_d.impl;
+      ex_dst : device d.impl;
+      pr_dst : device d.impl;
+    connections
+      c_sw_ex     : bus access sw -> ex.net;
+      c_sw_pr     : bus access sw -> pr.net;
+      c_sw_ex_dst : bus access sw -> ex_dst.net;
+      c_sw_pr_dst : bus access sw -> pr_dst.net;
+      data_ex     : port ex.out_p -> ex_dst.in_p;
+      data_pr     : port pr.out_p -> pr_dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+
+        // The express stream must produce a `WcttPreemptionApplied`
+        // Info diagnostic.
+        let applied: Vec<&AnalysisDiagnostic> = diags
+            .iter()
+            .filter(|d| d.message.starts_with("WcttPreemptionApplied"))
+            .collect();
+        assert_eq!(
+            applied.len(),
+            1,
+            "expected exactly one WcttPreemptionApplied for the express \
+             stream: {:#?}",
+            diags
+        );
+        assert!(applied[0].severity == Severity::Info);
+        // Numbers reported in nanoseconds in the diagnostic message.
+        // Legacy: 1518 B · 8 / 100 Mbps = 121_440 ns.
+        // With preemption: 68 B · 8 / 100 Mbps = 5_440 ns.
+        assert!(
+            applied[0].message.contains("121440 ns"),
+            "expected legacy blocking 121440 ns: {}",
+            applied[0].message
+        );
+        assert!(
+            applied[0].message.contains("5440 ns"),
+            "expected preempted blocking 5440 ns: {}",
+            applied[0].message
+        );
+
+        // The express stream gets a `WcttBound` (computed bound).
+        let express_bound = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttBound") && d.message.contains("data_ex"))
+            .unwrap_or_else(|| panic!("expected WcttBound for data_ex: {:#?}", diags));
+        assert!(express_bound.severity == Severity::Info);
+
+        // The preemptable stream still falls through to `WcttDeferred`.
+        let deferred = diags
+            .iter()
+            .find(|d| d.message.starts_with("WcttDeferred") && d.message.contains("data_pr"))
+            .unwrap_or_else(|| panic!("expected WcttDeferred for data_pr: {:#?}", diags));
+        assert!(deferred.severity == Severity::Info);
+    }
+
+    // ── Test 16: bus without Frame_Preemption keeps deferred path ────
+    #[test]
+    fn tsn_without_bus_preemption_keeps_deferred() {
+        // Even a stream that declares `Frame_Preemption => true` on its
+        // source falls through to `WcttDeferred` when the bus has not
+        // opted in (`Frame_Preemption` unset on the bus). This matches
+        // the c4 spec's "explicit-then-default order" — both sides must
+        // explicitly say yes for the small fragment-blocking term to
+        // apply, and a missing bus property is the safe `false` default.
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 100000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device express_d
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Frame_Preemption => true;
+  end express_d;
+  device implementation express_d.impl
+  end express_d.impl;
+
+  device d
+    features
+      net   : requires bus access;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      ex : device express_d.impl;
+      ex_dst : device d.impl;
+    connections
+      c_sw_ex     : bus access sw -> ex.net;
+      c_sw_ex_dst : bus access sw -> ex_dst.net;
+      data_ex     : port ex.out_p -> ex_dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+
+        // No `WcttPreemptionApplied` because the bus is silent.
+        let applied: Vec<&AnalysisDiagnostic> = diags
+            .iter()
+            .filter(|d| d.message.starts_with("WcttPreemptionApplied"))
+            .collect();
+        assert!(
+            applied.is_empty(),
+            "WcttPreemptionApplied must not fire when the bus omits \
+             Frame_Preemption: {:#?}",
+            diags
+        );
+        // `WcttDeferred` fires instead.
+        assert!(
+            diags.iter().any(|d| d.message.starts_with("WcttDeferred")),
+            "expected WcttDeferred when bus has no Frame_Preemption: {:#?}",
+            diags
+        );
+    }
+
+    // ── Test 17: stream without Frame_Preemption keeps deferred ─────
+    #[test]
+    fn tsn_with_low_cos_stream_keeps_deferred() {
+        // Bus declares `Frame_Preemption => true` but the source
+        // stream is preemptable (CoS = 0). No `WcttPreemptionApplied`
+        // is emitted; the stream falls through to `WcttDeferred`.
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 100000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Frame_Preemption       => true;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device pre_d
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 0;
+  end pre_d;
+  device implementation pre_d.impl
+  end pre_d.impl;
+
+  device d
+    features
+      net   : requires bus access;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      pr : device pre_d.impl;
+      pr_dst : device d.impl;
+    connections
+      c_sw_pr     : bus access sw -> pr.net;
+      c_sw_pr_dst : bus access sw -> pr_dst.net;
+      data_pr     : port pr.out_p -> pr_dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+
+        let applied: Vec<&AnalysisDiagnostic> = diags
+            .iter()
+            .filter(|d| d.message.starts_with("WcttPreemptionApplied"))
+            .collect();
+        assert!(
+            applied.is_empty(),
+            "WcttPreemptionApplied must not fire for non-express \
+             streams: {:#?}",
+            diags
+        );
+        let deferred: Vec<&AnalysisDiagnostic> = diags
+            .iter()
+            .filter(|d| d.message.starts_with("WcttDeferred"))
+            .collect();
+        assert!(
+            !deferred.is_empty(),
+            "expected WcttDeferred for non-express stream: {:#?}",
+            diags
+        );
+    }
+
+    // ── Test 18: high-CoS stream is express by default ──────────────
+    #[test]
+    fn tsn_high_cos_stream_is_express_by_default() {
+        // No `Frame_Preemption` set on the source, but `Class_of_Service
+        // => 7` makes it express via the default heuristic. With the
+        // bus also declaring `Frame_Preemption => true`, preemption
+        // applies and `WcttPreemptionApplied` is emitted.
+        let src = r#"
+package Net
+public
+
+  bus eth
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 100000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Frame_Preemption       => true;
+  end eth;
+  bus implementation eth.impl
+  end eth.impl;
+
+  device cos_d
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end cos_d;
+  device implementation cos_d.impl
+  end cos_d.impl;
+
+  device d
+    features
+      net   : requires bus access;
+      in_p  : in data port;
+  end d;
+  device implementation d.impl
+  end d.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      sw : bus eth.impl;
+      hi : device cos_d.impl;
+      hi_dst : device d.impl;
+    connections
+      c_sw_hi     : bus access sw -> hi.net;
+      c_sw_hi_dst : bus access sw -> hi_dst.net;
+      data_hi     : port hi.out_p -> hi_dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw));
+  end Sys.impl;
+end Net;
+"#;
+        let inst = instantiate(src, "Net", "Sys", "impl");
+        let diags = WcttAnalysis.analyze(&inst);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.starts_with("WcttPreemptionApplied")),
+            "high-CoS stream must opt into preemption by default: {:#?}",
+            diags
+        );
     }
 }

--- a/crates/spar-network/src/lib.rs
+++ b/crates/spar-network/src/lib.rs
@@ -54,7 +54,8 @@ pub use curves::{
 };
 pub use extract::extract_network_graph;
 pub use tsn::{
-    ClassOfService, CreditPool, GateSchedule, GateScheduleError, GateWindow, get_gate_schedule,
+    ClassOfService, CreditPool, GateSchedule, GateScheduleError, GateWindow, MIN_FRAGMENT_BYTES,
+    PREEMPTION_HEADER_BYTES, get_gate_schedule, is_express_stream, preemption_blocking_term_ps,
     tas_residual_service,
 };
 pub use types::{NetworkGraph, NetworkLink, NetworkNode, NodeKind, SwitchType};

--- a/crates/spar-network/src/tsn.rs
+++ b/crates/spar-network/src/tsn.rs
@@ -166,6 +166,119 @@ pub fn get_gate_control_list_raw(props: &PropertyMap) -> Option<String> {
     get_raw(props, "Gate_Control_List").map(|s| s.trim().trim_matches('"').to_string())
 }
 
+// ── Frame preemption (802.1Qbu) ──────────────────────────────────────
+//
+// 802.1Qbu allows an "express" traffic class to interrupt a
+// "preemptable" frame mid-flight, dramatically shrinking the worst-case
+// blocking term seen by express frames at a port. Without preemption,
+// an express frame may have to wait for an entire preemptable MTU to
+// drain before it can be transmitted (B_no_pmt = max_preemptable_frame
+// / link_rate). With preemption, that blocking shrinks to a single
+// minimum fragment plus the preemption header
+// (B_pmt = (MIN_FRAGMENT_BYTES + PREEMPTION_HEADER_BYTES) / link_rate).
+//
+// References:
+// - IEEE Std 802.1Qbu-2016 (Frame Preemption), §6.7.2.
+// - IEEE Std 802.3br-2016 (Interspersed Express Traffic), §99.4.7
+//   (mPacket and the 4-byte mCRC / SMD-S preemption header).
+// - Le Boudec & Thiran, *Network Calculus* (2001), §1.5 (FIFO blocking
+//   bounds — the "max_p_size / R" envelope that preemption attacks).
+// - docs/designs/track-d-tsn-wctt-research.md §5.2-5.3.
+
+/// Minimum Ethernet frame payload size, in bytes (IEEE 802.3 §3.2.7
+/// "minFrameSize" — 64 bytes including FCS, the smallest legal
+/// Ethernet frame). When 802.1Qbu preemption is enabled this is the
+/// minimum size of an in-flight preemptable fragment, and so it
+/// dominates the residual blocking seen by an express frame.
+pub const MIN_FRAGMENT_BYTES: u64 = 64;
+
+/// Preemption header overhead per fragment, in bytes (IEEE 802.3br
+/// §99.4.7 — the SMD-S/SMD-C start-of-mPacket delimiter plus the
+/// 4-byte mCRC tail). Charged once per blocking event because the
+/// express frame waits at most one fragment to start transmitting.
+pub const PREEMPTION_HEADER_BYTES: u64 = 4;
+
+/// Picoseconds per second; mirrors `crates/spar-network/src/curves.rs`
+/// to keep the unit conversion auditable in one place.
+const PS_PER_SECOND: u128 = 1_000_000_000_000;
+/// Bits per byte.
+const BITS_PER_BYTE: u128 = 8;
+
+/// Compute the per-hop blocking term, in picoseconds, that an express
+/// frame may encounter at a TSN port before it can begin transmission.
+///
+/// - `link_rate_bps` — egress link rate in bits per second.
+/// - `max_competing_frame_bytes` — the largest preemptable frame size
+///   that could be in flight when the express frame arrives (typically
+///   the link MTU, e.g. 1518 bytes including the 4-byte VLAN tag).
+/// - `preemption_enabled` — whether IEEE 802.1Qbu preemption is active
+///   on both the express stream and the bus. When `true`, the
+///   blocking term shrinks to
+///   `(MIN_FRAGMENT_BYTES + PREEMPTION_HEADER_BYTES) / link_rate`;
+///   when `false`, the legacy
+///   `max_competing_frame_bytes / link_rate` term is returned.
+///
+/// Returns `0` when `link_rate_bps == 0` (the caller is responsible
+/// for screening that pathological case — a port with zero rate has
+/// already failed the bus-bandwidth check).
+///
+/// The returned value is rounded *up* (ceiling division) so the
+/// blocking term is never an under-estimate; this matches the
+/// pessimism direction used elsewhere in `spar-network::curves`
+/// (`time_to_send_ps` is also a ceiling). See
+/// `docs/designs/track-d-tsn-wctt-research.md` §5.2-5.3 for the
+/// mathematical derivation.
+pub fn preemption_blocking_term_ps(
+    link_rate_bps: u64,
+    max_competing_frame_bytes: u64,
+    preemption_enabled: bool,
+) -> u64 {
+    if link_rate_bps == 0 {
+        return 0;
+    }
+    let bytes = if preemption_enabled {
+        MIN_FRAGMENT_BYTES.saturating_add(PREEMPTION_HEADER_BYTES)
+    } else {
+        max_competing_frame_bytes
+    };
+    let numer = (bytes as u128) * BITS_PER_BYTE * PS_PER_SECOND;
+    let denom = link_rate_bps as u128;
+    let ps = numer.div_ceil(denom);
+    if ps > u64::MAX as u128 {
+        u64::MAX
+    } else {
+        ps as u64
+    }
+}
+
+/// Decide whether a stream is "express" — entitled to preempt other
+/// traffic — given its source-side properties.
+///
+/// Resolution order, per IEEE 802.1Qbu typical mappings and the v0.8.1
+/// c4 spec:
+///
+/// 1. If the stream has an explicit `Spar_TSN::Frame_Preemption` set,
+///    use it (`true` ⇒ express).
+/// 2. Otherwise default by class-of-service: a stream is express iff
+///    `Class_of_Service >= 6` (the two highest 802.1Q PCP values are
+///    conventionally reserved for network control / time-sensitive
+///    express traffic).
+/// 3. With neither property declared, the stream is *not* express.
+///
+/// The "explicit-then-default" order matches the c4 design spec: an
+/// explicit `Frame_Preemption => false` on a high-priority stream
+/// overrides the CoS heuristic, and an explicit `Frame_Preemption =>
+/// true` on a low-priority stream forces express semantics.
+pub fn is_express_stream(props: &PropertyMap) -> bool {
+    if let Some(b) = get_frame_preemption(props) {
+        return b;
+    }
+    if let Some(cos) = get_class_of_service(props) {
+        return cos.0 >= 6;
+    }
+    false
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────
 
 const SIZE_UNIT_FACTORS_BYTES: &[(&str, u64)] = &[
@@ -834,5 +947,141 @@ mod tests {
         // diagnostic at the WCTT pass when this returns None).
         let bad = make_props(SPAR_TSN, "Gate_Control_List", "not a gcl", None);
         assert!(get_gate_schedule(&bad).is_none());
+    }
+
+    // ── Frame preemption (802.1Qbu) ──────────────────────────────────
+
+    /// 100 Mbps in bits per second.
+    const HUNDRED_MBPS: u64 = 100_000_000;
+
+    #[test]
+    fn preemption_constants_match_802_3br() {
+        // IEEE 802.3 minFrameSize = 64 bytes (incl. FCS).
+        assert_eq!(MIN_FRAGMENT_BYTES, 64);
+        // IEEE 802.3br SMD-S + 4-byte mCRC = 4 bytes preemption header.
+        assert_eq!(PREEMPTION_HEADER_BYTES, 4);
+    }
+
+    #[test]
+    fn preemption_blocking_term_with_preemption_enabled() {
+        // 100 Mbps, MTU=1518 (irrelevant when preemption is enabled).
+        // Bytes blocked = 64 + 4 = 68 bytes.
+        // Blocking time = 68 * 8 * 1e12 / 1e8 = 5_440_000 ps = 5.44 us.
+        let t = preemption_blocking_term_ps(HUNDRED_MBPS, 1518, true);
+        assert_eq!(t, 5_440_000);
+    }
+
+    #[test]
+    fn preemption_blocking_term_without_preemption_falls_back_to_max_frame() {
+        // 100 Mbps, MTU=1518: the legacy term.
+        // Blocking time = 1518 * 8 * 1e12 / 1e8 = 121_440_000 ps ≈ 121 us.
+        let t = preemption_blocking_term_ps(HUNDRED_MBPS, 1518, false);
+        assert_eq!(t, 121_440_000);
+    }
+
+    #[test]
+    fn preemption_blocking_term_zero_rate_returns_zero() {
+        // Pathological zero-rate input is screened by bus_bandwidth
+        // upstream; we just make sure we don't panic / divide by zero.
+        assert_eq!(preemption_blocking_term_ps(0, 1518, true), 0);
+        assert_eq!(preemption_blocking_term_ps(0, 1518, false), 0);
+    }
+
+    #[test]
+    fn preemption_blocking_term_rounds_up_for_pessimism() {
+        // Non-integer-byte boundary: 65 bytes at 100 Mbps with no
+        // preemption enabled. 65 * 8 = 520 bits @ 100 Mbps = 5.2 us.
+        // Integer-rounded numerator/denominator: 5_200_000_000_000_000
+        // / 100_000_000 = 5_200_000 ps exactly. Pick a rate that is
+        // *not* a clean divisor instead.
+        // 1518 bytes at 1 Gbps: 1518 * 8 * 1e12 / 1e9 = 12_144_000 ps
+        // exactly. Use 999_999_999 bps (1 Gbps - 1 bps) so we straddle.
+        let exact = preemption_blocking_term_ps(1_000_000_000, 1518, false);
+        let nearly = preemption_blocking_term_ps(999_999_999, 1518, false);
+        // Nearly-Gbps (lower) takes *strictly more* time than exact Gbps.
+        assert!(nearly > exact);
+        // Difference is at most one ceiling round-up bit (1 ps).
+        assert!(nearly - exact >= 1);
+    }
+
+    #[test]
+    fn is_express_stream_explicit_overrides_cos() {
+        // Explicit Frame_Preemption=>true forces express even at low CoS.
+        let mut props = make_props(
+            SPAR_TSN,
+            "Class_of_Service",
+            "0",
+            Some(PropertyExpr::Integer(0, None)),
+        );
+        props.add(spar_hir_def::properties::PropertyValue {
+            name: PropertyRef {
+                property_set: Some(Name::new(SPAR_TSN)),
+                property_name: Name::new("Frame_Preemption"),
+            },
+            value: "true".to_string(),
+            typed_expr: Some(PropertyExpr::Boolean(true)),
+            is_append: false,
+        });
+        assert!(is_express_stream(&props));
+
+        // Explicit Frame_Preemption=>false forces preemptable even at
+        // high CoS.
+        let mut props = make_props(
+            SPAR_TSN,
+            "Class_of_Service",
+            "7",
+            Some(PropertyExpr::Integer(7, None)),
+        );
+        props.add(spar_hir_def::properties::PropertyValue {
+            name: PropertyRef {
+                property_set: Some(Name::new(SPAR_TSN)),
+                property_name: Name::new("Frame_Preemption"),
+            },
+            value: "false".to_string(),
+            typed_expr: Some(PropertyExpr::Boolean(false)),
+            is_append: false,
+        });
+        assert!(!is_express_stream(&props));
+    }
+
+    #[test]
+    fn is_express_stream_cos_default_threshold() {
+        // No Frame_Preemption set → fall back to CoS-based default.
+        // CoS 0..=5: not express.
+        for cos in 0u8..=5 {
+            let props = make_props(
+                SPAR_TSN,
+                "Class_of_Service",
+                &cos.to_string(),
+                Some(PropertyExpr::Integer(cos as i64, None)),
+            );
+            assert!(
+                !is_express_stream(&props),
+                "CoS {} must default to non-express",
+                cos
+            );
+        }
+        // CoS 6 and 7: express.
+        for cos in 6u8..=7 {
+            let props = make_props(
+                SPAR_TSN,
+                "Class_of_Service",
+                &cos.to_string(),
+                Some(PropertyExpr::Integer(cos as i64, None)),
+            );
+            assert!(
+                is_express_stream(&props),
+                "CoS {} must default to express",
+                cos
+            );
+        }
+    }
+
+    #[test]
+    fn is_express_stream_no_props_is_not_express() {
+        // Neither Frame_Preemption nor Class_of_Service declared: the
+        // safe default is non-express (preemptable).
+        let empty = PropertyMap::new();
+        assert!(!is_express_stream(&empty));
     }
 }


### PR DESCRIPTION
## Summary

Adds the IEEE 802.1Qbu frame-preemption hook to the WCTT analysis (Track D Phase 2 v0.8.1 c4/5). Express streams traversing TSN switches now have their per-hop blocking term shrunk from the legacy `max_frame / link_rate` (≈121 µs at 100 Mbps with a 1518 B MTU) to `(64 + 4) / link_rate` (≈5.4 µs) when both the bus and the source stream declare `Spar_TSN::Frame_Preemption => true`.

- New public API in `spar-network::tsn`: constants `MIN_FRAGMENT_BYTES = 64` (IEEE 802.3 minFrameSize) and `PREEMPTION_HEADER_BYTES = 4` (IEEE 802.3br §99.4.7 SMD-S/mCRC); helpers `preemption_blocking_term_ps(...)` (with ceiling-rounded pessimism direction) and `is_express_stream(...)` (explicit `Frame_Preemption` overrides the `Class_of_Service >= 6` default).
- `spar-analysis::wctt` dispatches at TSN hops on `(bus_preemption AND stream_express)` — when active it computes a real residual_service / delay_bound and emits a new `WcttPreemptionApplied` Info diagnostic carrying the legacy and preempted blocking figures (ns); when inactive it preserves the existing `WcttDeferred` Phase-1 placeholder so the c2 (TAS) and c3 (CBS) sibling PRs can fill in service-curve math without conflict.
- Same dispatch mirrored in `compute_network_hop_latency` so the latency-analysis integration picks up the gain end-to-end.
- REQ-TSN-004 + TEST-TSN-PREEMPTION added (rivet validate: PASS).
- 12 new tests (8 unit-level in `spar-network::tsn`, 4 end-to-end in `spar-analysis::wctt`).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p spar-network` — 40 unit tests (was 32; +8 new)
- [x] `cargo test -p spar-analysis --lib -- wctt` — 17 tests (was 13; +4 new)
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `rivet validate` — Result: PASS

## Coordination

Sibling PRs c2 (TAS) and c3 (CBS) touch the same files. All additions here are append-only:
- New public symbols in `spar-network::tsn` (no edits to existing accessors).
- TSN hop dispatch is gated on `(bus_preemption AND stream_express)`; when false, the v0.8.0 `WcttDeferred` skip is preserved verbatim, so c2/c3 can extend the same dispatch when they replace the deferred branch.

## References

- IEEE Std 802.1Qbu-2016, §6.7.2 (Frame Preemption)
- IEEE Std 802.3br-2016, §99.4.7 (Interspersed Express Traffic)
- `docs/designs/track-d-tsn-wctt-research.md` §5.2-5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)