### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -8,6 +8,13 @@ name: Bench Nightly
 # Scheduled at 03:30 UTC, offset from other nightly jobs (e.g. fuzzing)
 # so bench machines aren't contending for runner minutes.
 
+# Each scheduled run is independent baseline data — must complete and
+# never cancel its predecessor. Use a per-run group so two scheduled
+# runs never queue or cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   schedule:
     - cron: "30 3 * * *"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
 
+# Cancel superseded PR runs; never cancel runs on main / tags / scheduled
+# events. See docs/ci-concurrency.md (or the org-wide CI concurrency brief)
+# for rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,5 +1,12 @@
 name: Fuzz (nightly)
 
+# Each scheduled fuzz run is independent corpus + crash data — must
+# complete and never cancel its predecessor. Per-run group so two
+# scheduled runs never queue or cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   schedule:
     # Daily 03:00 UTC

--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -16,6 +16,12 @@ name: Lean Proofs
 # (`proofs/.lake`) keyed on `lake-manifest.json`, so warm runs only
 # rebuild the in-tree proof modules.
 
+# Lean proof runs are multi-hour on cold cache. Cancel superseded PR
+# runs aggressively; never cancel main / scheduled / tag runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# Releases publish to registries + write SLSA attestations. Cancelling
+# mid-publish leaves external state inconsistent. Group for
+# serialization (one release per tag), never cancel.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     tags:


### PR DESCRIPTION
## Summary

Per the org-wide CI concurrency hardening brief, adds a top-level `concurrency:` block to every workflow under `.github/workflows/`.

Cancels superseded PR runs aggressively; never cancels runs on `main`, tags, or scheduled events.

## Variant per file

| Workflow | Variant | Group | cancel-in-progress |
|---|---|---|---|
| `ci.yml` | default | `${{ github.workflow }}-${{ github.head_ref \|\| github.ref }}` | conditional on PR event |
| `proofs.yml` | default | same | conditional on PR event |
| `bench-nightly.yml` | scheduled | `${{ github.workflow }}-${{ github.run_id }}` | `false` |
| `fuzz-nightly.yml` | scheduled | same | `false` |
| `release.yml` | release | `release-${{ github.ref }}` | `false` |

Reasons:
- `proofs.yml` Lean runs can be multi-hour on cold cache — cancelling superseded PR commits is the highest-leverage saving here. Main runs still protected.
- Nightly fuzz/bench data must accumulate; per-run group prevents cross-cancellation between scheduled runs.
- Releases publish SLSA attestations + push to registries — cancelling mid-publish leaves external state inconsistent.

## Test plan

- [x] `python3 -c yaml.safe_load` on all 5 files
- [x] Diff stays strictly inside `.github/workflows/` (no job restructure, no runner changes, no cache changes — all out of scope per brief)
- [ ] CI passes on this PR
- [ ] Push a no-op follow-up to verify earlier run shows as Cancelled within ~30s
- [ ] Post-merge main run completes (not cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)