### PR TITLE
cleanup: spar --help works + reconcile crate/pass counts in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ spar parse vehicle.aadl --tree
 spar items vehicle.aadl
 
 # Instantiate a system hierarchy
-spar instance --root Pkg::System.Impl vehicle.aadl platform.aadl
+spar instance --root Pkg::System.Impl vehicle.aadl test-data/sensor_lib.aadl
 
 # Run all analysis passes
-spar analyze --root Pkg::System.Impl vehicle.aadl platform.aadl
+spar analyze --root Pkg::System.Impl vehicle.aadl test-data/sensor_lib.aadl
 
 # Allocate threads to processors (deployment solver)
-spar allocate --root Pkg::System.Impl vehicle.aadl platform.aadl
+spar allocate --root Pkg::System.Impl vehicle.aadl test-data/sensor_lib.aadl
 
 # Render the architecture as SVG
-spar render --root Pkg::System.Impl -o arch.svg vehicle.aadl platform.aadl
+spar render --root Pkg::System.Impl -o arch.svg vehicle.aadl test-data/sensor_lib.aadl
 
 # Run verification assertions
 spar verify --root Pkg::System.Impl --rules rules.toml vehicle.aadl
@@ -92,26 +92,34 @@ spar verify --root Pkg::System.Impl --rules rules.toml vehicle.aadl
 
 ## Architecture
 
-12 crates, layered from low-level parsing to high-level analysis:
+20 crates, layered from low-level parsing to high-level analysis:
 
 ```
-spar-syntax     Lossless CST (rowan red-green trees)
-spar-parser     Recursive descent parser with error recovery
-spar-annex      AADL annex sublanguage parsing (EMV2, BLESS, BA)
-spar-base-db    Salsa database for incremental computation
-spar-hir-def    HIR definitions -- item tree, instance model, arenas
-spar-hir        Public semantic facade (name resolution, properties)
-spar-analysis   27+ pluggable analysis passes
-spar-transform  Format transforms (AADL <-> WIT, WAC, Rust crates, wRPC)
-spar-solver     Deployment solver (thread-to-processor allocation)
-spar-render     SVG architecture diagrams (compound Sugiyama layout)
-spar-cli        Command-line interface
-spar-wasm       WebAssembly component (WASI P2)
+spar-syntax        Lossless CST (rowan red-green trees)
+spar-parser        Recursive descent parser with error recovery
+spar-annex         AADL annex sublanguage parsing (EMV2, BLESS, BA)
+spar-base-db       Salsa database for incremental computation
+spar-hir-def       HIR definitions -- item tree, instance model, arenas
+spar-hir           Public semantic facade (name resolution, properties)
+spar-analysis      30 pluggable analysis passes
+spar-transform     Format transforms (AADL <-> WIT, WAC, Rust crates, wRPC)
+spar-solver        Deployment solver (thread-to-processor allocation)
+spar-render        SVG architecture diagrams (compound Sugiyama layout)
+spar-network       Network topology and WCTT analysis support
+spar-variants      Product-line variant selection and HIR filtering
+spar-verify        Requirements verification engine
+spar-verify-macros Procedural macros for verification rules
+spar-codegen       Rust + WIT code generation from instance models
+spar-insight       Discrepancy assistant (compare CTF traces vs expected)
+spar-sysml2        SysML v2 / KerML extraction and generation
+spar-mcp           Model Context Protocol server (read-only oracles)
+spar-cli           Command-line interface
+spar-wasm          WebAssembly component (WASI P2)
 ```
 
 ## Key Features
 
-- **27+ analysis passes** -- scheduling, latency, connectivity, resource budgets, ARINC 653, EMV2 fault trees, bus bandwidth, weight/power, mode reachability, and more
+- **30 analysis passes** -- scheduling, latency, connectivity, resource budgets, ARINC 653, EMV2 fault trees, bus bandwidth, weight/power, mode reachability, and more
 - **Assertion engine** -- declarative verification rules in TOML (`spar verify`)
 - **Deployment solver** -- automated thread-to-processor allocation with constraint satisfaction
 - **SARIF output** -- analysis results in SARIF format for CI integration
