### PR TITLE
docs: add quickstart.md + tighten stale headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,25 @@ Use `rivet validate --format json` for machine-readable output.
 - Always include traceability links when creating artifacts
 - Run `rivet validate` before committing
 <!-- END rivet-managed -->
+
+## Spar contributor quick map
+
+Spar-specific guidance for contributors and agents (outside the rivet-managed
+section above):
+
+- **Build**: `cargo build --workspace`. Single-binary CLI: `cargo build --release -p spar`.
+- **Tests**: `cargo test --workspace`. Per-crate fixtures live under each crate's `tests/` directory.
+- **Salsa graph**: query definitions and the incremental DB live in
+  `crates/spar-base-db/`; HIR-side queries are in `crates/spar-hir-def/` and
+  `crates/spar-hir/`. Add new queries near existing ones — do not stand up a
+  parallel database.
+- **Analysis registry**: pluggable passes are wired in
+  `crates/spar-analysis/src/lib.rs` (see `Runner::register` / `register_all`).
+  New passes implement the `Analysis` trait and are registered there.
+- **Lean proofs gate**: proofs live in `proofs/Proofs/` (Scheduling, Network).
+  CI runs `lake build`; sorry-free is required for the verified-core modules
+  (`RTA`, `RTAJittered`, `EDF`, `RMBound`).
+- **Sample models**: `test-data/vehicle.aadl` + `test-data/sensor_lib.aadl` are
+  the canonical pair used in docs and smoke tests.
+- **Quickstart**: see [`docs/quickstart.md`](docs/quickstart.md) for the
+  user-facing entry point.

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,6 +1,6 @@
 # AS5506D AADL v2.2/v2.3 Compliance Gap Analysis
 
-**Updated**: 2026-04-28 (v0.8.0 released; v0.8.1 Phase 2 TSN close-out in progress)
+**Updated**: 2026-04-28 (v0.9.1 released; v0.10 in progress)
 **Source**: 102 HTML files from OSATE2 (`org.osate.help/html/std/`)
 **Toolchain**: spar (2759+ tests passing across 18 crates)
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A first-party VS Code extension lives in [`vscode-spar/`](vscode-spar/). It pair
 
 ## Documentation
 
+- [Quickstart](docs/quickstart.md) -- build spar, parse + analyze the sample model in ~30 minutes
 - [`spar moves` reference](docs/cli/moves.md) -- hypothetical-rebinding oracle (verify + enumerate)
 - [WASM-as-architecture design](docs/plans/2026-03-10-wasm-as-architecture-design.md) -- WIT/WAC/wRPC transforms
 - [VS Code extension design](docs/plans/2026-03-18-vscode-extension-design.md) -- editor integration

--- a/docs/designs/v0.7.0-hierarchical-rta.md
+++ b/docs/designs/v0.7.0-hierarchical-rta.md
@@ -1,10 +1,16 @@
 # Design: Hierarchical IRQ-aware RTA (v0.7.0 Track A, commit 2)
 
