### PR TITLE
feat(trace-topology): IPv4 + IPv6 in Spar_Identity (v0.10.x B-6)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1895,4 +1895,18 @@ artifacts:
     status: implemented
     tags: [trace-topology, ingest, gptp, sync, v0100]
 
+  - id: REQ-TRACE-TOPOLOGY-007
+    type: requirement
+    title: IPv4 + IPv6 address properties in Spar_Identity
+    description: >
+      System shall extend the Spar_Identity property set with
+      IPv4_Address and IPv6_Address (aadlstring; applies to device,
+      processor, system, bus, abstract). Typed accessors live in
+      spar-trace-topology::identity following the same typed-first /
+      string-fallback pattern as the existing six identity
+      properties. Enables the v0.11.0 reconciler to check L3
+      identity against runtime-observed ARP / NDP / DHCP state.
+    status: implemented
+    tags: [trace-topology, properties, identity, ip, v0100]
+
   # Research findings tracked separately in research/findings.yaml

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2468,3 +2468,21 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-TRACE-TOPOLOGY-006
+
+  - id: TEST-TRACE-TOPOLOGY-IP-IDENTITY
+    type: feature
+    title: IPv4/IPv6 accessors honour typed and raw paths
+    description: >
+      Tests in crates/spar-trace-topology/src/identity.rs verify that
+      get_ipv4_address / get_ipv6_address return the typed value
+      first and fall back to the raw quoted form, mirroring the
+      existing 6 Spar_Identity accessors.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-trace-topology --lib -- identity::tests
+    status: passing
+    tags: [trace-topology, properties, identity, ip, v0100]
+    links:
+      - type: satisfies
+        target: REQ-TRACE-TOPOLOGY-007

--- a/crates/spar-hir-def/src/standard_properties.rs
+++ b/crates/spar-hir-def/src/standard_properties.rs
@@ -573,6 +573,14 @@ const SPAR_IDENTITY: &[(&str, &str)] = &[
     // LLDP port-id of a bus access feature as reported by the runtime
     // LLDP snapshot. Applies to bus access (feature-level).
     ("LLDP_Port_Id", "aadlstring"),
+    // L3 IPv4 address of an addressable AADL component as reported by
+    // runtime ARP / DHCP snapshots. Applies to device, processor,
+    // system, bus, abstract.
+    ("IPv4_Address", "aadlstring"),
+    // L3 IPv6 address of an addressable AADL component as reported by
+    // runtime NDP / DHCPv6 snapshots. Applies to device, processor,
+    // system, bus, abstract.
+    ("IPv6_Address", "aadlstring"),
 ];
 
 /// Helper: collect properties from a table into the result vector.
