### PR TITLE
fix(codegen): --format wit emits only WIT, not the Rust workspace

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2117,6 +2117,22 @@ artifacts:
     status: implemented
     tags: [ci, rivet, verification, v0100]
 
+  - id: REQ-CODEGEN-WIT-STRICT
+    type: requirement
+    title: codegen --format wit emits only WIT interface files
+    description: >
+      `spar codegen --format wit` shall emit exclusively `.wit` interface
+      files.  The deployment config TOML and the Rust/Bazel workspace
+      scaffolding (Cargo.toml, BUILD.bazel) are gated to `--format rust`
+      and `--format both`.  This gives downstream consumers (e.g. the
+      rules_wasm_component Bazel ruleset) a predictably-shaped tree
+      artifact: `wit` yields interfaces, `rust` yields a buildable
+      workspace, `both` yields everything.  Previously config + workspace
+      files were emitted unconditionally, leaking 5 non-WIT files into
+      `--format wit` output.
+    status: implemented
+    tags: [codegen, wit, cli, v0100]
+
   # Research findings tracked separately in research/findings.yaml
 
   # ── Mermaid M3 (classDiagram + requirementDiagram) ─────────────────────

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2820,3 +2820,25 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-MERMAID-REQ-001
+
+  # ── codegen --format wit strict filter ──────────────────────────────────
+
+  - id: TEST-CODEGEN-WIT-STRICT
+    type: feature
+    title: codegen --format wit strict-filter tests
+    description: >
+      Tests in crates/spar-codegen/tests/golden_test.rs verify that
+      --format wit (OutputFormat::Wit) emits only `.wit` files with no
+      Cargo.toml / BUILD.bazel / config TOML leakage
+      (wit_format_emits_only_wit_files), and that --format rust still
+      emits the Cargo.toml + BUILD.bazel workspace scaffolding
+      (rust_format_still_emits_workspace).
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-codegen --test golden_test
+    status: passing
+    tags: [codegen, wit, cli, v0100]
+    links:
+      - type: satisfies
+        target: REQ-CODEGEN-WIT-STRICT

--- a/crates/spar-codegen/src/lib.rs
+++ b/crates/spar-codegen/src/lib.rs
@@ -351,9 +351,13 @@ pub fn generate(inst: &SystemInstance, config: &CodegenConfig) -> CodegenOutput 
         }
     }
 
-    // Generate config files
-    for &(idx, _comp) in &processes {
-        files.push(config_gen::generate_config(inst, idx));
+    // Generate config files. These are deployment TOML for the Rust
+    // components, not interface definitions — `--format wit` must not
+    // emit them (strict-filter semantics: `wit` yields only `.wit`).
+    if config.format == OutputFormat::Rust || config.format == OutputFormat::Both {
+        for &(idx, _comp) in &processes {
+            files.push(config_gen::generate_config(inst, idx));
+        }
     }
 
     // Generate test harnesses
@@ -393,16 +397,21 @@ pub fn generate(inst: &SystemInstance, config: &CodegenConfig) -> CodegenOutput 
         }
     }
 
-    // Generate workspace files
-    let process_names: Vec<String> = processes
-        .iter()
-        .map(|(_, c)| sanitize_ident(c.name.as_str()))
-        .collect();
+    // Generate workspace files (Cargo.toml + BUILD.bazel). A Rust/Bazel
+    // workspace is meaningless without Rust crates to build, so it is
+    // emitted only for `--format rust` and `--format both`. Under
+    // `--format wit` the output is strictly the `.wit` interface files.
+    if config.format == OutputFormat::Rust || config.format == OutputFormat::Both {
+        let process_names: Vec<String> = processes
+            .iter()
+            .map(|(_, c)| sanitize_ident(c.name.as_str()))
+            .collect();
 
-    files.extend(workspace_gen::generate_workspace(
-        &config.root_name,
-        &process_names,
-    ));
+        files.extend(workspace_gen::generate_workspace(
+            &config.root_name,
+            &process_names,
+        ));
+    }
 
     CodegenOutput { files }
 }

