### PR TITLE
fix(mcp): check_chain variant inputs no longer silently discarded

### DIFF
--- a/crates/spar-mcp/src/schema.rs
+++ b/crates/spar-mcp/src/schema.rs
@@ -93,14 +93,18 @@ pub fn verify_move_descriptor() -> ToolDescriptor {
                 },
                 "variant": {
                     "type": "string",
-                    "description": "Optional variant name (implicit form; spar shells out to rivet resolve)."
+                    "description": "Optional variant name (implicit form; spar shells out to rivet resolve). Mutually exclusive with variant_context."
                 },
                 "variant_context": {
                     "type": "string",
-                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                    "description": "Optional explicit-form variant-context path or '-' for stdin. Mutually exclusive with variant."
                 }
             },
-            "required": ["model", "root", "component", "target"]
+            "required": ["model", "root", "component", "target"],
+            "not": {
+                "type": "object",
+                "required": ["variant", "variant_context"]
+            }
         }),
         annotations: Annotations::read_only_idempotent(),
     }
@@ -144,14 +148,18 @@ pub fn enumerate_moves_descriptor() -> ToolDescriptor {
                 },
                 "variant": {
                     "type": "string",
-                    "description": "Optional variant name (implicit form)."
+                    "description": "Optional variant name (implicit form). Mutually exclusive with variant_context."
                 },
                 "variant_context": {
                     "type": "string",
-                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                    "description": "Optional explicit-form variant-context path or '-' for stdin. Mutually exclusive with variant."
                 }
             },
-            "required": ["model", "root", "component"]
+            "required": ["model", "root", "component"],
+            "not": {
+                "type": "object",
+                "required": ["variant", "variant_context"]
+            }
         }),
         annotations: Annotations::read_only_idempotent(),
     }
@@ -189,14 +197,18 @@ pub fn check_chain_descriptor() -> ToolDescriptor {
                 },
                 "variant": {
                     "type": "string",
-                    "description": "Optional variant name (implicit form)."
+                    "description": "Not yet supported for check_chain (tracked as v0.10 enhancement); supplying this returns BAD_INPUT. Use spar.verify_move or spar.enumerate_moves for variant-scoped queries. Mutually exclusive with variant_context."
                 },
                 "variant_context": {
                     "type": "string",
-                    "description": "Optional explicit-form variant-context path or '-' for stdin."
+                    "description": "Not yet supported for check_chain (tracked as v0.10 enhancement); supplying this returns BAD_INPUT. Use spar.verify_move or spar.enumerate_moves for variant-scoped queries. Mutually exclusive with variant."
                 }
             },
-            "required": ["model", "root", "source_thread", "sink_thread"]
+            "required": ["model", "root", "source_thread", "sink_thread"],
+            "not": {
+                "type": "object",
+                "required": ["variant", "variant_context"]
+            }
         }),
         annotations: Annotations::read_only_idempotent(),
     }

--- a/crates/spar-mcp/src/tools/check_chain.rs
+++ b/crates/spar-mcp/src/tools/check_chain.rs
@@ -8,8 +8,8 @@
 //!   "root":  "Pkg::Type.Impl",
 //!   "source_thread": "fw.acquire",
 //!   "sink_thread":   "fw.actuate",
-//!   "variant":         "diesel-eu5",          // optional
-//!   "variant_context": "/path/to/ctx.json"    // optional
+//!   "variant":         "diesel-eu5",          // NOT YET SUPPORTED — rejected
+//!   "variant_context": "/path/to/ctx.json"    // NOT YET SUPPORTED — rejected
 //! }
 //! ```
 //!
@@ -18,6 +18,19 @@
 //! `LatencyAnalysis` pass — these already alternate compute (WCET) and
 //! network (WCTT) hops in the message stream so an LLM can read the
 //! shape without re-running its own walk.
