### PR TITLE
feat(nc): α(0)=0 causality fix + discharge MinPlus arrival_at_zero sorry (v0.9.2)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,6 +1,6 @@
 # AS5506D AADL v2.2/v2.3 Compliance Gap Analysis
 
-**Updated**: 2026-04-28 (v0.9.1 released; v0.10 in progress)
+**Updated**: 2026-04-28 (v0.9.1 released; v0.9.2 in progress)
 **Source**: 102 HTML files from OSATE2 (`org.osate.help/html/std/`)
 **Toolchain**: spar (2759+ tests passing across 18 crates)
 
@@ -240,6 +240,58 @@ artifacts at github.com/pulseengine/spar/releases/tag/v0.7.1.
 - Criterion benchmarks for scheduling solver and codegen (#143, closes #137).
 - Lean / Bazel / proptest CI gates (#151, closes #135) — Lean proofs now machine-checked in CI for the first time.
 - Track D and Track E research design docs (#152, #153) and Track F engagement strategy (#160) anchoring v0.8.0+ scope.
+
+---
+
+## v0.9.2 (soundness pass — Lean ↔ Rust reconciliation, in progress)
+
+**Commit 1 of 5 — α(0) = 0 causality fix + first MinPlus sorry discharge**
+
+The 12-persona Wave 3 audit (Lean reviewer) flagged a real spec/impl
+mismatch in the arrival curve at `t = 0`:
+
+- The Lean spec in `proofs/Proofs/Network/MinPlus.lean` gave
+  `α(0) = min(σ + ρ·0, p·0) = min(σ, 0) = 0` for the peak-capped
+  branch, and `α(0) = σ + ρ·0 = σ` for the affine-only branch — an
+  internal inconsistency.
+- The Rust impl in `crates/spar-network/src/curves.rs::ArrivalCurve::at`
+  short-circuited `t_ps == 0` to return `σ` for *both* branches —
+  pre-mature optimisation that violated causality (a zero-length
+  window cannot admit any bytes).
+
+v0.9.2 reconciles toward the **causal answer** (`α(0) = 0` for all
+arrival curves):
+
+- Rust: `ArrivalCurve::at` now short-circuits `t_ps == 0` to `0`, not
+  `σ`. Doc comment + module-level doc updated. The peak-capped branch
+  would give 0 by `min(σ, 0)` natively; the affine-only branch needs
+  the explicit short-circuit because `σ + ρ · 0 = σ`.
+- Lean: `ArrivalCurve.at` adds a matching `if t_ps = 0 then 0`
+  short-circuit so the affine-only branch also returns 0. The
+  `arrival_at_mono` proof is updated to case-split on the
+  short-circuit; structurally identical otherwise.
+- The 5th tracked sorry in `proofs/Proofs/Network/MinPlus.lean`
+  (`arrival_at_zero_is_burst` peak-rate branch) is **discharged**.
+  Theorem renamed `arrival_at_zero_is_zero` (statement now
+  `α.at 0 = 0`), proof is `unfold ArrivalCurve.at; simp`. The Rust
+  test `arrival_curve_at_zero_is_burst` is renamed
+  `arrival_curve_at_zero_is_zero` and asserts `α.at(0) == 0` for both
+  branches.
+- No `WcttBound` numbers change: the Network Calculus *bounds*
+  (`backlog_bound`, `delay_bound`, `output_bound`, `residual_service`)
+  use closed-form expressions in σ and ρ directly; none of them call
+  `α.at(0)`. The fix is therefore semantically scoped to the readout
+  convention and does not perturb any wctt fixture or test bound.
+
+Sorry count delta: `proofs/Proofs/Network/MinPlus.lean` is now down to
+**4** tracked sorrys (was 5 in v0.9.1). The remaining four
+(`backlog_bound_classical`, `delay_bound_classical`,
+`output_dominates_input`, `compose_delays_dominates`) all require the
+Le Boudec & Thiran integer-arithmetic horizontal-distance arguments
+and remain scoped to v0.10 / v1.0.0.
+
+`proofs/README.md` § "Known sorrys" updated; the 5th entry moved to a
+new "Discharged in v0.9.2" sub-section.
 
 ---
 

--- a/crates/spar-network/src/curves.rs
+++ b/crates/spar-network/src/curves.rs
@@ -108,8 +108,19 @@ fn time_to_send_ps(bytes: u64, rate_bps: u64) -> u64 {
 /// α(t) = burst_bytes + sustained_rate · t
 /// ```
 ///
-/// when it is `None`. For `t = 0`, α(0) = `burst_bytes` regardless of
-/// the peak (the burst is the y-intercept).
+/// when it is `None`.
+///
+/// **Causality at t = 0**: α(0) = 0 by convention, regardless of the
+/// burst σ. A window of length zero contains zero bytes — the burst is
+/// only realized as soon as t > 0 (instantaneously). For the
+/// peak-capped form this falls out of `min(σ + 0, p · 0) = min(σ, 0) =
+/// 0`; for the affine-only form we special-case it. Aligned with the
+/// Lean spec in `proofs/Proofs/Network/MinPlus.lean` (v0.9.2 fix).
+///
+/// Note: the Network Calculus *bounds* (`backlog_bound`, `delay_bound`,
+/// `output_bound`, `residual_service`) all use the closed-form
+/// expressions in σ and ρ directly — they do **not** call `at(0)` —
+/// so this convention only affects readouts of α at t = 0 and tests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArrivalCurve {
     /// σ — the maximum instantaneous burst in bytes (the y-intercept).
@@ -146,9 +157,20 @@ impl ArrivalCurve {
     /// Returns the number of bytes. Saturates to `u64::MAX` if the
     /// underlying arithmetic would overflow (which only happens for
     /// astronomical rate × time products).
+    ///
+    /// **Causality**: α(0) = 0 — a zero-length window admits no bytes
+    /// even when σ > 0. The peak-capped branch enforces this naturally
+    /// via `min(σ + 0, p · 0) = 0`; the affine-only branch needs the
+    /// explicit `t_ps == 0` short-circuit since `σ + ρ · 0 = σ`. This
+    /// matches the Lean spec in `proofs/Proofs/Network/MinPlus.lean`
+    /// (v0.9.2: aligned away from the prior pre-mature-optimisation
+    /// short-circuit that returned σ at t = 0).
     pub fn at(&self, t_ps: u64) -> u64 {
         if t_ps == 0 {
-            return self.burst_bytes;
+            // Causal: zero-length window admits zero bytes. The peak
+            // branch would give 0 by `min(σ, 0)` anyway; the affine-only
+            // branch needs this explicit case because `σ + ρ·0 = σ`.
+            return 0;
         }
         let sustained = self
             .burst_bytes
@@ -358,12 +380,20 @@ mod tests {
     const ONE_US_PS: u64 = 1_000_000;
 
     #[test]
-    fn arrival_curve_at_zero_is_burst() {
+    fn arrival_curve_at_zero_is_zero() {
+        // Causality: α(0) = 0 for all arrival curves — a zero-length
+        // window admits zero bytes even when σ > 0. v0.9.2 alignment
+        // with the Lean spec; the prior short-circuit that returned σ
+        // was a pre-mature optimisation that violated causality.
         let alpha = ArrivalCurve::affine(1500, HUNDRED_MBPS);
-        assert_eq!(alpha.at(0), 1500);
+        assert_eq!(alpha.at(0), 0);
 
         let alpha = ArrivalCurve::with_peak(1500, HUNDRED_MBPS, GBPS);
-        assert_eq!(alpha.at(0), 1500);
+        assert_eq!(alpha.at(0), 0);
+
+        // The burst is still the y-intercept of the affine line and is
+        // realised as t grows beyond zero — this is captured by other
+        // tests (`affine_arrival_eval`, `affine_arrival_with_peak`).
     }
 
     #[test]

--- a/proofs/Proofs/Network/MinPlus.lean
+++ b/proofs/Proofs/Network/MinPlus.lean
@@ -72,12 +72,23 @@ theorem scale_pos : 0 < scale := by
 /-- α(t) at a given time `t` in picoseconds.  Affine `σ + ρ·t/scale`
     form with optional peak-rate cap `p·t/scale`.  The integer division
     by `scale` mirrors the Rust `bits_to_bytes_in_window` helper.
-    Mirrors `ArrivalCurve::at`. -/
+    Mirrors `ArrivalCurve::at`.
+
+    **Causality at t = 0**: α(0) = 0 for *all* arrival curves — a
+    zero-length window admits zero bytes regardless of σ.  The
+    peak-capped branch would give `min(σ, 0) = 0` automatically; the
+    affine-only branch needs the explicit `t_ps = 0` short-circuit
+    since `σ + ρ·0 = σ`.  v0.9.2 alignment: the Rust impl in
+    `crates/spar-network/src/curves.rs::ArrivalCurve::at` was updated
+    in the same change-set to return 0 at t = 0 (previously it
+    short-circuited to σ, which violated causality). -/
 def ArrivalCurve.at (α : ArrivalCurve) (t_ps : Nat) : Nat :=
-  let sustained := α.burst_bytes + (α.sustained_rate_bps * t_ps) / scale
-  match α.peak_rate_bps with
-  | none => sustained
-  | some p => Nat.min sustained ((p * t_ps) / scale)
+  if t_ps = 0 then 0
+  else
+    let sustained := α.burst_bytes + (α.sustained_rate_bps * t_ps) / scale
+    match α.peak_rate_bps with
+    | none => sustained
+    | some p => Nat.min sustained ((p * t_ps) / scale)
 
 /-- β(t) at a given time `t`.  Rate-latency form: `R · max(0, t − T) / scale`.
     Below the latency the server has not started: `β(t) = 0`.
@@ -92,23 +103,32 @@ def ServiceCurve.at (β : ServiceCurve) (t_ps : Nat) : Nat :=
 theorem arrival_at_mono (α : ArrivalCurve) {t1 t2 : Nat} (h : t1 ≤ t2) :
     α.at t1 ≤ α.at t2 := by
   unfold ArrivalCurve.at
-  -- Both the affine and the peak-cap branch are monotone:
-  -- σ + ρt/scale and pt/scale are each monotone in t, and `min`
-  -- preserves the inequality on both sides.
-  have hsust : α.burst_bytes + α.sustained_rate_bps * t1 / scale
-             ≤ α.burst_bytes + α.sustained_rate_bps * t2 / scale := by
-    apply Nat.add_le_add_left
-    apply Nat.div_le_div_right
-    exact Nat.mul_le_mul_left _ h
-  cases hp : α.peak_rate_bps with
-  | none => simpa [hp] using hsust
-  | some p =>
-    have hpeak : p * t1 / scale ≤ p * t2 / scale := by
+  -- Three cases on the `if t = 0` causality short-circuit:
+  --   • t1 = 0:        LHS = 0, any RHS ≥ 0.
+  --   • t1 > 0, t2 > 0: both fall through to the affine/peak branches,
+  --                     each of which is monotone in t.
+  -- (t1 > 0 ∧ t2 = 0 is impossible since t1 ≤ t2.)
+  by_cases h1 : t1 = 0
+  · -- LHS = 0 by the causality short-circuit; any Nat is ≥ 0.
+    simp [h1]
+  · -- t1 ≠ 0, hence t2 ≠ 0 too (since t1 ≤ t2 and t1 > 0).
+    have h2 : t2 ≠ 0 := by omega
+    rw [if_neg h1, if_neg h2]
+    -- Now both branches are the affine/peak forms with no short-circuit.
+    have hsust : α.burst_bytes + α.sustained_rate_bps * t1 / scale
+               ≤ α.burst_bytes + α.sustained_rate_bps * t2 / scale := by
+      apply Nat.add_le_add_left
       apply Nat.div_le_div_right
       exact Nat.mul_le_mul_left _ h
-    simp only [hp]
-    -- `min` is monotone in both arguments separately (Mathlib's `min_le_min`).
-    exact min_le_min hsust hpeak
+    cases hp : α.peak_rate_bps with
+    | none => simpa [hp] using hsust
+    | some p =>
+      have hpeak : p * t1 / scale ≤ p * t2 / scale := by
+        apply Nat.div_le_div_right
+        exact Nat.mul_le_mul_left _ h
+      simp only [hp]
+      -- `min` is monotone in both arguments separately (Mathlib's `min_le_min`).
+      exact min_le_min hsust hpeak
 
 /-! ## Theorem 2 — Monotonicity of β(t) -/
 
@@ -292,30 +312,27 @@ theorem compose_delays_dominates
   -- per-hop sorries above are discharged.
   sorry -- TODO(v1.0.0)
 
-/-! ## Sanity check — the zero-jitter / zero-burst sub-case
+/-! ## Sanity check — causality at t = 0
 
-    A degenerate sub-case the Rust tests pin (`arrival_curve_at_zero_is_burst`):
-    `α.at 0 = α.burst_bytes`. -/
+    A degenerate sub-case the Rust tests pin (`arrival_curve_at_zero_is_zero`):
+    `α.at 0 = 0` for *all* arrival curves, regardless of σ or peak cap.
+    A zero-length window admits zero bytes — the burst σ is the
+    y-intercept of the affine line and is realised only as soon as
+    `t > 0` (instantaneously), not *at* `t = 0`.  This is the causal
+    reading agreed in v0.9.2 (the prior Rust short-circuit returned σ
+    at t = 0; that was a pre-mature optimisation that violated
+    causality and has been retracted in `crates/spar-network/src/curves.rs`). -/
 
-/-- α(0) = σ regardless of peak rate. -/
-theorem arrival_at_zero_is_burst (α : ArrivalCurve) :
-    α.at 0 = α.burst_bytes := by
+/-- **Causality** — α(0) = 0 for all arrival curves, regardless of
+    burst σ or peak rate.  The peak-capped branch would give
+    `min(σ, 0) = 0` automatically; the affine-only branch needs the
+    explicit `t = 0` short-circuit baked into `ArrivalCurve.at`.
+    Discharged in v0.9.2 (was the 5th tracked `sorry`). -/
+theorem arrival_at_zero_is_zero (α : ArrivalCurve) :
+    α.at 0 = 0 := by
+  -- Direct from the `if t_ps = 0 then 0` short-circuit.
   unfold ArrivalCurve.at
-  -- Both branches reduce: ρ·0/scale = 0, p·0/scale = 0, and
-  -- σ + 0 = σ; min σ 0 ≠ σ in general, but the Rust impl returns
-  -- σ at t=0 by short-circuit.  Match that here.
-  cases hp : α.peak_rate_bps with
-  | none => simp [hp]
-  | some p =>
-    -- `min (σ + 0) 0 = 0`, which contradicts `α.at 0 = σ`.
-    -- The Rust impl special-cases t=0 via `if t_ps == 0` — we
-    -- follow with a separate theorem rather than fold the
-    -- short-circuit into the spec.  This subgoal therefore captures
-    -- the "no peak" case only; the peak case is documented to
-    -- diverge from the Rust impl by `min(σ, 0) = 0`.  We mark with
-    -- `sorry` to flag the spec/impl mismatch as a v1.0.0 reconcile.
-    -- TODO(v1.0.0): align Lean spec with Rust short-circuit.
-    sorry -- TODO(v1.0.0)
+  simp
 
 /-- β below latency is monotone-zero.  Sanity corollary of Theorem 3. -/
 theorem service_at_zero_at_zero (β : ServiceCurve) :

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -67,23 +67,25 @@ was decorative. The post-build grep makes the gate honest.
 ## Known sorrys (tracked in COMPLIANCE.md)
 
 The Network Calculus closed-form bounds in
-`proofs/Proofs/Network/MinPlus.lean` carry five unsorried theorems.
-They are listed below at file:line with one-line context. They are
-tracked as `TODO(v1.0.0)` in `COMPLIANCE.md` v0.9.1, and the post-build
-"fail on sorry" gate in `.github/workflows/proofs.yml` turns CI red
-until they are discharged. Discharging is scoped to a separate v0.10
-PR — the math is non-trivial Le Boudec & Thiran ch. 1 closed-form
-reasoning in min-plus algebra, and one of the five is a real
-spec-vs-Rust mismatch that needs reconciliation before it can be
-proved.
+`proofs/Proofs/Network/MinPlus.lean` carry **four** unsorried theorems
+(was five in v0.9.1; the `arrival_at_zero` mismatch was reconciled in
+v0.9.2 — see below). They are listed below at file:line with one-line
+context. They are tracked as `TODO(v1.0.0)` in `COMPLIANCE.md`, and
+the post-build "fail on sorry" gate in `.github/workflows/proofs.yml`
+turns CI red until they are discharged. Discharging is scoped to a
+separate v0.10 PR — the math is non-trivial Le Boudec & Thiran ch. 1
+closed-form reasoning in min-plus algebra.
 
 | File:line | Theorem | One-line context |
 |-----------|---------|-------------------|
-| `Proofs/Network/MinPlus.lean:169` | `backlog_bound_classical` | Closed-form backlog `B = σ + ρ·T` for affine α (no peak cap) and stable rate-latency β; needs case split `t ≤ T` vs `t > T` plus `Nat.div` arithmetic with `h_stable`. The classical real-line proof shows `sup_t (α(t) − β(t))` is reached at `t = T`. |
-| `Proofs/Network/MinPlus.lean:199` | `delay_bound_classical` | Closed-form delay `D = T + σ/R` (Le Boudec & Thiran horizontal-distance argument). In integer arithmetic this reduces to chasing `div_ceil` bounds across the affine ↔ rate-latency intersection point. |
-| `Proofs/Network/MinPlus.lean:240` | `output_dominates_input` | The closed-form output curve dominates the input curve at every `t`: burst inflates by `ρ·T`, sustained rate preserved, so `α'(t) ≥ α(t)`. Le Boudec & Thiran 1.4.3. |
-| `Proofs/Network/MinPlus.lean:293` | `compose_delays_dominates` | Naive serial-chain composition: `α(t) ≤ β2(β1(t + D_naive))`. Chains `delay_bound_classical` per hop through `output_dominates_input`; trivial *after* the per-hop sorrys above are discharged. |
-| `Proofs/Network/MinPlus.lean:318` | `arrival_at_zero_is_burst` (peak-rate branch) | Spec/impl mismatch: the Lean spec gives `min(σ, 0) = 0` at `t = 0` when a peak cap is set, but the Rust `ArrivalCurve::at` short-circuits `t == 0` and returns `σ`. The "no peak" branch is proved; the peak branch is `sorry` until v1.0.0 reconciles the spec to fold the short-circuit in. |
+| `Proofs/Network/MinPlus.lean:189` | `backlog_bound_classical` | Closed-form backlog `B = σ + ρ·T` for affine α (no peak cap) and stable rate-latency β; needs case split `t ≤ T` vs `t > T` plus `Nat.div` arithmetic with `h_stable`. The classical real-line proof shows `sup_t (α(t) − β(t))` is reached at `t = T`. |
+| `Proofs/Network/MinPlus.lean:219` | `delay_bound_classical` | Closed-form delay `D = T + σ/R` (Le Boudec & Thiran horizontal-distance argument). In integer arithmetic this reduces to chasing `div_ceil` bounds across the affine ↔ rate-latency intersection point. |
+| `Proofs/Network/MinPlus.lean:260` | `output_dominates_input` | The closed-form output curve dominates the input curve at every `t`: burst inflates by `ρ·T`, sustained rate preserved, so `α'(t) ≥ α(t)`. Le Boudec & Thiran 1.4.3. |
+| `Proofs/Network/MinPlus.lean:313` | `compose_delays_dominates` | Naive serial-chain composition: `α(t) ≤ β2(β1(t + D_naive))`. Chains `delay_bound_classical` per hop through `output_dominates_input`; trivial *after* the per-hop sorrys above are discharged. |
+
+### Discharged in v0.9.2
+
+- `arrival_at_zero_is_zero` (was `arrival_at_zero_is_burst` at MinPlus.lean:318): the v0.9.1 spec/impl mismatch (Lean gave `min(σ, 0) = 0` while Rust short-circuited to `σ`) was reconciled by aligning **toward the Lean spec** (causality: a zero-length window admits zero bytes, regardless of σ). The Rust `ArrivalCurve::at` no longer short-circuits to σ at `t = 0`; the Lean spec adds a matching `if t = 0 then 0` short-circuit so the affine-no-peak branch is also 0; the proof discharges via `simp`. Theorem renamed `arrival_at_zero_is_zero` and the Rust unit test renamed `arrival_curve_at_zero_is_zero`.
 
 The Lean tree is **load-bearing** for `RTAJittered` / `RTA` / `EDF` /
 `RMBound` (Liu & Layland 1973, Joseph & Pandya 1986, Dertouzos 1974


### PR DESCRIPTION
## Summary

- Reconciles the v0.9.1 spec/impl mismatch on `α(0)` between Rust `ArrivalCurve::at` and Lean `MinPlus.arrival_at_zero_is_burst` by aligning **toward the Lean spec direction**: α(0) = 0 (causality — a zero-length window admits no bytes), with the Rust short-circuit retracted from `σ` to `0`.
- Discharges the 5th tracked `sorry` in `proofs/Proofs/Network/MinPlus.lean` (was `arrival_at_zero_is_burst`, now `arrival_at_zero_is_zero`); proof is `unfold ArrivalCurve.at; simp` after the spec mirror lands. Sorry count in `MinPlus.lean`: 5 → 4.
- No `WcttBound` numeric changes — the NC bounds (`backlog_bound`, `delay_bound`, `output_bound`, `residual_service`) all use closed forms in σ and ρ directly and never call `α.at(0)`.

## Why this direction

The audit picked the causal interpretation because:
- The Lean spec was internally inconsistent — `none` branch returned σ at t=0 while the `some p` branch returned `min(σ, 0) = 0`.
- The Rust short-circuit was a pre-mature optimisation that violated causality.
- α(t) represents the maximum bytes that can arrive in any *window of length t*; a zero-length window admits zero bytes by definition. The burst σ is the y-intercept of the affine line and is realised only as t grows beyond zero.

## File deltas (4 files)

- `crates/spar-network/src/curves.rs` — `at(0) = 0` short-circuit; struct doc + fn doc updated to call out causality; test renamed `arrival_curve_at_zero_is_zero` and asserts 0 for both affine and peak branches.
- `proofs/Proofs/Network/MinPlus.lean` — `ArrivalCurve.at` adds matching `if t_ps = 0 then 0` short-circuit; `arrival_at_mono` proof case-splits on the new branch; `arrival_at_zero_is_burst` renamed `arrival_at_zero_is_zero`, sorry discharged.
- `proofs/README.md` — § "Known sorrys" table down to 4 rows; new "Discharged in v0.9.2" sub-section.
- `COMPLIANCE.md` — header date moved from "v0.10 in progress" to "v0.9.2 in progress"; new v0.9.2 section narrating the reconciliation.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean (no FAILED; the renamed `arrival_curve_at_zero_is_zero` passes; no other test bound changes needed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `rivet validate` PASS (99 pre-existing warnings)
- [ ] CI `lake build` + the honest fail-on-sorry post-build grep — should report 4 tracked sorrys (was 5), discharged sorry no longer present
- [ ] Reviewer confirms the causality direction is the agreed reconciliation (vs the alternative of folding the short-circuit into the Lean spec at `σ`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)