### PR TITLE
feat(tsn): v0.8.1 Phase 2 integration + COMPLIANCE close-out (c5/5)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,8 +1,8 @@
 # AS5506 AADL v2.2 Compliance Gap Analysis
 
-**Updated**: 2026-04-27 (v0.7.1 released; v0.8.0 in progress)
+**Updated**: 2026-04-28 (v0.8.0 released; v0.8.1 Phase 2 TSN close-out in progress)
 **Source**: 102 HTML files from OSATE2 (`org.osate.help/html/std/`)
-**Toolchain**: spar (2200+ tests passing across 18 crates)
+**Toolchain**: spar (2759+ tests passing across 18 crates)
 
 ---
 
@@ -240,6 +240,28 @@ artifacts at github.com/pulseengine/spar/releases/tag/v0.7.1.
 - Criterion benchmarks for scheduling solver and codegen (#143, closes #137).
 - Lean / Bazel / proptest CI gates (#151, closes #135) — Lean proofs now machine-checked in CI for the first time.
 - Track D and Track E research design docs (#152, #153) and Track F engagement strategy (#160) anchoring v0.8.0+ scope.
+
+---
+
+## v0.8.1 (Track D Phase 2 close-out, in progress on main)
+
+**Track D — TSN/Ethernet WCTT analysis, Phase 2 (5/5 commits delivered)**
+
+Phase 2 wires the TSN-shaped service curves the v0.8.0 close-out had explicitly deferred. The four-way dispatch in `crates/spar-analysis/src/wctt.rs` now selects the per-hop service curve based on bus + stream properties, with a deterministic precedence (TAS → CBS → preemption → deferred) so a model that only carries one shaping property gets the matching arm and nothing else.
+
+- Foundation: `Spar_TSN` property set (`Stream_ID`, `Class_of_Service`, `Gate_Control_List`, `Max_Frame_Size`, `Frame_Preemption`) + `spar-network::tsn` skeleton (#177).
+- TAS (802.1Qbv) gate-window service curve (#180): `GateSchedule` parser for the Gate_Control_List string, `tas_residual_service` closed form (`R_K = R_link · open_fraction(K)`, `T_K = max_closed_window(K) + max_frame / R_link`), and `WcttTasGated` Info diagnostic carrying open fraction + worst-case gate latency. Wctt dispatch routes streams whose source declares `Class_of_Service` matching a window in the bus's GCL.
+- CBS (802.1Qav) credit-pool service curve (#182): `CbsReservation::new` (validates idle/link rates, computes `sendSlope = idleSlope − linkRate`), `cbs_residual_service` per Le Boudec/Thiran §1.4.3 + Lim et al., and `WcttCbsShaped` Info diagnostic carrying idle slope + service latency in ns. New property `Spar_TSN::Bandwidth_Reservation`. Wctt dispatch routes streams whose source declares the reservation when no GCL is active.
+- Frame preemption (802.1Qbu) blocking term (#181): `preemption_blocking_term_ps` closed form (legacy `max_frame / R` vs. preempted `(MIN_FRAGMENT + PREEMPTION_HEADER) / R`), `is_express_stream` resolver (explicit `Frame_Preemption` overrides default `CoS >= 6`), and `WcttPreemptionApplied` Info diagnostic carrying both the legacy and preempted blocking terms in ns. Wctt dispatch routes express streams when the bus has `Frame_Preemption => true`.
+- Integration close-out (this commit): single-instance integration test in `crates/spar-analysis/tests/tsn_integration.rs` that exercises all three dispatch arms in one `WcttAnalysis::analyze` run (three sub-systems, one per shaping path; asserts `WcttTasGated`, `WcttCbsShaped`, and `WcttPreemptionApplied` co-exist and carry plausible numeric values; asserts no `WcttDeferred` slips through). COMPLIANCE.md + design-doc Phase 2 status block updated. Total predeclared property count: 128 (Spar_TSN: 6 properties).
+
+Deferred to v0.8.x (research-grade follow-ups, not blockers for the close-out):
+
+- Piecewise-affine NC composition: the v0.8.1 service curves are rate-latency closed forms; multi-class TAS schedules and chained CBS classes both benefit from the more general piecewise-affine min-plus convolution that v0.8.0 deliberately scoped to v0.9.0.
+- Multi-stream sharing of a CBS class: today the CBS service curve is treated as exclusive to the tagged stream (other-class blocking is absorbed into the latency term). Same-class residual decomposition lands when the second CBS-shaped stream model arrives.
+- Advanced TAS guards: GCL gap detection across cascaded switches (the "no-wait packet scheduling" problem) and modal GCL transients are scoped to v0.9.0.
+
+**Test count delta**: v0.8.0 closed at ~2200+ tests across 18 crates; v0.8.1 Phase 2 lands at 2759 passing tests across 18 crates (delta ~+550 tests, dominated by the new spar-mcp / spar-insight surfaces from the v0.9.0 foundations and the TSN unit + integration tests under spar-network::tsn and spar-analysis::wctt).
 
 ---
 

--- a/crates/spar-analysis/tests/tsn_integration.rs
+++ b/crates/spar-analysis/tests/tsn_integration.rs
@@ -1,0 +1,403 @@
+//! Phase 2 TSN end-to-end integration test.
+//!
+//! Exercises the four-way TSN dispatch in
+//! [`spar_analysis::wctt::WcttAnalysis`] introduced across v0.8.1
+//! commits 2-4 (PR #180 TAS, #182 CBS, #181 Frame Preemption). A single
+//! `SystemInstance` is constructed with three TSN-typed buses — one per
+//! shaping path — wrapped as three sub-systems of a root system. Each
+//! sub-system carries its own `Actual_Connection_Binding` so the
+//! dispatch consistently picks one shaping arm per stream:
+//!
+//! - **TAS (802.1Qbv)**: bus carries `Spar_TSN::Gate_Control_List`; the
+//!   stream declares `Spar_TSN::Class_of_Service => 7`. Dispatch's
+//!   first arm matches `(GCL_on_bus, stream.cos)` and routes here.
+//!   Expect one `WcttTasGated` Info diagnostic carrying the open
+//!   fraction (50% for the GCL `"0:5000:0x80;5000:5000:0x7F"`) and the
+//!   worst-case gate latency (5 000 000 ps = 5 us — the GCL offsets
+//!   are in nanoseconds per the c2 parser, hence ps when reported).
+//! - **CBS (802.1Qav)**: bus is plain TSN (no GCL); the stream
+//!   declares `Spar_TSN::Bandwidth_Reservation` plus a CoS so the
+//!   dispatch falls past TAS (no GCL on this bus) into the CBS arm.
+//!   Expect one `WcttCbsShaped` Info diagnostic carrying
+//!   `idle_slope=300000000 bps`.
+//! - **Frame preemption (802.1Qbu)**: bus declares only
+//!   `Spar_TSN::Frame_Preemption => true` (no GCL); the stream
+//!   declares `Spar_TSN::Class_of_Service => 7`, which makes it
+//!   express via [`is_express_stream`]'s default heuristic. Both prior
+//!   arms fail (no GCL on this bus, no Bandwidth_Reservation on the
+//!   stream); the preemption arm matches because the bus has
+//!   Frame_Preemption=true and the stream is express. Expect one
+//!   `WcttPreemptionApplied` Info diagnostic carrying both the legacy
+//!   max-frame blocking (1518 B · 8 / 100 Mbps = 121 440 ns) and the
+//!   802.1Qbu fragment blocking (68 B · 8 / 100 Mbps = 5 440 ns).
+//!
+//! The test asserts that all three diagnostics fire in the same
+//! `analyze` run, that no `WcttDeferred` slips through (which would
+//! indicate the dispatch arms aren't reached), and that each diagnostic
+//! carries plausible numeric values.
+//!
+//! Per the v0.8.1 c5 close-out scope: same `SystemInstance`, same
+//! `WcttAnalysis::analyze` call, all three Phase-2 diagnostics
+//! co-existing in one run. Multi-stream sharing of a CBS class and
+//! advanced TAS guards stay deferred to v0.8.x follow-ups.
+//!
+//! Traceability (Rivet): REQ-TSN-001 (TAS), REQ-TSN-002 (preemption),
+//! REQ-TSN-003 (CBS); TEST-TSN-DISPATCH (this file).
+
+use spar_analysis::{Analysis, AnalysisDiagnostic, Severity, wctt::WcttAnalysis};
+use spar_hir_def::{
+    HirDefDatabase, Name, file_item_tree, instance::SystemInstance, resolver::GlobalScope,
+};
+
+/// AADL fixture exercising all three Phase-2 TSN dispatch paths in one
+/// system instance. The root `Sys.impl` has three child sub-systems
+/// (`tas_seg`, `cbs_seg`, `pmt_seg`), each containing its own bus +
+/// source + sink + data stream. The sub-system isolation means each
+/// stream's `Actual_Connection_Binding` resolves to exactly one bus —
+/// the one inside its parent sub-system — so the dispatch arm picked
+/// in `wctt.rs` is deterministic per stream.
+const TSN_TRIPLE_DISPATCH_AADL: &str = r#"
+package TsnTriple
+public
+
+  -- ── TAS bus: carries a GCL, opens 50% of the cycle for CoS 7. ─────
+  bus eth_tas
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Gate_Control_List      => "0:5000:0x80;5000:5000:0x7F";
+  end eth_tas;
+  bus implementation eth_tas.impl
+  end eth_tas.impl;
+
+  -- ── CBS bus: plain TSN (no GCL, no preemption). ───────────────────
+  bus eth_cbs
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 1000000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+  end eth_cbs;
+  bus implementation eth_cbs.impl
+  end eth_cbs.impl;
+
+  -- ── Preemption bus: 100 Mbps + Frame_Preemption => true. No GCL,
+  --    so high-CoS streams skip the TAS arm and land on preemption. ──
+  bus eth_pmt
+    properties
+      Spar_Network::Switch_Type        => TSN;
+      Spar_Network::Output_Rate        => 100000000 bitsps;
+      Spar_Network::Forwarding_Latency => 0 us .. 0 us;
+      Spar_Network::Queue_Depth        => 1;
+      Spar_TSN::Frame_Preemption       => true;
+  end eth_pmt;
+  bus implementation eth_pmt.impl
+  end eth_pmt.impl;
+
+  -- ── Plain sink device: no TSN annotations, just receives. ─────────
+  device d_sink
+    features
+      net   : requires bus access;
+      in_p  : in data port;
+  end d_sink;
+  device implementation d_sink.impl
+  end d_sink.impl;
+
+  -- ── TAS source: declares CoS=7 only — bus's GCL drives the gate. ─
+  device d_tas_src
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end d_tas_src;
+  device implementation d_tas_src.impl
+  end d_tas_src.impl;
+
+  -- ── CBS source: declares Bandwidth_Reservation + CoS=5. The CBS
+  --    bus has no GCL so the TAS arm cannot fire even with CoS set;
+  --    the CBS arm matches on the idle slope. CoS=5 keeps the source
+  --    out of the express set (so preemption dispatch is not a risk
+  --    even if a future commit reorders the arms). ───────────────────
+  device d_cbs_src
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service        => 5;
+      Spar_TSN::Bandwidth_Reservation   => 300000000 bitsps;
+      Spar_Network::Queue_Depth         => 1;
+  end d_cbs_src;
+  device implementation d_cbs_src.impl
+  end d_cbs_src.impl;
+
+  -- ── Preemption-express source: high CoS so it counts as express
+  --    by the default heuristic. No CBS reservation, no GCL on its
+  --    bus → falls to the preemption arm. ─────────────────────────────
+  device d_pmt_src
+    features
+      net   : requires bus access;
+      out_p : out data port;
+    properties
+      Spar_TSN::Class_of_Service => 7;
+  end d_pmt_src;
+  device implementation d_pmt_src.impl
+  end d_pmt_src.impl;
+
+  -- ── Per-arm sub-system. Each sub-system contains its own bus, its
+  --    own pair of endpoints, its own stream, and its own
+  --    Actual_Connection_Binding. Because the binding is declared at
+  --    the sub-system scope (i.e. the `system implementation` whose
+  --    `connections` list owns the stream), `collect_streams` picks
+  --    up exactly that bus for that stream. ────────────────────────
+  system TasSeg
+  end TasSeg;
+  system implementation TasSeg.impl
+    subcomponents
+      sw_tas : bus eth_tas.impl;
+      src    : device d_tas_src.impl;
+      dst    : device d_sink.impl;
+    connections
+      c_sw_src : bus access sw_tas -> src.net;
+      c_sw_dst : bus access sw_tas -> dst.net;
+      data_tas : port src.out_p -> dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw_tas));
+  end TasSeg.impl;
+
+  system CbsSeg
+  end CbsSeg;
+  system implementation CbsSeg.impl
+    subcomponents
+      sw_cbs : bus eth_cbs.impl;
+      src    : device d_cbs_src.impl;
+      dst    : device d_sink.impl;
+    connections
+      c_sw_src : bus access sw_cbs -> src.net;
+      c_sw_dst : bus access sw_cbs -> dst.net;
+      data_cbs : port src.out_p -> dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw_cbs));
+  end CbsSeg.impl;
+
+  system PmtSeg
+  end PmtSeg;
+  system implementation PmtSeg.impl
+    subcomponents
+      sw_pmt : bus eth_pmt.impl;
+      src    : device d_pmt_src.impl;
+      dst    : device d_sink.impl;
+    connections
+      c_sw_src : bus access sw_pmt -> src.net;
+      c_sw_dst : bus access sw_pmt -> dst.net;
+      data_pmt : port src.out_p -> dst.in_p;
+    properties
+      Deployment_Properties::Actual_Connection_Binding => (reference (sw_pmt));
+  end PmtSeg.impl;
+
+  -- Root system aggregates the three arm sub-systems.
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      tas_seg : system TasSeg.impl;
+      cbs_seg : system CbsSeg.impl;
+      pmt_seg : system PmtSeg.impl;
+  end Sys.impl;
+end TsnTriple;
+"#;
+
+fn instantiate(aadl_src: &str, pkg: &str, sys: &str, sys_impl: &str) -> SystemInstance {
+    let db = HirDefDatabase::default();
+    let file = spar_base_db::SourceFile::new(
+        &db,
+        "tsn_integration.aadl".to_string(),
+        aadl_src.to_string(),
+    );
+    let tree = file_item_tree(&db, file);
+    let scope = GlobalScope::from_trees(vec![tree]);
+    let inst = SystemInstance::instantiate(
+        &scope,
+        &Name::new(pkg),
+        &Name::new(sys),
+        &Name::new(sys_impl),
+    );
+    assert!(
+        inst.component_count() > 0,
+        "instantiation failed; diagnostics: {:?}",
+        inst.diagnostics
+    );
+    inst
+}
+
+#[test]
+fn phase2_dispatch_routes_each_stream_to_its_shaping_path() {
+    let inst = instantiate(TSN_TRIPLE_DISPATCH_AADL, "TsnTriple", "Sys", "impl");
+    let diags: Vec<AnalysisDiagnostic> = WcttAnalysis.analyze(&inst);
+
+    let by_kind = |kind: &'static str| -> Vec<&AnalysisDiagnostic> {
+        diags
+            .iter()
+            .filter(|d| d.message.starts_with(kind))
+            .collect()
+    };
+
+    let tas = by_kind("WcttTasGated");
+    let cbs = by_kind("WcttCbsShaped");
+    let pmt = by_kind("WcttPreemptionApplied");
+    let deferred = by_kind("WcttDeferred");
+
+    // ── Co-existence: all three shaping diagnostics in the same run. ──
+    assert_eq!(
+        tas.len(),
+        1,
+        "expected exactly one WcttTasGated for the TAS-routed stream; \
+         got {}: full diagnostics: {:#?}",
+        tas.len(),
+        diags
+    );
+    assert_eq!(
+        cbs.len(),
+        1,
+        "expected exactly one WcttCbsShaped for the CBS-routed stream; \
+         got {}: full diagnostics: {:#?}",
+        cbs.len(),
+        diags
+    );
+    assert_eq!(
+        pmt.len(),
+        1,
+        "expected exactly one WcttPreemptionApplied for the express \
+         stream on the preemption-capable port; got {}: full \
+         diagnostics: {:#?}",
+        pmt.len(),
+        diags
+    );
+
+    // ── No WcttDeferred slipped through. If the dispatch routed a
+    //    stream to the legacy Phase-1 deferral path, the dispatch is
+    //    broken — surface it loudly. ───────────────────────────────────
+    assert!(
+        deferred.is_empty(),
+        "no WcttDeferred should fire when every stream has a Phase-2 \
+         shaping path: {:#?}",
+        deferred
+    );
+
+    // ── Severity is Info for all three (they describe successful
+    //    bound computation, not a problem). ───────────────────────────
+    assert!(
+        tas[0].severity == Severity::Info,
+        "WcttTasGated must be Info: {:?}",
+        tas[0]
+    );
+    assert!(
+        cbs[0].severity == Severity::Info,
+        "WcttCbsShaped must be Info: {:?}",
+        cbs[0]
+    );
+    assert!(
+        pmt[0].severity == Severity::Info,
+        "WcttPreemptionApplied must be Info: {:?}",
+        pmt[0]
+    );
+
+    // ── Plausible numeric content per arm. ───────────────────────────
+
+    // TAS: GCL is "0:5000:0x80;5000:5000:0x7F" — 5 us (5 000 ns)
+    //      window for CoS 7 followed by 5 us window for CoS 0..6.
+    //      Open fraction for CoS 7 is 5 000 / 10 000 = 50%. The c2
+    //      parser stores GCL offsets/durations in picoseconds (5 us
+    //      = 5 000 000 ps), so the worst-case gate latency reported
+    //      in the diagnostic is `5000000 ps`.
+    let tas_msg = &tas[0].message;
+    assert!(
+        tas_msg.contains("data_tas"),
+        "WcttTasGated must reference the TAS-routed connection: {}",
+        tas_msg
+    );
+    assert!(
+        tas_msg.contains("CoS 7"),
+        "WcttTasGated must report stream's CoS: {}",
+        tas_msg
+    );
+    assert!(
+        tas_msg.contains("50%"),
+        "WcttTasGated must report 50% open fraction (5 us / 10 us): {}",
+        tas_msg
+    );
+    assert!(
+        tas_msg.contains("gate latency 5000000 ps"),
+        "WcttTasGated must report gate latency 5_000_000 ps (5 us): {}",
+        tas_msg
+    );
+
+    // CBS: idle slope is 300 Mbps (declared on d_cbs_src). The
+    //      WcttCbsShaped message reports `idle_slope=<bps> bps`.
+    let cbs_msg = &cbs[0].message;
+    assert!(
+        cbs_msg.contains("data_cbs"),
+        "WcttCbsShaped must reference the CBS-routed connection: {}",
+        cbs_msg
+    );
+    assert!(
+        cbs_msg.contains("idle_slope=300000000 bps"),
+        "WcttCbsShaped must report idle slope 300 Mbps: {}",
+        cbs_msg
+    );
+    assert!(
+        cbs_msg.contains("cos=5"),
+        "WcttCbsShaped must report stream's CoS: {}",
+        cbs_msg
+    );
+    // The CBS service-curve latency is reported in nanoseconds; it
+    // captures other-class blocking by the 1518 B max-competing
+    // frame. Must be a positive number with the `ns` suffix.
+    assert!(
+        cbs_msg.contains("service_latency=") && cbs_msg.contains(" ns"),
+        "WcttCbsShaped must report service latency in ns: {}",
+        cbs_msg
+    );
+
+    // Preemption: the eth_pmt bus is 100 Mbps. Legacy max-frame
+    //             blocking is 1518 B · 8 bits / 100_000_000 bps =
+    //             121 440 ns. With 802.1Qbu the preemption-fragment
+    //             term is 68 B · 8 / 100 Mbps = 5 440 ns (the 64 B
+    //             minimum frame plus the 4 B mPacket header).
+    let pmt_msg = &pmt[0].message;
+    assert!(
+        pmt_msg.contains("data_pmt"),
+        "WcttPreemptionApplied must reference the preemption-routed \
+         connection: {}",
+        pmt_msg
+    );
+    assert!(
+        pmt_msg.contains("121440 ns"),
+        "WcttPreemptionApplied must report legacy blocking 121440 ns: {}",
+        pmt_msg
+    );
+    assert!(
+        pmt_msg.contains("5440 ns"),
+        "WcttPreemptionApplied must report fragment blocking 5440 ns: {}",
+        pmt_msg
+    );
+
+    // ── Each stream produces a finite WcttBound. ────────────────────
+    let bounds = by_kind("WcttBound");
+    assert_eq!(
+        bounds.len(),
+        3,
+        "expected one WcttBound per stream (3 streams): {:#?}",
+        bounds
+    );
+    for b in &bounds {
+        assert!(b.severity == Severity::Info);
+        assert!(
+            b.message.contains(" ps "),
+            "WcttBound must carry a picosecond bound: {}",
+            b.message
+        );
+    }
+}

--- a/docs/designs/track-d-tsn-wctt-research.md
+++ b/docs/designs/track-d-tsn-wctt-research.md
@@ -969,6 +969,44 @@ sees a smaller subgraph.
 breakpoint pairs, typically <100 breakpoints per curve. ~10 KiB per
 stream → ~2 MiB for 200 streams. Negligible.
 
+### 5.8 Phase 2 implementation status (v0.8.1)
+
+Phase 2 of Track D landed across five v0.8.1 commits. The four-way
+WCTT dispatch in `crates/spar-analysis/src/wctt.rs` now selects the
+per-hop service curve based on `(bus_props, stream_props)` with
+deterministic precedence (TAS → CBS → preemption → deferred); the
+table below tracks status at v0.8.1 close-out:
+
+| Phase 2 item | Section | Status | PR |
+|---|---|---|---|
+| `Spar_TSN::*` property set + `spar-network::tsn` skeleton | §5.1 | DONE | #177 |
+| TAS (802.1Qbv) gate-window service curve, `WcttTasGated` | §4.5 / §5.4 | DONE | #180 |
+| CBS (802.1Qav) credit-pool service curve, `WcttCbsShaped` | §4.5 / §5.4 | DONE | #182 |
+| Frame preemption (802.1Qbu) blocking term, `WcttPreemptionApplied` | §4.5 / §5.4 | DONE | #181 |
+| End-to-end integration test + COMPLIANCE close-out | §5.4 / §5.6 | DONE | this commit |
+
+Each shaping diagnostic carries auditable numeric content: TAS reports
+open-fraction percent and worst-case gate latency in picoseconds; CBS
+reports idle slope (bits per second) and service-curve latency (ns);
+preemption reports both legacy max-frame and 802.1Qbu fragment blocking
+terms (ns) so the user can see the gain.
+
+Deferred to v0.8.x or v0.9.0+ (off the v0.8.1 critical path):
+
+- **Piecewise-affine NC composition.** v0.8.1 stays on rate-latency
+  closed forms for the per-hop service curves; multi-class TAS and
+  chained CBS classes need the general piecewise-affine min-plus
+  convolution scoped to v0.9.0.
+- **Multi-stream sharing of a CBS class.** The CBS service curve is
+  currently treated as exclusive to the tagged stream (other-class
+  blocking is folded into its latency term). Same-class residual
+  decomposition between two CBS streams in one class is a v0.8.x
+  follow-up; a fixture is the natural trigger.
+- **Advanced TAS guards.** GCL gap detection across cascaded switches
+  (the "no-wait packet scheduling" problem, [Robust TAS
+  analysis][robust-tas]) and modal GCL transients are v0.9.0 scope
+  per §7.2.
+
 ---
 
 ## Section 6 — Roadmap proposal


### PR DESCRIPTION
## Summary

Closes out Track D Phase 2 (TAS/CBS/preemption) — the fifth and final commit of the v0.8.1 series. Builds on:
- #177 (c1/5) — Spar_TSN property set + spar-network::tsn skeleton
- #180 (c2/5) — TAS (802.1Qbv) gate-window service curve
- #182 (c3/5) — CBS (802.1Qav) credit-pool service curve
- #181 (c4/5) — Frame preemption (802.1Qbu)

The v0.8.1 c5 deliverable has three pieces:

1. **End-to-end integration test** (`crates/spar-analysis/tests/tsn_integration.rs`). Builds a SystemInstance with three sub-systems (`TasSeg`, `CbsSeg`, `PmtSeg`), each carrying its own TSN-typed bus + stream + `Actual_Connection_Binding`. Sub-system isolation lets each stream's binding resolve to exactly one bus, so the dispatch arm picked in `wctt.rs` is deterministic per stream. The test asserts that `WcttTasGated`, `WcttCbsShaped`, and `WcttPreemptionApplied` all fire in the same `WcttAnalysis::analyze` run, that no `WcttDeferred` slips through, and that each diagnostic carries plausible numeric values (50% open fraction + 5 us gate latency for TAS, 300 Mbps idle slope for CBS, 121440 ns legacy / 5440 ns fragment blocking for preemption).
2. **COMPLIANCE.md update**. New `## v0.8.1 (Track D Phase 2 close-out, in progress on main)` section narrating Phase 2 with deferred follow-ups (piecewise-affine NC composition, multi-stream CBS-class sharing, advanced TAS guards). Test count updated from 2200+ to 2759+, date refreshed to 2026-04-28.
3. **docs/designs/track-d-tsn-wctt-research.md update**. New §5.8 "Phase 2 implementation status (v0.8.1)" with a status table marking TAS, CBS, frame preemption, and integration as DONE with PR refs. Three deferred items are cross-referenced to §7.2.

The version bump and CHANGELOG entry intentionally stay deferred to a separate v0.8.1 release PR per the c5 spec.

## Quality gates

- `cargo build --workspace`: clean
- `cargo test --workspace`: 2759 passing, 0 failing — +1 new integration test, all prior tests still pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `rivet validate`: PASS (91 warnings, all pre-existing)

## Test plan

- [x] `cargo test -p spar-analysis --test tsn_integration` runs the new `phase2_dispatch_routes_each_stream_to_its_shaping_path` test
- [x] Full workspace test suite still green (2759 passing)
- [x] Clippy clean with `-D warnings`
- [x] Rustfmt check clean
- [x] `rivet validate` PASS
- [ ] Reviewer: confirm the `## v0.8.1` COMPLIANCE.md section reads correctly and the design-doc status table picks up the right PR refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)