### PR TITLE
fix(assertion-eval): has() matches features (v0.9.x bug closeout)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1940,4 +1940,18 @@ artifacts:
     status: implemented
     tags: [binding, hir-def, overlay, v093]
 
+  - id: REQ-HAS-FEATURES
+    type: requirement
+    title: has() predicate matches component features by name
+    description: >
+      The has() predicate in the assertion DSL must return true when
+      the component under evaluation owns a feature (port, bus access,
+      data access, parameter, feature group, etc.) whose name matches
+      the argument string, in addition to the existing property-name
+      match. Bare names (no '::' separator) are checked against both
+      property names and feature names; qualified names (set::name)
+      continue to resolve only against the property namespace.
+    status: implemented
+    tags: [assertions, v093]
+
   # Research findings tracked separately in research/findings.yaml

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2525,3 +2525,23 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-BINDING-002
+
+  - id: TEST-HAS-FEATURES
+    type: feature
+    title: has() predicate matches features by name
+    description: >
+      Unit tests in crates/spar-cli/src/assertion/mod.rs verify that
+      has('feature_name') returns true when a component owns a feature
+      with that name (has_matches_feature_by_name), false when no such
+      feature exists (has_feature_name_absent_returns_false), and that
+      all() correctly fails when only some components carry the named
+      feature (has_feature_all_fails_when_partial).
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar --bin spar -- assertion::tests::has
+    status: passing
+    tags: [assertions, v093]
+    links:
+      - type: satisfies
+        target: REQ-HAS-FEATURES

--- a/crates/spar-cli/src/assertion/eval.rs
+++ b/crates/spar-cli/src/assertion/eval.rs
@@ -375,12 +375,23 @@ fn eval_component_predicate(
             let func_name = first_token_text(node);
             if func_name == "has" {
                 let prop_name = find_string_literal(node).unwrap_or_default();
+                // Check properties first.
                 let props = ctx.instance.properties_for(idx);
-                if let Some((set, name)) = prop_name.split_once("::") {
+                let prop_found = if let Some((set, name)) = prop_name.split_once("::") {
                     props.get(set, name).is_some()
                 } else {
                     props.get("", &prop_name).is_some()
+                };
+                if prop_found {
+                    return true;
                 }
+                // Also check whether the component has a feature with this name.
+                // Property names always contain '::' (set::name); bare names are
+                // therefore unambiguously feature name lookups.
+                let comp = ctx.instance.component(idx);
+                comp.features.iter().any(|&feat_idx| {
+                    ctx.instance.features[feat_idx].name.as_str() == prop_name.as_str()
+                })
             } else {
                 false
             }

--- a/crates/spar-cli/src/assertion/mod.rs
+++ b/crates/spar-cli/src/assertion/mod.rs
@@ -1184,4 +1184,76 @@ check = "components.count()"
         assert!(file.assertion[0].description.is_empty());
         assert_eq!(file.assertion[0].severity, SeverityFilter::Error);
     }
+
+    // ── has() feature matching tests (REQ-HAS-FEATURES) ────────────────
+
+    /// has('feature_name') must return true when a component owns a feature
+    /// with that exact name, not just when a property with that name exists.
+    #[test]
+    fn has_matches_feature_by_name() {
+        let inst = make_test_instance();
+        let diags = vec![];
+        let ctx = EvalContext {
+            instance: &inst,
+            diagnostics: &diags,
+        };
+
+        // thread1 has a feature named "sensor_out" — has() must find it.
+        match eval_check(
+            "components.where(category == 'thread').any(has('sensor_out'))",
+            &ctx,
+        )
+        .unwrap()
+        {
+            Value::Bool(b) => assert!(b, "has('sensor_out') must be true for thread1"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    /// has('nonexistent_feature') must return false when no feature or
+    /// property with that name exists on any component.
+    #[test]
+    fn has_feature_name_absent_returns_false() {
+        let inst = make_test_instance();
+        let diags = vec![];
+        let ctx = EvalContext {
+            instance: &inst,
+            diagnostics: &diags,
+        };
+
+        match eval_check(
+            "components.any(has('no_such_port'))",
+            &ctx,
+        )
+        .unwrap()
+        {
+            Value::Bool(b) => assert!(!b, "has('no_such_port') must be false — port does not exist"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
+
+    /// all() with has('feature_name') must fail when only some components
+    /// carry the named feature.
+    #[test]
+    fn has_feature_all_fails_when_partial() {
+        let inst = make_test_instance();
+        let diags = vec![];
+        let ctx = EvalContext {
+            instance: &inst,
+            diagnostics: &diags,
+        };
+
+        // Only thread1 has "sensor_out"; the processor has no features at all.
+        // all() across threads (thread1 + thread2) must fail: thread2 has
+        // "cmd_in" / "status_out", not "sensor_out".
+        match eval_check(
+            "components.where(category == 'thread').all(has('sensor_out'))",
+            &ctx,
+        )
+        .unwrap()
+        {
+            Value::Bool(b) => assert!(!b, "not all threads have sensor_out"),
+            other => panic!("expected Bool, got {:?}", other),
+        }
+    }
 }

--- a/crates/spar-cli/src/assertion/mod.rs
+++ b/crates/spar-cli/src/assertion/mod.rs
@@ -1221,13 +1221,11 @@ check = "components.count()"
             diagnostics: &diags,
         };
 
-        match eval_check(
-            "components.any(has('no_such_port'))",
-            &ctx,
-        )
-        .unwrap()
-        {
-            Value::Bool(b) => assert!(!b, "has('no_such_port') must be false — port does not exist"),
+        match eval_check("components.any(has('no_such_port'))", &ctx).unwrap() {
+            Value::Bool(b) => assert!(
+                !b,
+                "has('no_such_port') must be false — port does not exist"
+            ),
             other => panic!("expected Bool, got {:?}", other),
         }
     }


### PR DESCRIPTION
## Summary

- `has('name')` in the assertion DSL only matched component **properties**; it now also matches **features** (ports, bus access, parameters, etc.) by name.
- Bare names (no `::`) are checked against both the property namespace and the component's feature list; qualified names (`set::name`) still resolve against properties only.
- Three new unit tests added: `has_matches_feature_by_name`, `has_feature_name_absent_returns_false`, `has_feature_all_fails_when_partial`.
- Artifacts: `REQ-HAS-FEATURES` (requirement) + `TEST-HAS-FEATURES` (verification) added; `rivet validate` passes.

## Minimal working example

Before fix — assertion always returned `false` even though `sensor_out` exists:
```
components.where(category == 'thread').any(has('sensor_out'))
# → Bool(false)  ← wrong
```

After fix:
```
components.where(category == 'thread').any(has('sensor_out'))
# → Bool(true)   ← correct
```

## Test plan

- [x] `cargo test -p spar --bin spar -- assertion::tests` — 46 tests pass (3 new)
- [x] `cargo test -p spar` — full suite green
- [x] `cargo clippy -p spar` — no warnings
- [x] `rivet validate` — PASS (99 pre-existing warnings, no errors)

Closes v0.9.x bug: `has()` operator did not match features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>