@@ -120,9 +128,13 @@ spar-wasm       WebAssembly component (WASI P2)
 - **Incremental** -- salsa-based memoization for fast re-analysis
 - **Lossless parsing** -- every byte preserved in the syntax tree
 
+## Editor support
+
+A first-party VS Code extension lives in [`vscode-spar/`](vscode-spar/). It pairs the `spar lsp` server (diagnostics, hover, go-to-definition, completion, rename, inlay hints) with a live architecture-diagram webview that re-renders on save. See [`vscode-spar/README.md`](vscode-spar/README.md) for install + setup.
+
 ## Documentation
 
-- [Integration plan](docs/plans/2026-03-08-spar-rivet-integration.md) -- rivet lifecycle integration
+- [`spar moves` reference](docs/cli/moves.md) -- hypothetical-rebinding oracle (verify + enumerate)
 - [WASM-as-architecture design](docs/plans/2026-03-10-wasm-as-architecture-design.md) -- WIT/WAC/wRPC transforms
 - [VS Code extension design](docs/plans/2026-03-18-vscode-extension-design.md) -- editor integration
 - [Deployment solver plan](docs/plans/2026-03-21-deployment-solver-plan.md) -- allocation algorithm

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -53,8 +53,13 @@ fn main() {
         "mcp" => cmd_mcp(&args[2..]),
         "moves" => moves::cmd_moves_dispatch(&args[2..]),
         "insight" => insight::cmd_insight(&args[2..]),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            process::exit(0);
+        }
         other => {
             eprintln!("Unknown command: {other}");
+            print_usage();
             process::exit(1);
         }
     }

