### PR TITLE
fix(ci): remove duplicate concurrency block in proofs.yml

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -28,11 +28,6 @@ on:
   pull_request:
     branches: [main]
 
-# Avoid duplicate runs on PR + push for the same SHA.
-concurrency:
-  group: proofs-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   lean:
     name: Lean proof typecheck (lake build)


### PR DESCRIPTION
## Summary
- proofs.yml had two top-level `concurrency:` keys; the second (preexisting) block overrode the brief-conformant one #200 added.
- Result: `cancel-in-progress: true` was applied unconditionally, cancelling main and scheduled runs alongside PR runs — exactly the behaviour the brief warned against for the multi-hour Lean job.
- Fix is a 5-line removal of the duplicate; the surviving block is the correct one (PR-only cancel via `${{ github.event_name == 'pull_request' }}`).

## Test plan
- [ ] CI green
- [ ] `grep -c '^concurrency:' .github/workflows/proofs.yml` returns 1 (verified locally)
- [ ] Surviving `concurrency:` block matches the brief (PR-only cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)