### PR TITLE
fix(ci): nightly fuzz + bench workflows actually run

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -21,6 +21,10 @@ jobs:
   solver-benchmarks:
     name: Solver criterion nightly
     runs-on: ubuntu-latest
+    # Belt-and-braces ceiling. milp/worst_64 is gated at the source level
+    # (SPAR_BENCH_SLOW_MILP). Keep a hard cap so a future slow-bench
+    # addition can't silently consume hours of runner budget.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Run fuzz target for 1h
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo +nightly fuzz run "$TARGET" -- -max_total_time=3600 -timeout=10
+        # `--target x86_64-unknown-linux-gnu` avoids the cargo-fuzz default
+        # musl target whose statically-linked libc is incompatible with
+        # AddressSanitizer. Same fix as the PR-time fuzz smoke (PR #142).
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu "$TARGET" -- -max_total_time=3600 -timeout=10
 
       - name: Upload corpus
         if: always()

--- a/crates/spar-solver/benches/solver_benchmarks.rs
+++ b/crates/spar-solver/benches/solver_benchmarks.rs
@@ -366,13 +366,21 @@ fn bench_solver_worst_case(c: &mut Criterion) {
     let workload = synth_worst_case(64, 8);
     group.throughput(Throughput::Elements(workload.threads.len() as u64));
 
-    group.bench_function(BenchmarkId::new("milp", "worst_64"), |b| {
-        b.iter(|| {
-            // Worst-case inputs may be infeasible — treat the Result as data.
-            let result = solve_milp(black_box(&workload));
-            let _ = black_box(result);
+    // `milp/worst_64` does not converge in any reasonable time on
+    // ubuntu-latest CI runners — a single MILP solve on the near-saturated
+    // 64-task workload can run for tens of minutes, and criterion needs
+    // multiple iterations per sample. Gate behind `SPAR_BENCH_SLOW_MILP=1`
+    // so the nightly workflow finishes fast; ad-hoc deep-bench runs can
+    // opt in.
+    if std::env::var_os("SPAR_BENCH_SLOW_MILP").is_some() {
+        group.bench_function(BenchmarkId::new("milp", "worst_64"), |b| {
+            b.iter(|| {
+                // Worst-case inputs may be infeasible — treat the Result as data.
+                let result = solve_milp(black_box(&workload));
+                let _ = black_box(result);
+            });
         });
-    });
+    }
 
     group.bench_function(BenchmarkId::new("ffd", "worst_64"), |b| {
         b.iter(|| {


### PR DESCRIPTION
## Summary

Both nightly workflows have failed since they were introduced on 2026-04-24 — silently providing zero coverage.

**fuzz-nightly** (#0a07f91): cargo-fuzz defaults to `x86_64-unknown-linux-musl`. Static libc is incompatible with AddressSanitizer; the build aborts in <20s. Add `--target x86_64-unknown-linux-gnu` (same fix as the PR-time fuzz smoke job, PR #142).

**bench-nightly** (#5268531): `solver_worst_case/milp/worst_64` doesn't converge in reasonable time on `ubuntu-latest`. Gate behind `SPAR_BENCH_SLOW_MILP=1` env var so the nightly job finishes; ad-hoc deep-bench runs can opt in. Add `timeout-minutes: 60` ceiling.

## Test plan

- [x] `cargo build -p spar-solver --benches` clean (verifies the env-gate compiles)
- [ ] CI green
- [ ] Next nightly cron actually completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)