+//!
+//! # Variant scoping (deferred)
+//!
+//! Unlike `spar.verify_move` and `spar.enumerate_moves`, this tool does
+//! NOT yet apply rivet variant filtering to the analysis. Wiring the
+//! `VariantScope` through `LatencyAnalysis` requires the pass to honour
+//! "kept" predicates on the instance hierarchy (chains can cross dropped
+//! components in surprising ways), which is tracked as a v0.10
+//! enhancement. To avoid silently returning an unfiltered chain when an
+//! agent asks for a variant-scoped one, we hard-reject the inputs with
+//! a `BAD_INPUT` error here — the agent should fall back to
+//! `spar.verify_move` / `spar.enumerate_moves` for variant-scoped queries
+//! against the same chain participants.
 //!
 //! # Matching
 //!
@@ -122,22 +135,47 @@ pub fn call(arguments: &Value) -> ToolResult {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let _variant = match optional_string(arguments, "variant") {
+    let variant = match optional_string(arguments, "variant") {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let _variant_context = match optional_string(arguments, "variant_context") {
+    let variant_context = match optional_string(arguments, "variant_context") {
         Ok(v) => v,
         Err(e) => return e,
     };
 
+    // Mutual-exclusion guard, applied before the not-yet-supported
+    // refusal so an agent that supplies BOTH gets the more specific
+    // error. Mirrors the v1 contract's CLI-side enforcement in
+    // `spar_cli::moves::load_variant_context`.
+    if variant.is_some() && variant_context.is_some() {
+        return ToolResult::Error {
+            code: "BAD_INPUT",
+            message: "variant and variant_context are mutually exclusive (see \
+                 docs/contracts/rivet-spar-variant-v1.md)"
+                .to_string(),
+        };
+    }
+
+    // Variant inputs are accepted in the schema for API symmetry with
+    // verify_move / enumerate_moves but are not yet threaded into the
+    // latency analysis. Until that wiring lands (tracked as a v0.10
+    // enhancement), refuse the call rather than silently return an
+    // unfiltered chain — a wrong answer is worse than a clear refusal.
+    if variant.is_some() || variant_context.is_some() {
+        return ToolResult::Error {
+            code: "BAD_INPUT",
+            message: "variant and variant_context are not yet supported for check_chain \
+                 (tracked as v0.10 enhancement); call spar.verify_move or \
+                 spar.enumerate_moves with --variant for variant-scoped queries"
+                .to_string(),
+        };
+    }
+
     // Parse + instantiate. We reuse the same minimal pipeline as the
     // verify path (single file, named root) without going through
     // `spar_cli::moves` because the check_chain tool does not need
-    // overlay scaffolding. Variant scoping is accepted for API
-    // symmetry but not yet applied (latency analysis is monotonic
-    // w.r.t. the kept subset; non-kept components contribute 0 to the
-    // chain when their bindings are dropped).
+    // overlay scaffolding.
     let instance = match parse_and_instantiate(&model, &root) {
         Ok(i) => i,
         Err(e) => return e,

--- a/crates/spar-mcp/tests/in_process_tests.rs
+++ b/crates/spar-mcp/tests/in_process_tests.rs
@@ -364,6 +364,119 @@ fn enumerate_tool_with_objective_picks_least_loaded() {
     cleanup(&path);
 }
 
+// ── 6. check_chain_rejects_variant_input_with_bad_input ──────────────
+
+#[test]
+fn check_chain_rejects_variant_input_with_bad_input() {
+    // Tier A #7: check_chain previously accepted `variant` and silently
+    // discarded it, returning unfiltered chain results. Until variant
+    // scoping is wired through `LatencyAnalysis` (v0.10 enhancement),
+    // the tool refuses the input cleanly so an agent cannot mistake an
+    // unfiltered answer for a variant-scoped one.
+    let path = write_model("chain_variant_reject", CHAIN_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Chain::Sys.Impl",
+        "source_thread": "producer",
+        "sink_thread":   "consumer",
+        "variant":       "test-variant",
+    });
+    let result = check_chain::call(&args);
+    match result {
+        ToolResult::Error { code, message } => {
+            assert_eq!(
+                code, "BAD_INPUT",
+                "expected BAD_INPUT for variant on check_chain; got {code}: {message}",
+            );
+            assert!(
+                message.contains("not yet supported"),
+                "error message should explain the limitation; got {message}",
+            );
+            assert!(
+                message.contains("verify_move") || message.contains("enumerate_moves"),
+                "error message should suggest the variant-aware tools; got {message}",
+            );
+        }
+        ToolResult::Ok(v) => {
+            cleanup(&path);
+            panic!("expected BAD_INPUT for variant input on check_chain, got Ok({v})");
+        }
+    }
+    cleanup(&path);
+}
+
+// ── 7. tools_reject_both_variant_and_variant_context ─────────────────
+
+#[test]
+fn check_chain_rejects_both_variant_and_variant_context() {
+    // Tier C #50: mutual exclusion was previously enforced only at the
+    // pipeline layer (verify/enumerate); check_chain now applies it
+    // before the not-yet-supported refusal so an agent supplying both
+    // gets a stable BAD_INPUT mentioning the conflict.
+    let path = write_model("chain_both_variant", CHAIN_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Chain::Sys.Impl",
+        "source_thread": "producer",
+        "sink_thread":   "consumer",
+        "variant":         "test-variant",
+        "variant_context": "/tmp/ctx.json",
+    });
+    let result = check_chain::call(&args);
+    match result {
+        ToolResult::Error { code, message } => {
+            assert_eq!(
+                code, "BAD_INPUT",
+                "expected BAD_INPUT; got {code}: {message}"
+            );
+            assert!(
+                message.contains("mutually exclusive"),
+                "error message should mention mutual exclusion; got {message}",
+            );
+        }
+        ToolResult::Ok(v) => {
+            cleanup(&path);
+            panic!("expected BAD_INPUT for variant+variant_context, got Ok({v})");
+        }
+    }
+    cleanup(&path);
+}
+
+#[test]
+fn verify_rejects_both_variant_and_variant_context() {
+    // The verify pipeline already maps the conflict to
+    // `MovesError::VariantArgsConflict`, which classifies as
+    // BAD_INPUT. This test pins the contract so future refactors can't
+    // regress it without breaking the agent-visible error code.
+    let path = write_model("verify_both_variant", MOBILE_MODEL);
+    let args = json!({
+        "model": path.to_string_lossy(),
+        "root":  "Migrate::Sys.Impl",
+        "component": "t1",
+        "target":    "cpu2",
+        "variant":         "test-variant",
+        "variant_context": "/tmp/ctx.json",
+    });
+    let result = verify::call(&args);
+    match result {
+        ToolResult::Error { code, message } => {
+            assert_eq!(
+                code, "BAD_INPUT",
+                "expected BAD_INPUT; got {code}: {message}"
+            );
+            assert!(
+                message.contains("mutually exclusive"),
+                "error message should mention mutual exclusion; got {message}",
+            );
+        }
+        ToolResult::Ok(v) => {
+            cleanup(&path);
+            panic!("expected BAD_INPUT for variant+variant_context, got Ok({v})");
+        }
+    }
+    cleanup(&path);
+}
+
 // ── Validation helper used by stdio tests too ─────────────────────────
 
 /// Used by both in-process and stdio tests: accept either Ok(payload)

--- a/crates/spar-mcp/tests/stdio_tests.rs
+++ b/crates/spar-mcp/tests/stdio_tests.rs
@@ -291,6 +291,126 @@ fn unknown_tool_returns_method_not_found_error() {
     );
 }
 
+// ── 11. check_chain_with_variant_returns_bad_input_via_stdio ─────────
+
+#[test]
+fn check_chain_with_variant_returns_bad_input_via_stdio() {
+    // Tier A #7 reproduced through the stdio JSON-RPC envelope: an
+    // agent calling spar.check_chain with a variant must see a tool-
+    // level error (isError=true, code=BAD_INPUT) rather than an
+    // unfiltered success payload.
+    let path = write_model("chain_variant_stdio", CHAIN_MODEL);
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 100,
+        "method": "tools/call",
+        "params": {
+            "name": "spar.check_chain",
+            "arguments": {
+                "model": path.to_string_lossy(),
+                "root": "Chain::Sys.Impl",
+                "source_thread": "producer",
+                "sink_thread": "consumer",
+                "variant": "test-variant",
+            }
+        }
+    });
+    let resp = drive(&req.to_string());
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"].as_bool(),
+        Some(true),
+        "expected isError=true on BAD_INPUT; got {resp}",
+    );
+    let structured = &result["structuredContent"];
+    assert_eq!(
+        structured["code"].as_str(),
+        Some("BAD_INPUT"),
+        "expected structured code=BAD_INPUT; got {resp}",
+    );
+    let msg = structured["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("not yet supported"),
+        "expected message to explain limitation; got {msg}",
+    );
+    cleanup(&path);
+}
+
+// ── 12. tools_call_rejects_variant_plus_variant_context_via_stdio ────
+
+#[test]
+fn check_chain_rejects_both_variant_args_via_stdio() {
+    // Tier C #50: mutual exclusion is enforced before the not-yet-
+    // supported refusal, so the message points at the conflict rather
+    // than the deferred-feature error.
+    let path = write_model("chain_both_variant_stdio", CHAIN_MODEL);
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 101,
+        "method": "tools/call",
+        "params": {
+            "name": "spar.check_chain",
+            "arguments": {
+                "model": path.to_string_lossy(),
+                "root": "Chain::Sys.Impl",
+                "source_thread": "producer",
+                "sink_thread": "consumer",
+                "variant": "test-variant",
+                "variant_context": "/tmp/ctx.json",
+            }
+        }
+    });
+    let resp = drive(&req.to_string());
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"].as_bool(),
+        Some(true),
+        "expected isError=true on conflict; got {resp}",
+    );
+    let structured = &result["structuredContent"];
+    assert_eq!(
+        structured["code"].as_str(),
+        Some("BAD_INPUT"),
+        "expected structured code=BAD_INPUT; got {resp}",
+    );
+    let msg = structured["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("mutually exclusive"),
+        "expected message to mention mutual exclusion; got {msg}",
+    );
+    cleanup(&path);
+}
+
+// ── 13. tools_list_advertises_mutual_exclusion_in_schema ─────────────
+
+#[test]
+fn tools_list_advertises_variant_mutex_in_schema() {
+    // Each tool's input schema must encode the variant <-> variant_context
+    // mutex via JSON Schema `not` so a strict client can reject the
+    // conflicting payload before sending it.
+    let resp = drive(r#"{"jsonrpc":"2.0","id":50,"method":"tools/list"}"#);
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .expect("result.tools must be array");
+    for t in tools {
+        let name = t["name"].as_str().unwrap_or_default();
+        let not_clause = &t["inputSchema"]["not"];
+        assert!(
+            not_clause.is_object(),
+            "tool {name} must declare a top-level `not` clause for variant mutex; got {t}",
+        );
+        let required = not_clause["required"]
+            .as_array()
+            .unwrap_or_else(|| panic!("tool {name} `not.required` missing"));
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            names.contains(&"variant") && names.contains(&"variant_context"),
+            "tool {name} must mark both variant and variant_context as forbidden together; \
+             got {names:?}",
+        );
+    }
+}
+
 // ── Bonus: an unknown JSON-RPC method also gets MethodNotFound ───────
 
 #[test]


### PR DESCRIPTION
Tier A #7 + Tier C #50 from the Wave 3 MCP review. check_chain accepted variant / variant_context but discarded them silently — agents got unfiltered chain results with no warning. Picked Option B per the brief: hard-reject with BAD_INPUT pointing at verify_move/enumerate_moves (Option A requires threading VariantScope through LatencyAnalysis, a v0.10-scale effort). Also added JSON Schema 'not' mutex on all three tools and an up-front mutex guard in check_chain. Tests: 5 new (3 in-process, 3 stdio) covering the BAD_INPUT path, the conflict path, and the schema advertising. Quality gates (cargo test -p spar-mcp, clippy, fmt, rivet validate) all pass. Out of scope per brief: protocolVersion (#21), notifications/initialized (#22), outputSchema (#23).