-Status: **proposed** — implementation waits on PR #145 merge.
-Last update: 2026-04-23.
+Status: **shipped** in v0.7.0 (#145, April 2026).
+Last update: 2026-04-28.
 Preceded by: PR #145 (property set surface — `Spar_Timing::*`, `Spar_Trace::*`).
 Followed by: commit 3 (`Spar_Proofs/Scheduling/RTAJittered.lean`), commit 4 (integration
 tests + COMPLIANCE).
+
+> **As implemented:** the hierarchical IRQ-aware RTA logic described below
+> landed in `crates/spar-analysis/src/scheduling_verified.rs` (verified bridge
+> tied to `proofs/Proofs/Scheduling/RTAJittered.lean`). Read this design for
+> the rationale and consult `scheduling_verified.rs` for the current shape of
+> the code.
 
 ## Context: what RTA does today
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart
+
+Spar is a Rust toolchain for [AADL](https://www.sae.org/standards/content/as5506d/) v2.2/v2.3 — the Architecture Analysis & Design Language used to describe embedded and safety-critical systems (threads, processes, processors, buses, ports, latency budgets). Spar parses AADL, builds an instance model, runs the analysis pipeline (timing, scheduling, port-binding, latency, modes, properties), and emits SVG/Mermaid diagrams plus JSON for downstream tools (Bazel, Lean, MCP).
+
+In ~30 minutes you will: build spar, parse a real model, instantiate it, run analyses, and render a diagram.
+
+## 1. Build (≈ 2 min on a modern laptop)
+
+```sh
+git clone https://github.com/pulseengine/spar.git
+cd spar
+cargo build --release -p spar
+export PATH="$PWD/target/release:$PATH"
+```
+
+No system dependencies beyond a stable Rust toolchain.
+
+## 2. Parse, instantiate, analyze, render
+
+The repo ships `test-data/vehicle.aadl` (a small vehicle compute platform) and its dependency `test-data/sensor_lib.aadl`. AADL fully-qualified names follow `Package::Type.Implementation`.
+
+```sh
+# 1. Parse — checks syntax + AS5506 legality, emits diagnostics
+spar parse test-data/vehicle.aadl test-data/sensor_lib.aadl
+
+# 2. Instantiate — flattens the system rooted at an implementation
+spar instance --root 'Vehicle::ECU.basic' \
+  test-data/vehicle.aadl test-data/sensor_lib.aadl
+
+# 3. Analyze — runs the analysis pipeline (timing, ports, latency, modes…)
+spar analyze --root 'Vehicle::ECU.basic' \
+  test-data/vehicle.aadl test-data/sensor_lib.aadl
+
+# 4. Render — SVG of the instance hierarchy
+spar render --root 'Vehicle::ECU.basic' -o vehicle.svg \
+  test-data/vehicle.aadl test-data/sensor_lib.aadl
+```
+
+Diagnostics are colored and anchor each finding to the AS5506D section it enforces.
+
+## 3. Troubleshooting
+
+- **"unresolved implementation X" / "unknown package Y"** — you forgot to pass the file that declares package Y. Spar does not auto-resolve `with` imports from a search path; pass every `.aadl` file involved on the command line.
+- **A `test-data/*.aadl` file fails to parse** — `vehicle.aadl` + `sensor_lib.aadl` are the recommended starting pair.
+
+## 4. Where to go next, by role
+
+**Embedded / RTA engineer** — read `docs/cli/moves.md` for the move/RTA workflow. The `Spar_Timing` property set (period, deadline, WCET, jitter, priority) is what feeds rate-monotonic and EDF schedulability.
+
+**TSN network architect** — see `crates/spar-network/`. WCTT (network) and WCET (compute) alternate per hop in the latency analyzer; TAS + CBS + 802.1Qbu preemption are modeled but the closed-form bounds are not yet Lean-verified (see "What this is NOT").
+
+**AI agent / MCP user** — start `spar-mcp` (stdio server) and wire it into Claude Desktop or your MCP client. Exposed tools: `spar.verify_move`, `spar.enumerate_moves`, `spar.check_chain`. See `crates/spar-mcp/`.
+
+**Safety engineer** — `spar verify` produces a JSON evidence pack; combine with `proofs/` for the formally checked subset. Note: EMV2 analysis is currently structural-only; full annex consumption is on the v0.10 roadmap.
+
+**SysML v2 user** — `crates/spar-sysml2/` parses SysML v2 and lowers to AADL per the SEI 2023 mapping rules.
+
+**PLE / variant engineer** — variant filtering is driven by rivet (Shape 1: rivet owns the PLE, emits a JSON context, spar filters HIR). See `docs/contracts/rivet-spar-variant-v1.md`.
+
+## What this is NOT
+
+- **Not a simulator.** Spar is static analysis + model transformation. Co-simulation lives elsewhere (Renode, FMI).
+- **Not a fully verified tool.** The Lean proofs at v0.9.1 cover the rate-monotonic / RTA core (RTA, RTAJittered, EDF, RMBound — all sorry-free); network-calculus closed forms in MinPlus.lean are still informational at this version.
+- **Not real CTF.** `spar-insight`'s "Tier 1 CTF" is a bespoke textual subset for development; full LTTng / `babeltrace2` ingestion is a v0.9.x follow-up.
+
+## References
+
+- Repo: <https://github.com/pulseengine/spar>
+- Standard: SAE AS5506D (AADL v2.3)
+- Sample models: `test-data/vehicle.aadl`, `test-data/sensor_lib.aadl`
+- CLI docs: `docs/cli/`
+- VS Code extension: `vscode-spar/`
+- MCP server: `crates/spar-mcp/`
+- SysML v2 frontend: `crates/spar-sysml2/`


### PR DESCRIPTION
## Summary

Wave 3 docs PR: ships the user-facing quickstart designed by the 12-persona audit consolidator and tightens three pieces of doc drift flagged in the same review.

- **`docs/quickstart.md` (new)** — 30-minute path to build, parse, instantiate, analyze, and render the `test-data/vehicle.aadl` + `test-data/sensor_lib.aadl` pair. Role-based "where to go next" (RTA, TSN, MCP, safety, SysML v2, PLE) and a "What this is NOT" section calibrated to v0.9.1 (Lean RTA core sorry-free; MinPlus / CTF still informational).
- **`COMPLIANCE.md` header** — bumped from `v0.8.0 released; v0.8.1 Phase 2 ... in progress` to `v0.9.1 released; v0.10 in progress`. Body unchanged.
- **`docs/designs/v0.7.0-hierarchical-rta.md`** — status flipped from `proposed` to `shipped in v0.7.0 (#145, April 2026)`, with an as-implemented pointer to `crates/spar-analysis/src/scheduling_verified.rs`.
- **`AGENTS.md`** — added a Spar contributor quick map *outside* the `BEGIN/END rivet-managed` markers (build, salsa graph at `crates/spar-base-db/`, analysis registry at `crates/spar-analysis/src/lib.rs`, Lean proofs gate, sample models, quickstart link).
- **`README.md`** — `docs/quickstart.md` is now the first link in the Documentation section so new users land on usage rather than design plans.

The companion file `test-data/sensor_lib.aadl` is the correct match for `vehicle.aadl`'s `with SensorLib;` clause — no substitution needed.

## Quality gates

- `cargo build --workspace` — clean
- `rivet validate` — `Result: PASS (91 warnings)` (unchanged from baseline)
- All four quickstart commands ran cleanly against current main:
  - `spar parse test-data/vehicle.aadl test-data/sensor_lib.aadl` → both files OK
  - `spar instance --root 'Vehicle::ECU.basic' ...` → 3 component instances rendered
  - `spar analyze --root 'Vehicle::ECU.basic' ...` → `0 error(s), 7 warning(s), 3 info(s)` (expected: the model has unbound output ports + an unclassified subcomponent, exactly the kind of finding the diagnostics section advertises)
  - `spar render --root 'Vehicle::ECU.basic' -o vehicle.svg ...` → SVG written

## Deviations from the consolidator's draft

None — the body is verbatim. One observation worth flagging for a follow-up (not for this PR per scope): `spar instance` / `spar analyze` print the root as `Vehicle::ECU.` (trailing dot, dropping `basic`); the quickstart text describes the behaviour at a level of abstraction that doesn't depend on that exact line, so no `<!-- TODO -->` was added.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo build --release -p spar` clean
- [x] `rivet validate` PASS
- [x] Four quickstart commands run with non-error output on current main
- [ ] Reviewer skim of `docs/quickstart.md` for tone / link accuracy

Out of scope (sibling PRs): `spar --help` polish, `test-data/` updates, README crate/pass count reconciliation, CHANGELOG.

Co-authored with the 12-persona audit consolidator.

Generated with [Claude Code](https://claude.com/claude-code)