### PR TITLE
chore(verify-gate): revert TEST-PROOF-* steps to lake build (ELAN_HOME now on runners)

### DIFF
--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2651,13 +2651,10 @@ artifacts:
       latency_monotone: if every component WCET in c1 is pointwise ≤ the
       corresponding WCET in c2, then Latency s c1 ≤ Latency s c2. Verified
       by `lake build` under Lean 4 v4.29.0-rc6 + Mathlib with no sorry.
-      Gate runs a sorry-free smoke check; full `lake build` is exercised by
-      the dedicated "Lean proof typecheck (lake build)" CI workflow.
     fields:
       method: automated-test
       steps:
-        - run: "test -f proofs/Proofs/Scheduling/Latency.lean"
-        - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Latency.lean"
+        - run: cd proofs && lake build
     status: passing
     tags: [proof, latency, lean, v0100]
     links:
@@ -2673,14 +2670,11 @@ artifacts:
       then proves partition_isolation: in a conformant schedule, a thread
       bound to a different partition than a window's owner cannot execute
       within that window. Verified by `lake build` under Lean 4 v4.29.0-rc6
-      + Mathlib with no sorry.  Gate runs a sorry-free smoke check; full
-      `lake build` is exercised by the dedicated "Lean proof typecheck (lake
-      build)" CI workflow.
+      + Mathlib with no sorry.
     fields:
       method: automated-test
       steps:
-        - run: "test -f proofs/Proofs/Scheduling/Arinc653Isolation.lean"
-        - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Arinc653Isolation.lean"
+        - run: cd proofs && lake build
     status: passing
     tags: [proof, arinc653, lean, v0100]
     links:


### PR DESCRIPTION
## Summary

Reverts the sorry-grep workaround introduced in #223 now that smithy runners have Lean toolchain access.

## Background

PR #223 introduced two Lean proofs (`Latency.lean`, `Arinc653Isolation.lean`) with verification artifacts that intended to run \`cd proofs && lake build\`. But the rivet verification gate runs on \`[self-hosted, linux, x64, rust-cpu]\` runners which did not have Lean on PATH, so the gate failed.

The workaround was to substitute:
\`\`\`yaml
steps:
  - run: \"test -f proofs/Proofs/Scheduling/Latency.lean\"
  - run: \"! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Latency.lean\"
\`\`\`

— a file-exists + sorry-free smoke check. Functional but not full type-checking.

## Smithy fix landed

Smithy commit \`dfb0eed\`: \`ELAN_HOME=/home/ralf/.elan\` set in runner env, \`ProtectHome=read-only\` keeps ralf's shared elan state safe, all 12 runners verified with \`lake --version\` → Lake 5.0.0-src + Lean 4.29.0-rc6.

## What this PR does

Restores the two TEST-PROOF-* artifacts to use \`cd proofs && lake build\` as their verification step:

\`\`\`yaml
steps:
  - run: cd proofs && lake build
\`\`\`

The rivet verification gate now runs full Lean typechecking inline, not just a sorry-free smoke. The dedicated \"Lean proof typecheck (lake build)\" CI workflow remains as defense-in-depth.

## Test plan

- [x] \`rivet validate\` clean
- [ ] Verification gate runs \`cd proofs && lake build\` against TEST-PROOF-LATENCY + TEST-PROOF-ARINC653 successfully on this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>