### PR TITLE
feat(nc): gPTP ε budget + frame quantization (v0.9.1 soundness pass)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1537,6 +1537,39 @@ artifacts:
     status: implemented
     tags: [network, tsn, wctt, preemption, qbu, v081]
 
+  # ── v0.9.1 NC soundness pass ──────────────────────────────────────
+
+  - id: REQ-NETWORK-009
+    type: requirement
+    title: gPTP synchronization-error budget for TAS bounds
+    description: >
+      Spar_TSN::Sync_Error (Time, picoseconds; applies to bus,
+      processor) carries the per-hop 802.1AS-2020 synchronization
+      error ε. The TAS dispatch in wctt.rs subtracts ε from the
+      effective open time and adds ε to the worst-case gate latency,
+      restoring soundness — current TAS bounds are technically
+      unsound without ε because a frame can miss its window by ε in
+      silicon. ε = 0 (unset) reproduces v0.8.1 behaviour
+      byte-identically. Per the post-v0.9.0 reviewer's Tier 2 #5.
+    status: implemented
+    tags: [network, tsn, wctt, soundness, gptp, v091]
+
+  - id: REQ-NETWORK-010
+    type: requirement
+    title: Atomic-frame quantization in NC per-hop bound
+    description: >
+      Bytes-level NC undercounts each hop's bound by up to one MTU
+      because frames are atomic but the kernel treats packets as
+      continuous. wctt.rs adds `ceil(max_frame_bytes · 8e12 /
+      link_rate_bps)` picoseconds per hop on the TAS and FIFO/Priority
+      arms. The CBS arm's closed-form latency already absorbs the
+      max-frame term; the preemption arm replaces it with the
+      fragment-time. New `WcttFrameQuantization` Info diagnostic
+      records the correction per hop. Per the post-v0.9.0 reviewer's
+      Tier 2 #8.
+    status: implemented
+    tags: [network, wctt, soundness, v091]
+
   # ── Track G: spar-insight discrepancy assistant (v0.9.0) ──────────
 
   - id: REQ-INSIGHT-001

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2040,6 +2040,44 @@ artifacts:
       - type: satisfies
         target: REQ-TSN-004
 
+  - id: TEST-NC-SOUNDNESS
+    type: feature
+    title: gPTP ε budget + atomic-frame quantization soundness tests
+    description: >
+      Unit + integration tests covering the v0.9.1 soundness pass:
+      (1) `Spar_TSN::Sync_Error` accessor handles unset / typed
+      PropertyExpr / string fallback paths and unit conversions
+      (ps, ns, us, ms);
+      (2) `tas_residual_service_with_sync_error` shrinks
+      open_fraction by ε/cycle and grows worst_case_latency by ε;
+      ε equal to or exceeding a window's open_time clamps to
+      zero (gate effectively closed); ε = 0 reproduces v0.8.1
+      byte-identically;
+      (3) `frame_quantization_ps` returns ceil(max_frame · 8e12 /
+      link_rate_bps) — 1518 B at 100 Mbps ≈ 121440 ns; 64 B at 1 Gbps
+      ≈ 512 ns; rate-divides-evenly vs ceil-rounding cases; zero-rate
+      guard;
+      (4) wctt dispatch integration: TAS / FIFO arms emit
+      `WcttFrameQuantization` Info per hop and add the correction
+      to the per-hop delay; CBS / preemption arms remain unchanged
+      (their service curves already absorb / replace the max-frame
+      term); the v0.8.0 `single_hop_classical_ethernet`,
+      `multi_hop_chain_aggregates`, and TSN/TAS bound assertions
+      were updated to the sound numbers.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-network --lib -- tsn
+        - run: cargo test -p spar-analysis --lib -- wctt
+        - run: cargo test -p spar-analysis --test wctt_fixtures
+    status: passing
+    tags: [v0.9.1, network, wctt, soundness, gptp, quantization]
+    links:
+      - type: satisfies
+        target: REQ-NETWORK-009
+      - type: satisfies
+        target: REQ-NETWORK-010
+
   - id: TEST-INSIGHT-DISCREPANCY
     type: feature
     title: spar-insight CTF parser + 5-kind discrepancy detection

--- a/crates/spar-analysis/src/wctt.rs
+++ b/crates/spar-analysis/src/wctt.rs
@@ -56,9 +56,10 @@ use spar_network::extract::{
     extract_network_graph, read_forwarding_latency_ps, read_output_rate_bps, read_queue_depth,
 };
 use spar_network::tsn::{
-    CbsReservation, ClassOfService, GateSchedule, cbs_residual_service,
+    CbsReservation, ClassOfService, GateSchedule, cbs_residual_service, frame_quantization_ps,
     get_bandwidth_reservation_bps, get_class_of_service, get_frame_preemption, get_gate_schedule,
-    get_max_frame_size_bytes, is_express_stream, preemption_blocking_term_ps, tas_residual_service,
+    get_max_frame_size_bytes, get_sync_error_ps, is_express_stream, preemption_blocking_term_ps,
+    tas_residual_service_with_sync_error,
 };
 use spar_network::types::{NetworkGraph, NodeKind, SwitchType};
 
