### PR TITLE
chore(ci): raise verify-gate timeout 30 → 60 min for lake build

### DIFF
--- a/.github/workflows/verification-gate.yml
+++ b/.github/workflows/verification-gate.yml
@@ -17,7 +17,12 @@ jobs:
   rivet-verification:
     name: Verification Gate (rivet-driven)
     runs-on: [self-hosted, linux, x64, rust-cpu]
-    timeout-minutes: 30
+    # 60m budget: TEST-PROOF-* steps run `cd proofs && lake build`, which
+    # against Mathlib on a cold elan cache takes 25–35 min. Once smithy
+    # adds Lake build-artifact caching across runs, this can drop back
+    # toward 20m. The dedicated "Lean proof typecheck" workflow has its
+    # own budget for the same step.
+    timeout-minutes: 60
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: -D warnings


### PR DESCRIPTION
## Summary

PR #227 reverted `TEST-PROOF-LATENCY` and `TEST-PROOF-ARINC653` verification artifacts from sorry-grep to `cd proofs && lake build`. The first PR after #227 (#228) hit the verify-gate's 30-minute hard timeout — lake build against Mathlib on a cold elan cache takes 25–35 min, and the runner was terminated at 26m with an orphan `lake` process.

This bumps `timeout-minutes: 30 → 60` so `lake build` has headroom.

## Follow-up for smithy

Lake build-artifact caching across runner runs would let this drop back toward 20m. A cache key like `lake-{runner-id}-{hash(proofs/lakefile.toml)}-{hash(proofs/lean-toolchain)}` on `proofs/.lake/build` would let warm runs finish in seconds rather than 25 min.

## Test plan

- [ ] Verify-gate completes within 60min on next PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>