### PR TITLE
chore(release): bump to v0.8.1 + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to spar are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] — 2026-04-29
+
+Track D Phase 2: TSN-shaped service curves. Implements the three
+classical IEEE 802.1Q-suite shaping mechanisms — TAS gate-window
+scheduling (802.1Qbv), CBS credit-based shaping (802.1Qav), and frame
+preemption (802.1Qbu) — as residual service curves in the WCTT
+analysis pipeline. Models without `Spar_TSN::*` annotations produce
+byte-identical output to v0.8.0.
+
+### Added — Track D Phase 2: TSN service curves (5/5 commits)
+
+- **`Spar_TSN::*` property set** (#177) — six properties: `Stream_ID`,
+  `Class_of_Service` (0..=7 per 802.1Q PCP), `Gate_Control_List`
+  (raw blob in v0.8.1, structured `GateSchedule` from c2),
+  `Max_Frame_Size`, `Frame_Preemption`, and `Bandwidth_Reservation`
+  (added in c3 for CBS idleSlope). `crates/spar-network::tsn` skeleton
+  with `GateWindow`, `ClassOfService`, and `CreditPool` placeholder
+  types plus typed-first / string-fallback property accessors. Total
+  predeclared property count: 122 → 128.
+- **TAS — IEEE 802.1Qbv gate-window service curve** (#180) — parses
+  Gate_Control_List into a structured `GateSchedule` (`offset:duration:cos_mask`
+  triples that tile the cycle period). Computes ρ_K (open fraction
+  per CoS) and T_K (worst-case gate latency). `tas_residual_service`
+  emits a rate-latency `ServiceCurve` with rate = R_link · ρ_K and
+  latency = T_K. WCTT dispatch emits `WcttTasGated` per stream when
+  bus has GCL + stream has CoS.
+- **CBS — IEEE 802.1Qav credit-pool service curve** (#182) —
+  per-class `CbsReservation` from `Bandwidth_Reservation` (idleSlope).
+  `cbs_residual_service` produces rate-latency form: rate =
+  idleSlope, latency = (max_competing_frame / link_rate) +
+  (loCredit / |sendSlope|). Class isolation suppresses
+  competing-flow residual decomposition. Emits `WcttCbsShaped` per
+  stream when the dispatch routes through the CBS arm.
+- **Frame preemption — IEEE 802.1Qbu** (#181) — replaces the legacy
+  `max_frame_bytes / link_rate` blocking term with the preemption
+  fragment term `(MIN_FRAGMENT_BYTES + PREEMPTION_HEADER_BYTES) /
+  link_rate` (typically 68 B vs. 1518 B → 5.4 µs vs. 121 µs at 100
+  Mbps). Express-stream identification by explicit `Frame_Preemption =>
+  true` or default by CoS ≥ 6. Emits `WcttPreemptionApplied` per hop.
+- **Phase 2 integration** (#183) — end-to-end test
+  `phase2_dispatch_routes_each_stream_to_its_shaping_path` exercises
+  TAS + CBS + preemption arms in the same `WcttAnalysis::analyze`
+  run with three sub-systems, asserting all three diagnostics
+  (`WcttTasGated`, `WcttCbsShaped`, `WcttPreemptionApplied`) coexist.
+
+### Unified TSN dispatch
+
+The WCTT analysis pass now has a 4-arm priority cascade for TSN
+switches with orthogonal preconditions:
+
+1. **TAS** — bus has parsed GCL **AND** stream has CoS
+2. **CBS** — stream has `Bandwidth_Reservation` (idleSlope)
+3. **Preemption** — bus has `Frame_Preemption=>true` **AND** stream is
+   express
+4. **Deferred** — `WcttDeferred` Info diagnostic, hop skipped
+
+Orthogonal preconditions mean each arm fires only when its specific
+shaping is in play; models that mix TAS + CBS + preemption across
+different switches all work in the same analysis run.
+
+### Changed
+
+- COMPLIANCE.md narrative for v0.8.1 with per-PR breakdown.
+- Test count: 2759+ across 18 crates (was 2200+).
+- `docs/designs/track-d-tsn-wctt-research.md` §5.8 status table
+  marks Phase 2 DONE with PR refs.
+
+### Deferred (Phase 2 v0.8.x follow-ups)
+
+- Piecewise-affine NC composition for cascaded TSN switches.
+- Multi-stream sharing within one CBS class's reserved bandwidth.
+- Advanced TAS guards (GCL gap detection across cascaded switches,
+  modal GCL transients).
+
+---
+
 ## [0.8.0] — 2026-04-28
 
 This release promotes the Track D Phase 1 (TSN/Ethernet WCTT analysis) and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "etch",
  "la-arena",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "rowan",
  "salsa",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "salsa",
  "serde",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "spar-base-db",
  "spar-hir-def",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "etch",
  "la-arena",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "la-arena",
  "serde",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1428,14 +1428,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Track D Phase 2 close-out release. Bumps workspace version 0.8.0 → 0.8.1.

Phase 2 commits (already on main):
- #177 — Spar_TSN property set + spar-network::tsn skeleton
- #180 — TAS (802.1Qbv) gate-window service curve
- #182 — CBS (802.1Qav) credit-pool service curve
- #181 — Frame preemption (802.1Qbu) blocking term
- #183 — Phase 2 integration + COMPLIANCE close-out

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` 2759 pass / 0 fail
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS
- [ ] CI green
- [ ] Tag v0.8.1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)