--- a/crates/spar-cli/tests/help_flag.rs
+++ b/crates/spar-cli/tests/help_flag.rs
@@ -1,0 +1,59 @@
+//! Smoke tests for the help dispatch surfaced by the 12-persona audit
+//! (Tier B #10): `spar help`, `spar --help`, and `spar -h` must all print
+//! the same usage banner the no-args path prints, and must exit 0.
+
+use std::process::Command;
+
+fn spar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spar"))
+}
+
+/// The usage banner all help paths must include. Picking a stable substring
+/// (the first line of `print_usage`) keeps this test resilient to the
+/// command-list growing over time.
+const USAGE_HEADER: &str = "Usage: spar <command> [options] <file...>";
+
+fn assert_help_output(form: &[&str]) {
+    let output = spar()
+        .args(form)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `spar {}`: {e}", form.join(" ")));
+
+    assert!(
+        output.status.success(),
+        "`spar {}` should exit 0; got status {:?}\nstderr:\n{}",
+        form.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // The usage banner is currently printed to stderr (matching the
+    // existing no-args path). Accept either stream so we don't pin
+    // future banner-routing decisions.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{stderr}{stdout}");
+
+    assert!(
+        combined.contains(USAGE_HEADER),
+        "`spar {}` did not print the usage banner.\nstdout:\n{}\nstderr:\n{}",
+        form.join(" "),
+        stdout,
+        stderr,
+    );
+}
+
+#[test]
+fn spar_help_subcommand_prints_usage() {
+    assert_help_output(&["help"]);
+}
+
+#[test]
+fn spar_double_dash_help_prints_usage() {
+    assert_help_output(&["--help"]);
+}
+
+#[test]
+fn spar_dash_h_prints_usage() {
+    assert_help_output(&["-h"]);
+}

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -52,7 +52,7 @@ graph TB
 | `spar-base-db` | Salsa incremental computation database |
 | `spar-hir-def` | HIR definitions: item tree, instance model, properties |
 | `spar-hir` | Public HIR facade with serde serialization |
-| `spar-analysis` | 21 analysis passes (scheduling, latency, connectivity, etc.) |
+| `spar-analysis` | 30 analysis passes (scheduling, latency, connectivity, etc.) |
 | `spar-render` | SVG/HTML rendering via etch compound layout |
 | `spar-transform` | WIT/WAC/Rust crate transforms |
 | `spar-cli` | CLI (`spar parse/items/instance/analyze/render/modes/verify/lsp`) |
@@ -62,7 +62,7 @@ graph TB
 ## Key Features
 
 - **Full AADL v2.3 parser** (AS5506D) with error recovery and lossless syntax tree
-- **21 analysis passes** including RMA scheduling, latency, EMV2 fault trees, mode reachability
+- **30 analysis passes** including RMA scheduling, latency, EMV2 fault trees, mode reachability
 - **Port-aware rendering** with orthogonal edge routing and interactive HTML
 - **LSP server** with 10 IDE features (diagnostics, hover, completion, go-to-def, rename, etc.)
 - **WASM component** for browser-side rendering in rivet dashboard

--- a/vscode-spar/README.md
+++ b/vscode-spar/README.md
@@ -2,7 +2,7 @@
 
 AADL v2.2 language support with live interactive architecture diagrams.
 
-Powered by [spar](https://github.com/pulseengine/spar), an open-source AADL toolchain with 21 analysis passes, port-aware rendering, and orthogonal edge routing.
+Powered by [spar](https://github.com/pulseengine/spar), an open-source AADL toolchain with 30 analysis passes, port-aware rendering, and orthogonal edge routing.
 
 ## Features
 
@@ -10,7 +10,7 @@ Powered by [spar](https://github.com/pulseengine/spar), an open-source AADL tool
 Full TextMate grammar for AADL v2.2 — keywords, component categories, features, connections, properties, modes, and annexes.
 
 ### Language Server (10 IDE Features)
-- **Diagnostics** — parser errors + 21 analysis passes on save
+- **Diagnostics** — parser errors + 30 analysis passes on save
 - **Hover** — component types, features, keywords
 - **Go-to-Definition** — cross-file classifier references
 - **Completion** — keywords, classifiers, properties, packages


### PR DESCRIPTION
## Summary

Three onboarding fixes surfaced by the 12-persona audit, scoped to v0.10 prep (no CHANGELOG, no new features).

- **`spar help` / `--help` / `-h` now work** (Tier B #10). The CLI dispatcher previously rejected them with `Unknown command`. They now print the same usage banner the no-args path prints and exit 0. Unknown commands also now print the banner before exiting 1. New smoke tests in `crates/spar-cli/tests/help_flag.rs` cover all three forms.
- **README/doc reconciliation** (Tier B #12, #65, #66; Tier C #61, #63):
  - Quick Start no longer references the non-existent `platform.aadl`; uses `test-data/sensor_lib.aadl` (the real companion to `vehicle.aadl`).
  - Crate count corrected from "12" to "20"; architecture listing now enumerates all 20 crates.
  - Analysis-pass count reconciled to "30" across `README.md`, `docs/introduction.md`, and `vscode-spar/README.md` (was 27+ / 21 / 21). 30 = count of `impl Analysis for` impls and `register_all` entries in `crates/spar-analysis/src/lib.rs`.
  - Added an "Editor support" subsection in the README linking to `vscode-spar/`.
  - "Documentation" section now links `docs/cli/moves.md` (a real user-facing reference) instead of the March `2026-03-08-spar-rivet-integration.md` planning doc.
- **`Vehicle::ECU.` trailing-dot audit** (Tier B #16): grepped `README.md`, `docs/`, and crate READMEs. All existing references already use `Vehicle::ECU.Impl`; no trailing-dot examples remained to fix.

Out of scope (sibling Wave 3 PRs): `proofs/`, `crates/spar-mcp/`, test-data fixtures.

## Numbers found

- Crates: **20** (`find crates -mindepth 1 -maxdepth 1 -type d | wc -l`)
- Analysis passes: **30** (`impl Analysis for` impls in `crates/spar-analysis/src/`, matches `register_all`)

## Test plan

- [x] `cargo build -p spar` clean
- [x] `cargo test -p spar` clean (incl. 3 new help-flag smoke tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS (91 pre-existing artifact warnings, unchanged)