### PR TITLE
chore(release): bump to v0.9.1 + AADL spec-claim consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to spar are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] — 2026-04-29
+
+NC kernel soundness pass. Fixes two pure-soundness gaps flagged by an
+external reviewer of v0.9.0. Both turn slightly-optimistic NC output
+into sound output. Models without `Spar_TSN::Sync_Error` and with the
+same `Spar_TSN::Max_Frame_Size` defaults will see *larger* WCTT
+numbers — the v0.8.1 bounds were under-counting.
+
+### Added — NC soundness (Tier 2 reviewer items)
+
+- **gPTP synchronization-error budget (#186)** — new
+  `Spar_TSN::Sync_Error` (Time, picoseconds; applies to bus,
+  processor) carries the per-hop 802.1AS-2020 sync error ε. The TAS
+  dispatch in `wctt.rs` now subtracts ε from the effective open
+  time and adds ε to the worst-case gate latency. Without ε, v0.8.1
+  TAS bounds were *technically unsound* — a frame can miss its
+  window by ε in silicon. ε = 0 (unset) reproduces v0.8.1
+  byte-identically.
+- **Atomic-frame quantization (#186)** — wctt.rs now adds
+  `ceil(max_frame_bytes · 8e12 / link_rate_bps)` ps per hop on the
+  TAS and FIFO/Priority arms. Bytes-level NC under-counts by up to
+  one MTU per hop because frames are atomic. CBS arm unchanged
+  (closed-form latency absorbs the term). Preemption arm unchanged
+  (replaces with fragment-time). New `WcttFrameQuantization` Info
+  diagnostic.
+
+### Changed
+
+- Property count: 128 → 129; Spar_TSN per-set count: 6 → 7.
+- Test count: 2772 (was 2759 at v0.9.0).
+- Test bounds in `wctt::tests` updated from optimistic to sound:
+  single-hop 1 Gbps 12 µs → 24.144 µs; 3-hop chain 51 µs →
+  87.432 µs; gated TAS half-rate 29 µs → 41.144 µs.
+- Golden fixture `classical_ethernet.expected.json` updated.
+
+### Note on NC bound semantics
+
+The change is from *roughly upper* to *upper*. Old bounds matched a
+fluid-bytes assumption; new bounds enforce the atomic-frame physics
+("a frame in flight must drain"). Users who calibrated against v0.8.1
+numbers will see proportional growth: ≈ +12.144 µs per 1 Gbps hop
+with 1518 B MTU. The `WcttFrameQuantization` diagnostic makes the
+correction visible per hop.
+
+---
+
 ## [0.9.0] — 2026-04-29
 
 Major: spar gains an MCP (Model Context Protocol) tool surface and a

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,4 +1,4 @@
-# AS5506 AADL v2.2 Compliance Gap Analysis
+# AS5506D AADL v2.2/v2.3 Compliance Gap Analysis
 
 **Updated**: 2026-04-28 (v0.8.0 released; v0.8.1 Phase 2 TSN close-out in progress)
 **Source**: 102 HTML files from OSATE2 (`org.osate.help/html/std/`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "etch",
  "la-arena",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "rowan",
  "salsa",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "salsa",
  "serde",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "spar-base-db",
  "spar-hir-def",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "etch",
  "la-arena",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "la-arena",
  "serde",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1428,14 +1428,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/crates/spar-parser/src/grammar/mod.rs
+++ b/crates/spar-parser/src/grammar/mod.rs
@@ -1,4 +1,4 @@
-//! AADL v2.2 grammar rules.
+//! AADL v2.2/v2.3 grammar rules (SAE AS5506D).
 //!
 //! Each function corresponds to a grammar production from AS5506D.
 //! Functions take a `&mut Parser` and build nodes via markers.

--- a/crates/spar-parser/src/lexer.rs
+++ b/crates/spar-parser/src/lexer.rs
@@ -1,4 +1,4 @@
-//! Lexer for AADL v2.2 source text.
+//! Lexer for AADL v2.2/v2.3 source text (SAE AS5506D).
 //!
 //! Produces a flat sequence of `(SyntaxKind, &str)` token pairs from an input
 //! string. The lexer is a simple cursor-based implementation with no external

--- a/crates/spar-parser/src/syntax_kind.rs
+++ b/crates/spar-parser/src/syntax_kind.rs
@@ -1,6 +1,6 @@
 /// All syntax kinds for the AADL language.
 ///
-/// This enum covers every token and node type in AADL v2.2 (AS5506D).
+/// This enum covers every token and node type in AADL v2.2/v2.3 (SAE AS5506D).
 /// Option B: component categories use generic COMPONENT_TYPE/COMPONENT_IMPL
 /// nodes with a COMPONENT_CATEGORY child, rather than per-category variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/vscode-spar/README.md
+++ b/vscode-spar/README.md
@@ -1,13 +1,13 @@
 # AADL (spar) — VS Code Extension
 
-AADL v2.2 language support with live interactive architecture diagrams.
+AADL v2.2/v2.3 language support with live interactive architecture diagrams.
 
 Powered by [spar](https://github.com/pulseengine/spar), an open-source AADL toolchain with 21 analysis passes, port-aware rendering, and orthogonal edge routing.
 
 ## Features
 
 ### Syntax Highlighting
-Full TextMate grammar for AADL v2.2 — keywords, component categories, features, connections, properties, modes, and annexes.
+Full TextMate grammar for AADL v2.2/v2.3 — keywords, component categories, features, connections, properties, modes, and annexes.
 
 ### Language Server (10 IDE Features)
 - **Diagnostics** — parser errors + 21 analysis passes on save
@@ -59,7 +59,7 @@ Interactive HTML diagram that updates on every save:
 - [spar on GitHub](https://github.com/pulseengine/spar)
 - [Latest Release](https://github.com/pulseengine/spar/releases/latest)
 - [Issue Tracker](https://github.com/pulseengine/spar/issues)
-- [AADL Standard (SAE AS5506C)](https://www.sae.org/standards/content/as5506c/)
+- [AADL Standard (SAE AS5506D)](https://www.sae.org/standards/content/as5506d/)
 
 ## License
 

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -1,9 +1,9 @@
 {
   "name": "spar-aadl",
   "displayName": "AADL (spar)",
-  "description": "AADL v2.2 language support with live architecture visualization",
+  "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release: NC kernel soundness pass (#186 already merged) + AADL v2.3 spec-claim consistency cleanup.

**v0.9.1 content:**
- gPTP synchronization-error budget (`Spar_TSN::Sync_Error`)
- Atomic-frame quantization per hop on TAS / FIFO arms
- Test bounds updated to sound numbers (single-hop 1 Gbps: 12 µs → 24.144 µs)

**Spec-claim consistency:**
- `COMPLIANCE.md` title: "AS5506 AADL v2.2" → "AS5506D AADL v2.2/v2.3"
- `vscode-spar/package.json` description + `vscode-spar/README.md` body: "AADL v2.2" → "AADL v2.2/v2.3"
- `spar-parser` lexer / grammar / syntax_kind doc comments aligned to "AADL v2.2/v2.3 (SAE AS5506D)"
- `vscode-spar/README.md` AS5506C link → AS5506D

Top-level `README.md` already correctly claims "AADL v2.3" + AS5506D badge — this PR makes the rest of the project consistent with that.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean (2772 pass)
- [x] `rivet validate` PASS
- [x] `cargo fmt --all -- --check` clean
- [ ] CI green
- [ ] Tag v0.9.1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)