@@ -275,15 +276,39 @@ impl WcttAnalysis {
                 // about *when* class-K can transmit, not about
                 // ownership of bandwidth across competing streams.
                 let mut cbs_service: Option<ServiceCurve> = None;
+                // v0.9.1 NC soundness: a hop is "quantizable" iff its
+                // service curve does not already account for the
+                // atomic-frame max-MTU blocking term. The TAS arm and
+                // the FIFO/Priority fallback arm do not — they undercount
+                // the per-hop bound by up to one MTU because the
+                // bytes-level NC kernel treats packets as continuous.
+                // The CBS arm's `cbs_residual_service` already absorbs
+                // max-frame blocking via its closed-form latency; the
+                // preemption arm's `preemption_blocking_term_ps`
+                // *replaces* the same term with the much smaller
+                // fragment-time. Both of those leave `quantization_ps = 0`.
+                let mut quantization_ps: u64 = 0;
                 let svc = if matches!(st, SwitchType::Tsn) {
                     let bus_props = instance.properties_for(*sw_idx);
                     let bus_preemption = get_frame_preemption(bus_props).unwrap_or(false);
                     if let (Some(schedule), Some(cos)) =
                         (gate_schedule_for_bus.get(sw_idx), stream.cos)
                     {
-                        // Path 1: TAS service curve.
+                        // Path 1: TAS service curve, with the v0.9.1
+                        // gPTP synchronization-error budget ε applied
+                        // (subtracted from the effective open time,
+                        // added to the worst-case gate latency). When
+                        // `Spar_TSN::Sync_Error` is unset on the bus we
+                        // pass ε = 0, which reproduces the v0.8.1
+                        // service curve byte-identically.
                         let link_rate = link_rate_for_bus.get(sw_idx).copied().unwrap_or(0);
-                        let tas_svc = tas_residual_service(schedule, cos, link_rate);
+                        let sync_error_ps = get_sync_error_ps(bus_props).unwrap_or(0);
+                        let tas_svc = tas_residual_service_with_sync_error(
+                            schedule,
+                            cos,
+                            link_rate,
+                            sync_error_ps,
+                        );
                         let (open_ps, cycle_ps) = schedule.open_fraction(cos);
                         // open_fraction is reported as a percentage
                         // (integer-rounded toward zero) for human
@@ -298,7 +323,7 @@ impl WcttAnalysis {
                             severity: Severity::Info,
                             message: format!(
                                 "WcttTasGated: stream '{}' (CoS {}) on TSN switch '{}' at hop \
-                                 {}: open fraction {}% gate latency {} ps",
+                                 {}: open fraction {}% gate latency {} ps sync_error {} ps",
                                 stream_name,
                                 cos.0,
                                 graph
@@ -308,10 +333,16 @@ impl WcttAnalysis {
                                 hop_idx,
                                 open_pct,
                                 gate_latency_ps,
+                                sync_error_ps,
                             ),
                             path: stream_path.clone(),
                             analysis: self.name().to_string(),
                         });
+                        // TAS service curve: rate = R_link · ρ_K, but the
+                        // link itself still serializes one max-frame per
+                        // hop. Apply atomic-frame quantization at link rate.
+                        let bus_max_frame = get_max_frame_size_bytes(bus_props).unwrap_or(1518);
+                        quantization_ps = frame_quantization_ps(bus_max_frame, link_rate);
                         tas_svc
                     } else if let Some(idle_slope_bps) = stream.cbs_idle_slope_bps {
                         // Path 2: CBS service curve. Stream declares
@@ -496,10 +527,16 @@ impl WcttAnalysis {
                         continue;
                     }
                 } else {
-                    match service_for_bus.get(sw_idx) {
+                    let s = match service_for_bus.get(sw_idx) {
                         Some(s) => *s,
                         None => continue,
-                    }
+                    };
+                    // FIFO / Priority hop: bytes-level NC undercounts by
+                    // up to one MTU; apply atomic-frame quantization.
+                    let bus_props = instance.properties_for(*sw_idx);
+                    let bus_max_frame = get_max_frame_size_bytes(bus_props).unwrap_or(1518);
+                    quantization_ps = frame_quantization_ps(bus_max_frame, s.rate_bps);
+                    s
                 };
 
                 if svc.rate_bps == 0 {
@@ -585,10 +622,32 @@ impl WcttAnalysis {
                 };
 
                 // Per-hop delay using the tagged stream's α and the
-                // residual service.
+                // residual service. Then add `quantization_ps` for
+                // atomic-frame correctness (zero on CBS / preemption arms,
+                // computed at link rate on TAS / FIFO arms).
                 match delay_bound(&alpha, &residual) {
                     Ok(d) => {
                         total_delay_ps = total_delay_ps.saturating_add(d);
+                        if quantization_ps > 0 {
+                            total_delay_ps = total_delay_ps.saturating_add(quantization_ps);
+                            diags.push(AnalysisDiagnostic {
+                                severity: Severity::Info,
+                                message: format!(
+                                    "WcttFrameQuantization: stream '{}' at hop {} on switch \
+                                     '{}': atomic-frame correction +{} ns (max-frame serialization \
+                                     at link rate)",
+                                    stream_name,
+                                    hop_idx,
+                                    graph
+                                        .node(*sw_idx)
+                                        .map(|n| n.name.as_str())
+                                        .unwrap_or("<unknown>"),
+                                    quantization_ps / 1_000,
+                                ),
+                                path: stream_path.clone(),
+                                analysis: self.name().to_string(),
+                            });
+                        }
                     }
                     Err(NcError::UnservableFlow) | Err(NcError::UnstableServer) => {
                         // delay_bound also returns UnstableServer when
@@ -1357,9 +1416,11 @@ end Net;
             .filter(|d| d.message.starts_with("WcttBound"))
             .collect();
         assert_eq!(info.len(), 1, "exactly one stream expected: {:#?}", diags);
+        // v0.9.1 soundness: 12 µs (NC bytes-fluid) + 12.144 µs (atomic-frame
+        // quantization at 1 Gbps for 1518-byte MTU) = 24.144 µs.
         assert!(
-            info[0].message.contains("12000000 ps"),
-            "expected 12 us bound, got: {}",
+            info[0].message.contains("24144000 ps"),
+            "expected 24.144 us bound (12 us NC + 12.144 us frame quantization), got: {}",
             info[0].message
         );
     }
@@ -1585,9 +1646,11 @@ end Net;
             "expected 3 hops in: {}",
             info.message
         );
+        // v0.9.1 soundness: 51 µs (NC) + 3 × 12.144 µs (atomic-frame
+        // quantization, one per hop) = 87.432 µs.
         assert!(
-            info.message.contains("51000000 ps"),
-            "expected 51 us bound, got: {}",
+            info.message.contains("87432000 ps"),
+            "expected 87.432 us bound (51 us NC + 36.432 us quantization), got: {}",
             info.message
         );
     }
@@ -2083,8 +2146,8 @@ end Net;
             .find(|d| d.message.starts_with("WcttBound"))
             .unwrap_or_else(|| panic!("expected WcttBound: {:#?}", diags));
         assert!(
-            bound.message.contains("29000000 ps"),
-            "expected 29 us TAS bound, got: {}",
+            bound.message.contains("41144000 ps"),
+            "expected 41.144 us TAS bound (29 us gated + 12.144 us quantization), got: {}",
             bound.message
         );
     }
@@ -2143,8 +2206,9 @@ end Net;
             .iter()
             .find(|d| d.message.starts_with("WcttBound"))
             .unwrap();
-        // 12 us = 12_000_000 ps for the ungated single hop.
-        assert!(ungated_bound.message.contains("12000000 ps"));
+        // v0.9.1 soundness: 12 µs (NC) + 12.144 µs (atomic-frame
+        // quantization, 1518 B at 1 Gbps) = 24.144 µs.
+        assert!(ungated_bound.message.contains("24144000 ps"));
 
         // Same model, but with TSN+GCL applied (50% open for CoS 7).
         // The bound must exceed the ungated 12 us.
@@ -2204,10 +2268,11 @@ end Net;
             .iter()
             .find(|d| d.message.starts_with("WcttBound"))
             .unwrap();
-        assert!(gated_bound.message.contains("29000000 ps"));
+        // v0.9.1 soundness: 29 µs gated NC + 12.144 µs quantization = 41.144 µs.
+        assert!(gated_bound.message.contains("41144000 ps"));
 
-        // Strictly: 29 us > 12 us — the gated bound is more pessimistic
-        // (and correctly so) than the ungated line-rate bound.
+        // Strictly: 41.144 µs > 24.144 µs — the gated bound is more
+        // pessimistic (and correctly so) than the ungated line-rate bound.
     }
 
     // ── Test 13: TSN switch without GCL still defers ────────────────

