### PR TITLE
chore(release): bump version 0.9.3 → 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1478,14 +1478,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.10.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump for the v0.10.0 release. Cargo.toml + Cargo.lock + vscode-spar/package.json → 0.10.0.

## What v0.10.0 ships

### Mermaid emission (M1 + M2 + M3)
- #220 — `spar-mermaid` foundation crate with `emit_flowchart`
- #222 — `spar emit --format mermaid` CLI subcommand
- #228 — classDiagram + requirementDiagram emitters + CLI flags

### Soundness deepening
- #223 — Lean 4 sorry-free proofs of end-to-end latency monotonicity + ARINC 653 partition isolation
- #224 — Kani BMC harnesses on generated-code AADL contract preservation (Logika-equivalent strategy)

### Safety analysis
- #225 — EMV2 error-propagation traversal across AADL connection graph (closes the #1 gap vs OSATE/HAMR)

### Verification infrastructure
- #221 — Rivet-driven verification gate + sticky PR comment
- #227, #229, #230 — TEST-PROOF-* tuning (sorry-grep + gate budget)

### Chore
- #226 — Pruned stale dev artifacts

## Test plan

- [x] `cargo build --workspace` clean at 0.10.0
- [ ] CI green
- [ ] After merge, push v0.10.0 tag → release workflow runs

After this merges, I'll push the `v0.10.0` tag, which triggers the release workflow (SLSA attestation, signed binaries, npm publish for vscode-spar).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>