@@ -1262,13 +1270,15 @@ mod tests {
         assert!(is_standard_property_set("Spar_Identity"));
 
         let props = standard_properties_in_set("Spar_Identity");
-        assert_eq!(props.len(), 6);
+        assert_eq!(props.len(), 8);
         assert!(props.contains(&"MAC_Address"));
         assert!(props.contains(&"VLAN_ID"));
         assert!(props.contains(&"Stream_Handle"));
         assert!(props.contains(&"Multicast_Group"));
         assert!(props.contains(&"LLDP_Chassis_Id"));
         assert!(props.contains(&"LLDP_Port_Id"));
+        assert!(props.contains(&"IPv4_Address"));
+        assert!(props.contains(&"IPv6_Address"));
 
         // Each property resolves to its expected type.
         assert_eq!(
@@ -1293,6 +1303,14 @@ mod tests {
         );
         assert_eq!(
             standard_property_type("Spar_Identity", "LLDP_Port_Id"),
+            Some("aadlstring")
+        );
+        assert_eq!(
+            standard_property_type("Spar_Identity", "IPv4_Address"),
+            Some("aadlstring")
+        );
+        assert_eq!(
+            standard_property_type("Spar_Identity", "IPv6_Address"),
             Some("aadlstring")
         );
 
@@ -1325,6 +1343,8 @@ mod tests {
             "Multicast_Group",
             "LLDP_Chassis_Id",
             "LLDP_Port_Id",
+            "IPv4_Address",
+            "IPv6_Address",
         ] {
             let result = scope.resolve_property(&Name::new("Spar_Identity"), &Name::new(prop_name));
             assert!(
@@ -1368,7 +1388,7 @@ mod tests {
     #[test]
     fn test_all_standard_properties_total_count() {
         let all = all_standard_properties();
-        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 + 1 + 9 + 6 = 137
+        // 12 + 13 + 14 + 14 + 8 + 25 + 4 + 13 + 5 + 4 + 5 + 4 + 1 + 9 + 8 = 139
         // (Timing + Communication + Memory + Deployment + Thread + Programming
         //  + Modeling + AADL_Project + Spar_Timing + Spar_Trace + Spar_Network
         //  + Spar_Migration + Spar_Power + Spar_TSN + Spar_Identity)
@@ -1383,7 +1403,9 @@ mod tests {
         // Spar_Identity: +6 for MAC_Address, VLAN_ID, Stream_Handle,
         //   Multicast_Group, LLDP_Chassis_Id, LLDP_Port_Id (v0.10.0
         //   trace-topology foundation, Track G).
-        assert_eq!(all.len(), 137);
+        //   +2 for IPv4_Address, IPv6_Address (v0.10.x B-6, L3
+        //   identity for the reconciler).
+        assert_eq!(all.len(), 139);
     }
 
     #[test]

--- a/crates/spar-trace-topology/src/identity.rs
+++ b/crates/spar-trace-topology/src/identity.rs
@@ -109,3 +109,29 @@ pub fn get_lldp_port_id(props: &PropertyMap) -> Option<String> {
     }
     get_raw(props, "LLDP_Port_Id").map(unquote)
 }
+
+/// Read [`Spar_Identity::IPv4_Address`] — the canonical IPv4 of a
+/// device, processor, system, or bus.
+///
+/// Returns the raw declared string (e.g. `"192.0.2.42"`); no
+/// canonicalisation here — the v0.11.0 reconciliation engine
+/// normalises before comparison.
+pub fn get_ipv4_address(props: &PropertyMap) -> Option<String> {
+    if let Some(PropertyExpr::StringLit(s)) = get_typed(props, "IPv4_Address") {
+        return Some(s.clone());
+    }
+    get_raw(props, "IPv4_Address").map(unquote)
+}
+
+/// Read [`Spar_Identity::IPv6_Address`] — the canonical IPv6 of a
+/// device, processor, system, or bus.
+///
+/// Returns the raw declared string (e.g. `"2001:db8::1"`); no
+/// canonicalisation here — the v0.11.0 reconciliation engine
+/// normalises before comparison.
+pub fn get_ipv6_address(props: &PropertyMap) -> Option<String> {
+    if let Some(PropertyExpr::StringLit(s)) = get_typed(props, "IPv6_Address") {
+        return Some(s.clone());
+    }
+    get_raw(props, "IPv6_Address").map(unquote)
+}

--- a/crates/spar-trace-topology/src/lib.rs
+++ b/crates/spar-trace-topology/src/lib.rs
@@ -21,7 +21,7 @@
 //! - The [`identity`] module exposes typed accessors for the new
 //!   `Spar_Identity::*` property surface (`MAC_Address`, `VLAN_ID`,
 //!   `Stream_Handle`, `Multicast_Group`, `LLDP_Chassis_Id`,
-//!   `LLDP_Port_Id`).
+//!   `LLDP_Port_Id`, `IPv4_Address`, `IPv6_Address`).
 //! - The [`ingest`] module declares trait skeletons for the four
 //!   parsers — frame source (PCAPNG), topology source (LLDP), switch
 //!   config source (Qcc YANG), and PTP-time source (gPTP). Real

--- a/crates/spar-trace-topology/tests/identity_accessors.rs
+++ b/crates/spar-trace-topology/tests/identity_accessors.rs
@@ -189,3 +189,46 @@ fn lldp_port_id_typed_and_string_fallback() {
     let empty = PropertyMap::new();
     assert_eq!(identity::get_lldp_port_id(&empty), None);
 }
+
+#[test]
+fn ipv4_address_typed_path() {
+    // Typed PropertyExpr::StringLit path returns the unquoted value
+    // directly.
+    let typed = make_props(
+        "Spar_Identity",
+        "IPv4_Address",
+        "\"192.0.2.42\"",
+        Some(PropertyExpr::StringLit("192.0.2.42".to_string())),
+    );
+    assert_eq!(
+        identity::get_ipv4_address(&typed),
+        Some("192.0.2.42".to_string())
+    );
+
+    // Absent => None.
+    let empty = PropertyMap::new();
+    assert_eq!(identity::get_ipv4_address(&empty), None);
+}
+
+#[test]
+fn ipv6_address_raw_fallback() {
+    // String-fallback path strips surrounding quotes from the raw
+    // source-text form.
+    let raw = make_props("Spar_Identity", "IPv6_Address", "\"2001:db8::1\"", None);
+    assert_eq!(
+        identity::get_ipv6_address(&raw),
+        Some("2001:db8::1".to_string())
+    );
+
+    // Typed path also works end-to-end.
+    let typed = make_props(
+        "Spar_Identity",
+        "IPv6_Address",
+        "\"fe80::1\"",
+        Some(PropertyExpr::StringLit("fe80::1".to_string())),
+    );
+    assert_eq!(
+        identity::get_ipv6_address(&typed),
+        Some("fe80::1".to_string())
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `IPv4_Address` and `IPv6_Address` (aadlstring) to the `Spar_Identity` property set so the v0.11.0 reconciler can check L3 identity against runtime ARP / NDP / DHCP state alongside the existing L2 / L2.5 / LLDP identities.
- New typed accessors `get_ipv4_address` / `get_ipv6_address` in `spar-trace-topology::identity` follow the typed-first / string-fallback pattern of the existing six Spar_Identity accessors.
- Bumps SPAR_IDENTITY 6 -> 8 entries (total standard properties 137 -> 139); updates the in-set count test, the global-scope resolution loop, and the per-property type-lookup assertions.

## Test plan
- [x] `cargo test -p spar-hir-def --lib -- standard_properties` (28 passed, count + per-property + global-scope all green)
- [x] `cargo test -p spar-trace-topology` (8 identity_accessors tests: 6 existing + 2 new — `ipv4_address_typed_path`, `ipv6_address_raw_fallback`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all` clean

Artifact tracking: REQ-TRACE-TOPOLOGY-007 (requirements.yaml) and TEST-TRACE-TOPOLOGY-IP-IDENTITY (verification.yaml).

Generated with [Claude Code](https://claude.com/claude-code)