--- a/crates/spar-analysis/tests/fixtures/wctt/classical_ethernet.expected.json
+++ b/crates/spar-analysis/tests/fixtures/wctt/classical_ethernet.expected.json
@@ -1,4 +1,6 @@
 [
-  "WcttBound: stream 'data_a (ecu_a → ecu_sink)' end-to-end WCTT 31666668 ps (1 hop)",
-  "WcttBound: stream 'data_b (ecu_b → ecu_sink)' end-to-end WCTT 31666668 ps (1 hop)"
+  "WcttBound: stream 'data_a (ecu_a → ecu_sink)' end-to-end WCTT 43810668 ps (1 hop)",
+  "WcttBound: stream 'data_b (ecu_b → ecu_sink)' end-to-end WCTT 43810668 ps (1 hop)",
+  "WcttFrameQuantization: stream 'data_a (ecu_a → ecu_sink)' at hop 0 on switch 'sw': atomic-frame correction +12144 ns (max-frame serialization at link rate)",
+  "WcttFrameQuantization: stream 'data_b (ecu_b → ecu_sink)' at hop 0 on switch 'sw': atomic-frame correction +12144 ns (max-frame serialization at link rate)"
 ]

--- a/crates/spar-hir-def/src/standard_properties.rs
+++ b/crates/spar-hir-def/src/standard_properties.rs
@@ -508,6 +508,15 @@ const SPAR_TSN: &[(&str, &str)] = &[
     // hi/lo credit slope arithmetic is computed inside the analysis.
     // Applies to bus and port.
     ("Bandwidth_Reservation", "aadlinteger units Data_Rate_Units"),
+    // Per-hop gPTP (IEEE 802.1AS) synchronization-error budget ε. In
+    // a real TSN deployment the gate-control list is enforced against
+    // the local synchronized clock, which differs from the master
+    // clock by at most ε per hop; v0.9.1 NC soundness pass subtracts
+    // ε from the effective TAS open time and adds ε to the worst-case
+    // gate latency so the bounds remain sound under realistic clock
+    // accuracy. Default unset = 0 (legacy v0.8.1 behaviour).
+    // Applies to bus and processor.
+    ("Sync_Error", "aadlinteger units Time_Units"),
 ];
 
 /// Helper: collect properties from a table into the result vector.