--- a/crates/spar-codegen/tests/golden_test.rs
+++ b/crates/spar-codegen/tests/golden_test.rs
@@ -107,6 +107,71 @@ fn golden_model_generates_wit() {
     );
 }
 
+// ── Strict --format wit filter ─────────────────────────────────────
+
+/// `--format wit` must yield ONLY `.wit` files — no Cargo.toml, no
+/// BUILD.bazel, no deployment config TOML. Regression guard for the
+/// `rules_wasm_component` integration, which consumes the codegen
+/// output as a predictably-shaped tree artifact.
+#[test]
+fn wit_format_emits_only_wit_files() {
+    let inst = golden_instance();
+    let config = CodegenConfig {
+        root_name: "building_system".into(),
+        output_dir: "output".into(),
+        format: OutputFormat::Wit,
+        verify: None,
+        rivet: false,
+        dry_run: true,
+    };
+    let output = generate(&inst, &config);
+
+    assert!(
+        !output.files.is_empty(),
+        "--format wit should still produce the .wit files"
+    );
+    let non_wit: Vec<&str> = output
+        .files
+        .iter()
+        .map(|f| f.path.as_str())
+        .filter(|p| !p.ends_with(".wit"))
+        .collect();
+    assert!(
+        non_wit.is_empty(),
+        "--format wit must emit only .wit files; leaked: {non_wit:?}"
+    );
+}
+
+/// `--format rust` still emits the Rust workspace scaffolding
+/// (Cargo.toml + BUILD.bazel) — gating must not strip it from the
+/// rust/both paths.
+#[test]
+fn rust_format_still_emits_workspace() {
+    let inst = golden_instance();
+    let config = CodegenConfig {
+        root_name: "building_system".into(),
+        output_dir: "output".into(),
+        format: OutputFormat::Rust,
+        verify: None,
+        rivet: false,
+        dry_run: true,
+    };
+    let output = generate(&inst, &config);
+
+    assert!(
+        output.files.iter().any(|f| f.path == "Cargo.toml"),
+        "--format rust should emit root Cargo.toml"
+    );
+    assert!(
+        output.files.iter().any(|f| f.path.ends_with("BUILD.bazel")),
+        "--format rust should emit BUILD.bazel"
+    );
+    assert!(
+        output.files.iter().all(|f| !f.path.ends_with(".wit")),
+        "--format rust should not emit .wit files"
+    );
+}
+
 // ── Rust generation ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Surfaced during the `rules_wasm_component` Bazel integration: `spar codegen --format wit` emits **7 files, not just WIT** — it also writes the deployment config TOML + `Cargo.toml` + `BUILD.bazel`.

## Root cause

`spar-codegen/src/lib.rs::generate()` gated the WIT and Rust file blocks on `OutputFormat` correctly, but **two blocks ran unconditionally**:
- the config-file loop (deployment TOML per process)
- the `workspace_gen::generate_workspace` call (`Cargo.toml` + `BUILD.bazel`)

So `--format wit` produced WIT files **+ config + workspace**.

## Fix

Gate both on `Rust || Both`:
- Config TOML is deployment glue for the Rust components — not an interface definition.
- A Cargo.toml/BUILD.bazel workspace is meaningless without Rust crates to build.

**Strict-filter contract now holds:**
| `--format` | output |
|---|---|
| `wit` | only `.wit` interface files |
| `rust` | Rust crates + Cargo.toml + BUILD.bazel + config |
| `both` | everything |

This gives `rules_wasm_component` a predictably-shaped tree artifact across spar versions.

## Test plan

- [x] `wit_format_emits_only_wit_files` — asserts zero non-WIT leakage under `OutputFormat::Wit`
- [x] `rust_format_still_emits_workspace` — guards that gating didn't strip Cargo.toml/BUILD.bazel from rust/both
- [x] All 21 golden_test cases pass; `cargo clippy -p spar-codegen --all-targets -D warnings` clean
- [x] `rivet validate` PASS

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>