### PR TITLE
cleanup(test-data): fix render_test.aadl + add move_oracle_demo.aadl + parse-roundtrip test

### DIFF
--- a/crates/spar-cli/tests/test_data_parse_roundtrip.rs
+++ b/crates/spar-cli/tests/test_data_parse_roundtrip.rs
@@ -1,0 +1,120 @@
+//! Parse-roundtrip sweep across every shipped top-level `test-data/*.aadl`
+//! fixture.
+//!
+//! The goal is simple: a junior dev cloning the repo and running
+//! `spar parse test-data/<name>.aadl` against any of the fixtures
+//! shipped at the top of `test-data/` should never see a parse error.
+//! This test re-checks that invariant from CI — a fixture that
+//! regresses (like `render_test.aadl` did pre-v0.9.1) will fail this
+//! sweep instead of silently shipping broken.
+//!
+//! Scope:
+//!   * Only top-level `test-data/*.aadl` files (subdirectories like
+//!     `negative/`, `parser/`, `osate2/`, etc. are out of scope —
+//!     they have their own per-feature tests, and `negative/` files
+//!     are *expected* to fail to parse).
+//!   * A fixture may opt out of the sweep by including the comment
+//!     `-- spar-test: skip-parse` anywhere in its first 20 lines.
+//!     This is intended for future fixtures that demonstrate parser
+//!     behaviour we don't yet support; today, no fixture opts out.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn spar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spar"))
+}
+
+/// Resolve the workspace `test-data/` directory relative to this
+/// crate's `CARGO_MANIFEST_DIR` (`crates/spar-cli`). Going two levels
+/// up lands at the workspace root.
+fn test_data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("test-data")
+}
+
+/// Returns true if the file's first 20 lines contain the opt-out
+/// marker `-- spar-test: skip-parse`.
+fn has_skip_marker(path: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    contents
+        .lines()
+        .take(20)
+        .any(|line| line.contains("-- spar-test: skip-parse"))
+}
+
+#[test]
+fn every_top_level_test_data_aadl_parses_cleanly() {
+    let dir = test_data_dir();
+    assert!(
+        dir.is_dir(),
+        "test-data directory not found at {}; CARGO_MANIFEST_DIR layout changed?",
+        dir.display(),
+    );
+
+    // Collect top-level *.aadl files (no recursion into subdirs).
+    let mut fixtures: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("read test-data/")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("aadl"))
+        .collect();
+    fixtures.sort();
+
+    assert!(
+        !fixtures.is_empty(),
+        "no top-level *.aadl fixtures found in {}",
+        dir.display(),
+    );
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+    let mut skipped: Vec<PathBuf> = Vec::new();
+
+    for path in &fixtures {
+        if has_skip_marker(path) {
+            skipped.push(path.clone());
+            continue;
+        }
+        checked += 1;
+
+        let out = spar()
+            .arg("parse")
+            .arg(path)
+            .output()
+            .expect("failed to run spar parse");
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            failures.push(format!(
+                "  {}\n    exit={:?}\n    stderr: {}\n    stdout: {}",
+                path.display(),
+                out.status.code(),
+                stderr.trim(),
+                stdout.trim(),
+            ));
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "every fixture was skipped via `-- spar-test: skip-parse`; sweep is a no-op",
+    );
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} top-level test-data/*.aadl fixtures failed `spar parse`:\n{}\n\
+         (skipped via `-- spar-test: skip-parse`: {:?})",
+        failures.len(),
+        checked,
+        failures.join("\n"),
+        skipped,
+    );
+}

--- a/test-data/move_oracle_demo.aadl
+++ b/test-data/move_oracle_demo.aadl
@@ -1,0 +1,62 @@
+-- Demo fixture for the `spar moves enumerate` hypothetical-rebinding oracle.
+--
+-- What this demonstrates:
+--   * One root system implementation (`Move_Oracle_Demo::Top.Impl`) that
+--     contains two processors of the same type (`cpu_a`, `cpu_b`) plus
+--     one process implementation hosting a `Brake_Handler` thread bound
+--     to `cpu_a`.
+--   * The thread is annotated with `Spar_Migration::Mobile => true` and
+--     `Spar_Migration::Allowed_Targets => (reference (cpu_a),
+--     reference (cpu_b))`, so the move oracle has exactly two
+--     candidate targets.
+--   * `Compute_Execution_Time`, `Period`, and `Deadline` are set so RTA
+--     produces a sensible response-time bound on either target.
+--
+-- See docs/cli/moves.md for the full CLI reference. To exercise the
+-- oracle against this fixture:
+--
+--   spar moves enumerate \
+--     --root Move_Oracle_Demo::Top.Impl \
+--     --component brake_handler \
+--     test-data/move_oracle_demo.aadl
+--
+-- Expected: at least 2 candidates (cpu_a — currently bound — and cpu_b),
+-- both `ok=true`.
+
+package Move_Oracle_Demo
+public
+
+  processor M4
+  end M4;
+
+  thread Brake_Handler
+    properties
+      Dispatch_Protocol => Periodic;
+      Period => 20 ms;
+      Compute_Execution_Time => 2 ms .. 4 ms;
+      Deadline => 20 ms;
+      Spar_Migration::Mobile => true;
+      Spar_Migration::Allowed_Targets => (reference (cpu_a), reference (cpu_b));
+  end Brake_Handler;
+
+  process App
+  end App;
+
+  process implementation App.Impl
+    subcomponents
+      brake_handler: thread Brake_Handler;
+  end App.Impl;
+
+  system Top
+  end Top;
+
+  system implementation Top.Impl
+    subcomponents
+      cpu_a: processor M4;
+      cpu_b: processor M4;
+      app: process App.Impl;
+    properties
+      Actual_Processor_Binding => (reference (cpu_a)) applies to app.brake_handler;
+  end Top.Impl;
+
+end Move_Oracle_Demo;

--- a/test-data/render_test.aadl
+++ b/test-data/render_test.aadl
@@ -31,14 +31,17 @@ public
       cmd_out: out data port;
   end Controller;
 
+  -- Note: subcomponent renamed from `compute` to `computer` because
+  -- `compute` is an AADL reserved keyword (see AS5506C §15.4 and the
+  -- COMPUTE_KW token in spar-parser/src/syntax_kind.rs).
   process implementation Controller.Impl
     subcomponents
       filter: thread FilterThread.Impl;
-      compute: thread ComputeThread.Impl;
+      computer: thread ComputeThread.Impl;
     connections
       c3: port sensor_in -> filter.raw_in;
-      c4: port filter.filtered_out -> compute.data_in;
-      c5: port compute.result_out -> cmd_out;
+      c4: port filter.filtered_out -> computer.data_in;
+      c5: port computer.result_out -> cmd_out;
   end Controller.Impl;
 
   thread FilterThread


### PR DESCRIPTION
## Summary

Wave-3 onboarding fixes for the top-level `test-data/` fixtures (Tier B audit feedback):

- **Fix `test-data/render_test.aadl`** — the subcomponent named `compute` on what was line 37 collided with the AADL reserved keyword `compute` (lexer maps it to `COMPUTE_KW` for the property language), so `spar parse test-data/render_test.aadl` failed. Renamed the subcomponent + connections to `computer` and added an inline comment explaining the constraint.
- **Add `test-data/move_oracle_demo.aadl`** — a 50-line demo fixture so `spar moves enumerate` can be exercised end-to-end against a shipped fixture (previously the only examples lived as inline strings in `crates/spar-cli/tests/moves_enumerate.rs`). One root system, two M4 processors (`cpu_a`, `cpu_b`), one Brake_Handler thread with `Spar_Migration::Mobile => true` and `Spar_Migration::Allowed_Targets => (reference (cpu_a), reference (cpu_b))`. `Compute_Execution_Time`, `Period`, `Deadline` set so RTA produces a sensible bound. Comment header points at `docs/cli/moves.md`.
- **Add `crates/spar-cli/tests/test_data_parse_roundtrip.rs`** — sweep test that runs `spar parse` on every top-level `test-data/*.aadl` fixture so a future broken fixture fails CI. Subdirectories (`negative/`, `parser/`, etc.) are out of scope; a fixture may opt out via a `-- spar-test: skip-parse` comment in its first 20 lines.

## Verification command

```sh
cargo run -p spar -- moves enumerate \
  --root Move_Oracle_Demo::Top.Impl \
  --component brake_handler \
  test-data/move_oracle_demo.aadl
```

Output:

```
Enumerate Top.Impl/app/brake_handler (2 candidates)
  ok     target                                        score   errs  violations
  OK     Top.Impl/cpu_b                               0.0000      0  none
  OK     Top.Impl/cpu_a                               4.0000      0  none
total=2 valid=2
```

Both candidates `ok=true`, including the currently-bound `cpu_a`.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean — including the new `every_top_level_test_data_aadl_parses_cleanly` sweep
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS
- [x] Manual `spar moves enumerate` returns 2 valid candidates

## Out of scope

No CLI / proofs / spar-mcp / CHANGELOG / Spar_TSN changes — strictly `test-data/` and `crates/spar-cli/tests/`.