@@ -1089,13 +1098,14 @@ mod tests {
         assert!(is_standard_property_set("Spar_TSN"));
 
         let props = standard_properties_in_set("Spar_TSN");
-        assert_eq!(props.len(), 6);
+        assert_eq!(props.len(), 7);
         assert!(props.contains(&"Stream_ID"));
         assert!(props.contains(&"Class_of_Service"));
         assert!(props.contains(&"Gate_Control_List"));
         assert!(props.contains(&"Max_Frame_Size"));
         assert!(props.contains(&"Frame_Preemption"));
         assert!(props.contains(&"Bandwidth_Reservation"));
+        assert!(props.contains(&"Sync_Error"));
 
         // Each property resolves to its expected type.
         assert_eq!(
@@ -1121,6 +1131,10 @@ mod tests {
         assert_eq!(
             standard_property_type("Spar_TSN", "Bandwidth_Reservation"),
             Some("aadlinteger units Data_Rate_Units")
+        );
+        assert_eq!(
+            standard_property_type("Spar_TSN", "Sync_Error"),
+            Some("aadlinteger units Time_Units")
         );
 
         // Deliberately-wrong name returns None.
@@ -1152,6 +1166,7 @@ mod tests {
             "Max_Frame_Size",
             "Frame_Preemption",
             "Bandwidth_Reservation",
+            "Sync_Error",
         ] {
             let result = scope.resolve_property(&Name::new("Spar_TSN"), &Name::new(prop_name));
             assert!(
@@ -1195,7 +1210,7 @@ mod tests {
     #[test]
     fn test_all_standard_properties_total_count() {
         let all = all_standard_properties();
-        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 + 1 + 6 = 128
+        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 + 1 + 7 = 129
         // (Timing + Communication + Memory + Deployment + Thread + Programming
         //  + Modeling + AADL_Project + Spar_Timing + Spar_Trace + Spar_Network
         //  + Spar_Migration + Spar_Power + Spar_TSN)
@@ -1206,7 +1221,8 @@ mod tests {
         // Spar_TSN: +5 for Stream_ID, Class_of_Service, Gate_Control_List,
         //   Max_Frame_Size, Frame_Preemption (Track D Phase 2 v0.8.1 c1)
         //   +1 for Bandwidth_Reservation (Track D Phase 2 v0.8.1 c3, CBS).
-        assert_eq!(all.len(), 128);
+        //   +1 for Sync_Error (v0.9.1 NC soundness, gPTP ε budget).
+        assert_eq!(all.len(), 129);
     }
 
     #[test]

--- a/crates/spar-network/src/tsn.rs
+++ b/crates/spar-network/src/tsn.rs
@@ -362,6 +362,32 @@ pub fn get_gate_control_list_raw(props: &PropertyMap) -> Option<String> {
     get_raw(props, "Gate_Control_List").map(|s| s.trim().trim_matches('"').to_string())
 }
 
+/// Read [`Spar_TSN::Sync_Error`] — the per-hop gPTP (IEEE 802.1AS)
+/// synchronization-error budget ε, returned in picoseconds.
+///
+/// In a real TSN deployment the gate-control list is enforced against
+/// the local synchronized clock, which can differ from the master clock
+/// by up to ε per hop. The TAS service-curve math (v0.9.1 NC soundness
+/// pass) subtracts ε from the effective open time and adds ε to the
+/// worst-case gate latency so the bounds remain sound under realistic
+/// clock accuracy. When the property is unset this accessor returns
+/// `None`, callers treat that as ε = 0 (legacy v0.8.1 behaviour) so
+/// the non-regression contract holds byte-identically.
+///
+/// Accepts the standard AADL time units (`ps`, `ns`, `us`, `ms`, `sec`,
+/// etc.) on both the typed and string-fallback paths. A bare integer
+/// (or string) is interpreted as picoseconds, matching the canonical
+/// unit used elsewhere in the WCTT pass.
+pub fn get_sync_error_ps(props: &PropertyMap) -> Option<u64> {
+    if let Some(expr) = get_typed(props, "Sync_Error")
+        && let Some(ps) = extract_time_ps_local(expr)
+    {
+        return Some(ps);
+    }
+    let raw = get_raw(props, "Sync_Error")?;
+    parse_time_ps_local(raw)
+}
+
 // ── Frame preemption (802.1Qbu) ──────────────────────────────────────
 //
 // 802.1Qbu allows an "express" traffic class to interrupt a
@@ -613,6 +639,127 @@ fn parse_size_bytes(s: &str) -> Option<u64> {
         }
     }
     s.parse::<u64>().ok()
+}
+
+// ── Time-unit helpers (local) ────────────────────────────────────────
+//
+// Mirrors the time-unit table in `crates/spar-network/src/extract.rs`
+// (which is crate-private to that module's call sites). Used by the
+// `Sync_Error` accessor so the property can be declared in any of the
+// standard AADL Time_Units (ps/ns/us/ms/sec/min/hr).
+
+const TIME_UNIT_FACTORS_PS_LOCAL: &[(&str, u64)] = &[
+    ("ps", 1),
+    ("ns", 1_000),
+    ("us", 1_000_000),
+    ("ms", 1_000_000_000),
+    ("sec", 1_000_000_000_000),
+    ("min", 60_000_000_000_000),
+    ("hr", 3_600_000_000_000_000),
+];
+
+fn time_unit_factor_ps_local(unit: &str) -> Option<u64> {
+    TIME_UNIT_FACTORS_PS_LOCAL
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(unit))
+        .map(|(_, f)| *f)
+}
+
+fn extract_time_ps_local(expr: &PropertyExpr) -> Option<u64> {
+    match expr {
+        PropertyExpr::Integer(v, Some(unit)) if *v >= 0 => {
+            let factor = time_unit_factor_ps_local(unit.as_str())?;
+            (*v as u64).checked_mul(factor)
+        }
+        PropertyExpr::Integer(v, None) if *v >= 0 => Some(*v as u64),
+        PropertyExpr::Real(s, Some(unit)) => {
+            let v: f64 = s.parse().ok()?;
+            if v < 0.0 {
+                return None;
+            }
+            let factor = time_unit_factor_ps_local(unit.as_str())?;
+            Some((v * factor as f64) as u64)
+        }
+        PropertyExpr::UnitValue(inner, unit) => {
+            let factor = time_unit_factor_ps_local(unit.as_str())?;
+            match inner.as_ref() {
+                PropertyExpr::Integer(v, _) if *v >= 0 => (*v as u64).checked_mul(factor),
+                PropertyExpr::Real(s, _) => {
+                    let v: f64 = s.parse().ok()?;
+                    if v < 0.0 {
+                        return None;
+                    }
+                    Some((v * factor as f64) as u64)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn parse_time_ps_local(s: &str) -> Option<u64> {
+    let s = s.trim();
+    for &(unit, factor) in TIME_UNIT_FACTORS_PS_LOCAL {
+        if let Some(num_str) = s.strip_suffix(unit).map(|s| s.trim()) {
+            if let Ok(v) = num_str.parse::<u64>() {
+                return v.checked_mul(factor);
+            }
+            if let Ok(v) = num_str.parse::<f64>() {
+                if v < 0.0 {
+                    return None;
+                }
+                return Some((v * factor as f64) as u64);
+            }
+        }
+    }
+    s.parse::<u64>().ok()
+}
+
+// ── Frame quantization (v0.9.1 NC soundness) ─────────────────────────
+//
+// Bytes-level NC undercounts by up to one MTU per hop because frames
+// are atomic — once a frame starts transmitting, the link is held
+// until the frame finishes, even if the tagged stream's α slope
+// suggests the link could be released earlier. Adding the per-hop
+// frame-quantization correction
+//
+//     q_ps = ceil(max_frame_bytes · 8 · 10^12 / link_rate_bps)
+//
+// turns a slightly-optimistic answer into a sound one. The correction
+// is applied in the non-preemption / non-CBS arms of the TSN dispatch
+// (preemption replaces this term with the much smaller fragment time;
+// CBS service curve already accounts for max-frame blocking via the
+// 1518-byte default in `cbs_residual_service`). See PR #186 / v0.9.1
+// soundness pass.
+
+/// Per-hop frame-quantization correction in picoseconds.
+///
+/// Returns `ceil(max_frame_bytes · 8 · 10^12 / link_rate_bps)` —
+/// the worst-case time it takes to drain one full preemptable Ethernet
+/// frame at the egress link rate, with rounding *up* so the term is
+/// never an under-estimate. `link_rate_bps == 0` returns `u64::MAX`
+/// (a safe pessimistic placeholder; the caller is responsible for
+/// screening that pathological case).
+///
+/// This is the atomic-frame correction for the bytes-level NC kernel:
+/// without it, the per-hop bound undercounts by up to one MTU because
+/// frames cannot be split mid-transmission. Apply once per hop in the
+/// TAS / FIFO arms of the WCTT dispatch; do *not* apply in the
+/// preemption arm (the fragment-blocking term replaces it) or the CBS
+/// arm (the closed-form latency already absorbs it).
+pub fn frame_quantization_ps(max_frame_bytes: u64, link_rate_bps: u64) -> u64 {
+    if link_rate_bps == 0 {
+        return u64::MAX;
+    }
+    let numer = (max_frame_bytes as u128) * BITS_PER_BYTE * PS_PER_SECOND;
+    let denom = link_rate_bps as u128;
+    let ps = numer.div_ceil(denom);
+    if ps > u64::MAX as u128 {
+        u64::MAX
+    } else {
+        ps as u64
+    }
 }
 
 // ── TAS (802.1Qbv) gate-window service curve ─────────────────────────
@@ -886,6 +1033,55 @@ pub fn tas_residual_service(
         }
     };
     ServiceCurve::rate_latency(rate_bps, latency_ps)
+}
+
+/// Derive the rate-latency [`ServiceCurve`] offered to a single
+/// class-of-service by a TAS-gated egress port, accounting for the
+/// per-hop gPTP synchronization-error budget ε.
+///
+/// This is the v0.9.1 NC soundness wrapper around
+/// [`tas_residual_service`]. In a real TSN deployment the gate-control
+/// list is enforced against the local synchronized clock, which differs
+/// from the master clock by at most ε per hop (IEEE 802.1AS / gPTP).
+/// Without accounting for ε the TAS bound is *technically unsound* — a
+/// frame can miss its window by ε.
+///
+/// The correction is: subtract ε from the effective open time
+/// (clamped at 0 — once ε exceeds the open time, the gate is
+/// effectively closed for that hop) and add ε to the worst-case gate
+/// latency. Both adjustments tighten the envelope in the safe (more
+/// pessimistic) direction.
+///
+/// `sync_error_ps == 0` reproduces [`tas_residual_service`]
+/// byte-identically (legacy v0.8.1 behaviour, non-regression contract).
+pub fn tas_residual_service_with_sync_error(
+    schedule: &GateSchedule,
+    cos: ClassOfService,
+    link_rate_bps: u64,
+    sync_error_ps: u64,
+) -> ServiceCurve {
+    let (open_ps, cycle_ps) = schedule.open_fraction(cos);
+    let latency_ps = schedule.worst_case_latency(cos);
+
+    // Effective open time shrinks by ε (clamped at 0). Once ε ≥ open
+    // time, the gate is effectively closed: rate = 0 with the worst-
+    // case-latency-plus-ε falling back to the closed-gate
+    // `(rate=0, latency=cycle_ps)` form via the saturating add below.
+    let effective_open_ps = open_ps.saturating_sub(sync_error_ps);
+    let effective_latency_ps = latency_ps.saturating_add(sync_error_ps);
+
+    let rate_bps = if cycle_ps == 0 || effective_open_ps == 0 {
+        0
+    } else {
+        let product = (link_rate_bps as u128).saturating_mul(effective_open_ps as u128);
+        let r = product / (cycle_ps as u128);
+        if r > u64::MAX as u128 {
+            u64::MAX
+        } else {
+            r as u64
+        }
+    };
+    ServiceCurve::rate_latency(rate_bps, effective_latency_ps)
 }
 
 /// Parse [`Spar_TSN::Gate_Control_List`] from a [`PropertyMap`] into a
@@ -1508,5 +1704,166 @@ mod tests {
         // safe default is non-express (preemptable).
         let empty = PropertyMap::new();
         assert!(!is_express_stream(&empty));
+    }
+
+    // ── Sync_Error / gPTP ε budget (v0.9.1 NC soundness) ─────────────
+
+    #[test]
+    fn read_sync_error_typed_path_picoseconds() {
+        // Bare integer — interpreted as picoseconds.
+        let props = make_props(
+            SPAR_TSN,
+            "Sync_Error",
+            "1000",
+            Some(PropertyExpr::Integer(1_000, None)),
+        );
+        assert_eq!(get_sync_error_ps(&props), Some(1_000));
+    }
+
+    #[test]
+    fn read_sync_error_typed_path_with_units() {
+        // 1 us with explicit Time_Units → 1_000_000 ps.
+        let props = make_props(
+            SPAR_TSN,
+            "Sync_Error",
+            "1us",
+            Some(PropertyExpr::Integer(1, Some(Name::new("us")))),
+        );
+        assert_eq!(get_sync_error_ps(&props), Some(1_000_000));
+
+        // 1 ms.
+        let props_ms = make_props(
+            SPAR_TSN,
+            "Sync_Error",
+            "1ms",
+            Some(PropertyExpr::Integer(1, Some(Name::new("ms")))),
+        );
+        assert_eq!(get_sync_error_ps(&props_ms), Some(1_000_000_000));
+    }
+
+    #[test]
+    fn read_sync_error_string_fallback_matches_typed() {
+        // The string-fallback path should agree with the typed-expr
+        // path for the same human-readable value.
+        let typed = make_props(
+            SPAR_TSN,
+            "Sync_Error",
+            "1us",
+            Some(PropertyExpr::Integer(1, Some(Name::new("us")))),
+        );
+        let stringy = make_props(SPAR_TSN, "Sync_Error", "1us", None);
+        assert_eq!(get_sync_error_ps(&typed), get_sync_error_ps(&stringy));
+        assert_eq!(get_sync_error_ps(&stringy), Some(1_000_000));
+    }
+
+    #[test]
+    fn read_sync_error_missing_returns_none() {
+        // Unset = legacy behaviour (callers treat as ε = 0).
+        let empty = PropertyMap::new();
+        assert_eq!(get_sync_error_ps(&empty), None);
+    }
+
+    // ── Frame quantization (v0.9.1 NC soundness) ─────────────────────
+
+    #[test]
+    fn frame_quantization_1518_at_100mbps() {
+        // 1518-byte MTU at 100 Mbps:
+        //   q_ps = ceil(1518 · 8 · 10^12 / 10^8) = 121_440_000 ps = 121.44 us.
+        // This matches the legacy preemption-disabled blocking term.
+        let q = frame_quantization_ps(1518, 100_000_000);
+        assert_eq!(q, 121_440_000);
+    }
+
+    #[test]
+    fn frame_quantization_64_at_1gbps() {
+        // 64-byte minimum frame at 1 Gbps:
+        //   q_ps = ceil(64 · 8 · 10^12 / 10^9) = 512_000 ps = 512 ns.
+        let q = frame_quantization_ps(64, 1_000_000_000);
+        assert_eq!(q, 512_000);
+    }
+
+    #[test]
+    fn frame_quantization_rounds_up() {
+        // Rate that does not divide evenly — ceiling rounding (pessimism)
+        // must produce a strict over-estimate vs. the exact-divisor case.
+        // 1518 bytes at 1 Gbps is exact (12_144_000 ps). At 999_999_999
+        // bps (1 bps slower) we should round *up*.
+        let exact = frame_quantization_ps(1518, 1_000_000_000);
+        let nearly = frame_quantization_ps(1518, 999_999_999);
+        assert_eq!(exact, 12_144_000);
+        assert!(
+            nearly > exact,
+            "ceiling rounding must over-estimate at non-exact divisors: \
+             exact={} nearly={}",
+            exact,
+            nearly
+        );
+    }
+
+    #[test]
+    fn frame_quantization_zero_rate_guard() {
+        // Pathological zero-rate input: returns u64::MAX so the caller
+        // can detect the unservable hop without panicking on division.
+        assert_eq!(frame_quantization_ps(1518, 0), u64::MAX);
+        assert_eq!(frame_quantization_ps(0, 0), u64::MAX);
+    }
+
+    #[test]
+    fn frame_quantization_zero_bytes_returns_zero() {
+        // Zero bytes is a degenerate but well-defined case: takes zero
+        // time to transmit. Used by tests that want to verify the
+        // correction is a strict additive overhead (i.e., setting it
+        // to zero recovers the v0.8.1 bound).
+        assert_eq!(frame_quantization_ps(0, 1_000_000_000), 0);
+    }
+
+    // ── TAS + gPTP ε budget (v0.9.1 NC soundness) ────────────────────
+
+    #[test]
+    fn tas_residual_service_with_sync_error_zero_matches_legacy() {
+        // ε = 0 must reproduce the legacy `tas_residual_service`
+        // byte-identically — this is the non-regression contract.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        let legacy = tas_residual_service(&s, cos7, TAS_GBPS);
+        let with_eps = tas_residual_service_with_sync_error(&s, cos7, TAS_GBPS, 0);
+        assert_eq!(legacy.rate_bps, with_eps.rate_bps);
+        assert_eq!(legacy.latency_ps, with_eps.latency_ps);
+    }
+
+    #[test]
+    fn tas_residual_service_with_sync_error_shrinks_open_grows_latency() {
+        // 50% open (5 us out of 10 us), 1 Gbps. Apply ε = 1 us.
+        //   effective_open  = 5 us − 1 us = 4 us
+        //   rate = 1 Gbps · 4/10 = 400 Mbps
+        //   effective_lat  = 5 us + 1 us = 6 us
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        let svc = tas_residual_service_with_sync_error(&s, cos7, TAS_GBPS, 1_000_000);
+        assert_eq!(svc.rate_bps, 400_000_000);
+        assert_eq!(svc.latency_ps, 6_000_000);
+    }
+
+    #[test]
+    fn tas_residual_service_with_sync_error_clamps_when_eps_equals_open() {
+        // ε equal to the open time → gate is effectively closed
+        // (rate = 0); latency = open_window_latency + ε.
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        // Open time for CoS 7 is 5 us = 5_000_000 ps.
+        let svc = tas_residual_service_with_sync_error(&s, cos7, TAS_GBPS, 5_000_000);
+        assert_eq!(svc.rate_bps, 0, "gate must close once ε ≥ open time");
+        assert_eq!(svc.latency_ps, 10_000_000, "5us legacy + 5us ε");
+    }
+
+    #[test]
+    fn tas_residual_service_with_sync_error_clamps_when_eps_exceeds_open() {
+        // ε strictly greater than open time → still closed; saturating
+        // sub clamps at 0 (the gate cannot have "negative open time").
+        let s = GateSchedule::parse("0:5000:0x80;5000:5000:0x7F").unwrap();
+        let cos7 = ClassOfService::new(7).unwrap();
+        let svc = tas_residual_service_with_sync_error(&s, cos7, TAS_GBPS, 10_000_000);
+        assert_eq!(svc.rate_bps, 0);
+        assert_eq!(svc.latency_ps, 15_000_000);
     }
 }


### PR DESCRIPTION
## Summary

Two pure-soundness fixes flagged by the post-v0.9.0 reviewer (Tier 2 items #5 and #8):

1. **gPTP synchronization-error budget (Tier 2 #5)** — adds `Spar_TSN::Sync_Error` carrying per-hop 802.1AS-2020 ε. TAS dispatch shrinks open-time by ε and grows worst-case-latency by ε. v0.8.1 TAS bounds were *technically unsound* without this — a frame can miss its window by ε in silicon. ε = 0 (unset) reproduces v0.8.1 byte-identically.

2. **Atomic-frame quantization (Tier 2 #8)** — adds `ceil(max_frame · 8e12 / link_rate_bps)` ps per hop on TAS / FIFO / Priority arms. Bytes-level NC undercounts each hop by up to one MTU because frames are atomic. CBS arm absorbs this in its closed-form latency; preemption arm replaces it with fragment-time. New `WcttFrameQuantization` Info diagnostic.

Existing test bounds updated from optimistic to sound:
- single-hop 1 Gbps: 12 µs → 24.144 µs
- 3-hop chain: 51 µs → 87.432 µs
- gated TAS half-rate: 29 µs → 41.144 µs

## Test plan

- [x] 2772 workspace tests pass (was 2759 at v0.9.0; +13 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS
- [ ] CI green
- [ ] Tag v0.9.1 after merge (release commit follows separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)