### PR TITLE
feat(trace-topology): Rust trace-fixture generator (netns + TSN, v0.11.0)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2162,3 +2162,26 @@ artifacts:
       non-requirement types shall be silently skipped.
     status: implemented
     tags: [mermaid, emission, v0100]
+
+  # ── Trace-topology fixtures (v0.11.0) ────────────────────────────────────
+
+  - id: REQ-TRACE-FIXTURES-001
+    type: requirement
+    title: Rust trace-fixture generator (netns + TSN)
+    description: >
+      spar shall provide a Rust binary (`gen-fixtures`, in the
+      spar-trace-topology crate) that builds a synthetic three-node TSN
+      topology — grandmaster / switch / endpoint connected by multi-queue
+      veth pairs — inside Linux network namespaces, and produces the four
+      runtime artefacts the v0.11.0 reconciliation engine consumes: a PCAPNG
+      L2 capture, an LLDP neighbour JSON, a Qcc YANG switch-config JSON, and
+      a gPTP sync-error JSON.  Every namespace is owned by a `NetnsGuard`
+      RAII type whose Drop runs `ip netns del`, so a panic or early return
+      still tears the topology down.  The tool probes netns capability at
+      startup and exits non-zero with a clear message if run in an
+      unsuitable environment.  The two transform steps — `tc -j qdisc show`
+      JSON to Qcc YANG, and `pmc` text to gPTP JSON with deterministic
+      synthetic timestamps — are pure functions, unit-tested on any host.
+      The CI harness that runs this tool (a KVM guest) lands in a follow-up.
+    status: implemented
+    tags: [trace-topology, fixtures, v0110]

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2842,3 +2842,34 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-CODEGEN-WIT-STRICT
+
+  # ── Trace-topology fixtures (v0.11.0) ────────────────────────────────────
+
+  - id: TEST-TRACE-FIXTURES
+    type: feature
+    title: trace-fixture transformer unit tests
+    description: >
+      Unit tests in crates/spar-trace-topology/src/fixtures/transform.rs
+      verify the two pure transformer functions with no network-namespace
+      or Linux dependency, so they run on any host: tc taprio+CBS JSON
+      round-trips through QccYangSwitchConfigSource
+      (tc_taprio_cbs_round_trips_qcc); a port with neither taprio nor cbs
+      yields a bare entry with no tsn block (tc_no_taprio_no_cbs_yields_bare_port);
+      a gatemask given as a JSON number is accepted (tc_gatemask_as_number_parsed);
+      a negative pmc masterOffset is abs()'d to a non-negative sync_error_ns
+      (pmc_parses_negative_master_offset_as_abs); a positive offset is
+      preserved (pmc_positive_master_offset_unchanged); synthetic timestamp_ns
+      is deterministic across runs (pmc_timestamp_determinism_two_rounds);
+      multi-round pmc output round-trips through GptpJsonPtpTimeSource
+      (pmc_round_trips_gptp_ingest); LLDP JSON validation accepts the
+      canonical shape and rejects a missing lldp.interface key
+      (lldp_validate_passthrough, lldp_validate_rejects_missing_interface).
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-trace-topology fixtures::transform
+    status: passing
+    tags: [trace-topology, fixtures, v0110]
+    links:
+      - type: satisfies
+        target: REQ-TRACE-FIXTURES-001

--- a/crates/spar-trace-topology/Cargo.toml
+++ b/crates/spar-trace-topology/Cargo.toml
@@ -14,5 +14,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pcap-parser = "0.16"
 
+[[bin]]
+name = "gen-fixtures"
+path = "src/bin/gen-fixtures.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/spar-trace-topology/src/bin/gen-fixtures.rs
+++ b/crates/spar-trace-topology/src/bin/gen-fixtures.rs
@@ -1,0 +1,380 @@
+//! `gen-fixtures` — generate real network-capture test fixtures for the
+//! v0.11.0 trace-topology reconciliation engine.
+//!
+//! # Overview
+//!
+//! The tool builds a 3-node topology inside Linux network namespaces:
+//!
+//! ```text
+//!   grandmaster  <--veth-gm-sw-->  switch  <--veth-sw-ep-->  endpoint
+//! ```
+//!
+//! Each veth pair is created with 4 TX/RX queues to satisfy `sch_taprio`'s
+//! multi-queue requirement (plain single-queue veth yields
+//! "Multi-queue device is required").  All three nodes get fixed MAC
+//! addresses so LLDP chassis-id + PCAPNG frames are stable across runs.
+//!
+//! # Fixture files produced
+//!
+//! | File             | Source                                         |
+//! |------------------|------------------------------------------------|
+//! | `capture.pcapng` | `tcpdump` in the GM namespace                  |
+//! | `lldp.json`      | `lldpd -H 0` + `lldpctl -f json`               |
+//! | `qcc-yang.json`  | `tc -j qdisc show` transformed to Qcc YANG     |
+//! | `gptp.json`      | `ptp4l` + `pmc` poll transformed to gPTP JSON  |
+//!
+//! # Environment requirements
+//!
+//! This tool runs only where the job has network-namespace capability —
+//! `ip netns`, `sch_taprio`, and `CLOCK_TAI` available without sudo. In CI
+//! that is inside a KVM guest, where the job is genuine root and the guest
+//! is the sandbox (no host capability grant). It probes that capability at
+//! startup and exits 1 with a clear message if it lands somewhere unsuitable.
+//!
+//! # RAII cleanup
+//!
+//! Every namespace is owned by a `NetnsGuard` whose `Drop` impl calls
+//! `ip netns del`.  A panic or `?`-propagated error still cleans up — the
+//! reliability win over an equivalent shell script, where a crash leaves
+//! stale `/run/netns` handles behind.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use std::thread;
+use std::time::Duration;
+
+use spar_trace_topology::fixtures::{
+    FixtureError, OutputPaths,
+    netns::{NetnsGuard, netns_capture, netns_exec, probe_netns_capability, run_cmd, run_id},
+    transform::{pmc_to_gptp_json, tc_qdisc_json_to_qcc, validate_lldp_json},
+};
+
+// ── Fixed MAC addresses ───────────────────────────────────────────────────
+
+const MAC_GM: &str = "aa:bb:cc:dd:00:01";
+const MAC_SW_LEFT: &str = "aa:bb:cc:dd:01:01";
+const MAC_SW_RIGHT: &str = "aa:bb:cc:dd:01:02";
+const MAC_EP: &str = "aa:bb:cc:dd:02:01";
+
+// ── Entry point ───────────────────────────────────────────────────────────
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("gen-fixtures: error: {e}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), FixtureError> {
+    // 1. Fail-fast capability probe.
+    eprintln!("gen-fixtures: probing netns capability ...");
+    probe_netns_capability()?;
+    eprintln!("gen-fixtures: netns probe OK");
+
+    // 2. Resolve output directory (first CLI arg or crate fixtures/).
+    let out_dir = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures"));
+    fs::create_dir_all(&out_dir)?;
+    let paths = OutputPaths::new(out_dir.clone());
+    eprintln!("gen-fixtures: output -> {}", out_dir.display());
+
+    // 3. Create namespaces (RAII: Drop deletes them even on panic/error).
+    let rid = run_id();
+    let ns_gm = NetnsGuard::create(format!("ts-gm-{rid}"))?;
+    let ns_sw = NetnsGuard::create(format!("ts-sw-{rid}"))?;
+    let ns_ep = NetnsGuard::create(format!("ts-ep-{rid}"))?;
+    eprintln!(
+        "gen-fixtures: namespaces: {} {} {}",
+        ns_gm.name, ns_sw.name, ns_ep.name
+    );
+
+    // 4. Veth pairs with 4 queues (required by sch_taprio).
+    let veth_gm = "veth-gm";
+    let veth_sw_l = "veth-sw-l";
+    let veth_sw_r = "veth-sw-r";
+    let veth_ep = "veth-ep";
+
+    run_cmd(
+        "ip",
+        &[
+            "link",
+            "add",
+            veth_gm,
+            "numtxqueues",
+            "4",
+            "numrxqueues",
+            "4",
+            "type",
+            "veth",
+            "peer",
+            "name",
+            veth_sw_l,
+            "numtxqueues",
+            "4",
+            "numrxqueues",
+            "4",
+        ],
+    )?;
+    run_cmd(
+        "ip",
+        &[
+            "link",
+            "add",
+            veth_sw_r,
+            "numtxqueues",
+            "4",
+            "numrxqueues",
+            "4",
+            "type",
+            "veth",
+            "peer",
+            "name",
+            veth_ep,
+            "numtxqueues",
+            "4",
+            "numrxqueues",
+            "4",
+        ],
+    )?;
+
+    // Move veths into namespaces.
+    for (dev, ns) in [
+        (veth_gm, &ns_gm.name),
+        (veth_sw_l, &ns_sw.name),
+        (veth_sw_r, &ns_sw.name),
+        (veth_ep, &ns_ep.name),
+    ] {
+        run_cmd("ip", &["link", "set", dev, "netns", ns])?;
+    }
+
+    // Assign MACs and bring links up.
+    for (ns, dev, mac) in [
+        (&ns_gm.name, veth_gm, MAC_GM),
+        (&ns_sw.name, veth_sw_l, MAC_SW_LEFT),
+        (&ns_sw.name, veth_sw_r, MAC_SW_RIGHT),
+        (&ns_ep.name, veth_ep, MAC_EP),
+    ] {
+        netns_exec(ns, "ip", &["link", "set", dev, "address", mac])?;
+        netns_exec(ns, "ip", &["link", "set", dev, "up"])?;
+    }
+    for ns in [&ns_gm.name, &ns_sw.name, &ns_ep.name] {
+        netns_exec(ns, "ip", &["link", "set", "lo", "up"])?;
+    }
+    eprintln!("gen-fixtures: veth pairs configured");
+
+    // 5. taprio (software mode, flags 0x0) + CBS on switch.
+    // 4 traffic classes; 2-entry schedule: all-open 400 µs then class-0-only 100 µs.
+    netns_exec(
+        &ns_sw.name,
+        "tc",
+        &[
+            "qdisc",
+            "add",
+            "dev",
+            veth_sw_l,
+            "parent",
+            "root",
+            "handle",
+            "100:",
+            "taprio",
+            "num_tc",
+            "4",
+            "map",
+            "0",
+            "1",
+            "2",
+            "3",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "0",
+            "queues",
+            "1@0",
+            "1@1",
+            "1@2",
+            "1@3",
+            "base-time",
+            "0",
+            "sched-entry",
+            "S",
+            "ff",
+            "400000",
+            "sched-entry",
+            "S",
+            "01",
+            "100000",
+            "clockid",
+            "CLOCK_TAI",
+            "flags",
+            "0x0",
+        ],
+    )?;
+    netns_exec(
+        &ns_sw.name,
+        "tc",
+        &[
+            "qdisc",
+            "add",
+            "dev",
+            veth_sw_l,
+            "parent",
+            "100:2",
+            "handle",
+            "200:",
+            "cbs",
+            "idleslope",
+            "750000",
+            "sendslope",
+            "-250000",
+            "hicredit",
+            "34",
+            "locredit",
+            "-15",
+            "offload",
+            "0",
+        ],
+    )?;
+    eprintln!("gen-fixtures: taprio + CBS configured on switch");
+
+    // 6. Read `tc -j qdisc show` and transform to Qcc YANG JSON.
+    let tc_json = netns_capture(
+        &ns_sw.name,
+        "tc",
+        &["-j", "qdisc", "show", "dev", veth_sw_l],
+    )?;
+    let qcc_value = tc_qdisc_json_to_qcc(veth_sw_l, &tc_json)?;
+    fs::write(&paths.qcc_json, serde_json::to_string_pretty(&qcc_value)?)?;
+    eprintln!("gen-fixtures: wrote {}", paths.qcc_json.display());
+
+    // 7. Start packet capture (background tcpdump, -c 50 frames, PCAPNG).
+    let pcapng_str = paths.pcapng.to_string_lossy().into_owned();
+    let mut capture_child = netns_spawn_bg(
+        &ns_gm.name,
+        "tcpdump",
+        &[
+            "-i",
+            veth_gm,
+            "-w",
+            &pcapng_str,
+            "--immediate-mode",
+            "-c",
+            "50",
+        ],
+    )?;
+    eprintln!("gen-fixtures: tcpdump capturing ...");
+
+    // 8. Start lldpd in GM and SW namespaces (-H 0 = immediate TX).
+    for (ns, dev, sysname) in [
+        (&ns_gm.name, veth_gm, "spar-grandmaster"),
+        (&ns_sw.name, veth_sw_l, "spar-switch"),
+    ] {
+        netns_exec(ns, "lldpd", &["-H", "0", "-I", dev, "-P", sysname])
+            .unwrap_or_else(|e| eprintln!("gen-fixtures: warning: lldpd ({ns}): {e}"));
+    }
+    thread::sleep(Duration::from_secs(3));
+
+    // 9. Collect LLDP JSON.
+    let lldp_raw = netns_capture(&ns_gm.name, "lldpctl", &["-f", "json"]).unwrap_or_else(|e| {
+        eprintln!("gen-fixtures: warning: lldpctl failed ({e}); using empty neighbor list");
+        r#"{"lldp":{"interface":[]}}"#.to_string()
+    });
+    let lldp_value = serde_json::from_str::<serde_json::Value>(&lldp_raw)
+        .unwrap_or_else(|_| serde_json::json!({"lldp":{"interface":[]}}));
+    let lldp_value = validate_lldp_json(&serde_json::to_string(&lldp_value)?)
+        .unwrap_or_else(|_| serde_json::json!({"lldp":{"interface":[]}}));
+    fs::write(&paths.lldp_json, serde_json::to_string_pretty(&lldp_value)?)?;
+    eprintln!("gen-fixtures: wrote {}", paths.lldp_json.display());
+
+    // 10. Generate L2 traffic (ARP) so PCAPNG has real frames.
+    netns_exec(
+        &ns_gm.name,
+        "ip",
+        &["addr", "add", "169.254.1.1/24", "dev", veth_gm],
+    )?;
+    netns_exec(
+        &ns_sw.name,
+        "ip",
+        &["addr", "add", "169.254.1.2/24", "dev", veth_sw_l],
+    )?;
+    let _ = netns_exec(
+        &ns_gm.name,
+        "arping",
+        &["-c", "5", "-I", veth_gm, "169.254.1.2"],
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    // 11. Start ptp4l (software timestamping, GM role) and poll pmc.
+    let mut ptp4l_child = netns_spawn_bg(
+        &ns_gm.name,
+        "ptp4l",
+        &["-i", veth_gm, "-S", "--masterOnly", "1"],
+    )?;
+    thread::sleep(Duration::from_secs(4));
+
+    let mut pmc_rounds: Vec<String> = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let round = netns_capture(&ns_gm.name, "pmc", &["-u", "-b", "0", "GET TIME_STATUS_NP"])
+            .unwrap_or_else(|e| {
+                eprintln!("gen-fixtures: warning: pmc failed ({e}); using stub");
+                "    masterOffset              0\n".to_string()
+            });
+        pmc_rounds.push(round);
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    let pmc_refs: Vec<&str> = pmc_rounds.iter().map(String::as_str).collect();
+    let gptp_value = pmc_to_gptp_json(veth_gm, Some(MAC_GM), 0, &pmc_refs)?;
+    fs::write(&paths.gptp_json, serde_json::to_string_pretty(&gptp_value)?)?;
+    eprintln!("gen-fixtures: wrote {}", paths.gptp_json.display());
+
+    // 12. Stop background processes and flush PCAPNG.
+    let _ = capture_child.kill();
+    let _ = capture_child.wait();
+    let _ = ptp4l_child.kill();
+    let _ = ptp4l_child.wait();
+    thread::sleep(Duration::from_millis(500));
+    eprintln!("gen-fixtures: wrote {}", paths.pcapng.display());
+
+    // 13. Drop guards → ip netns del for each namespace.
+    drop(ns_ep);
+    drop(ns_sw);
+    drop(ns_gm);
+
+    eprintln!("gen-fixtures: namespaces deleted; done.");
+    Ok(())
+}
+
+/// Spawn a background process in a network namespace.
+///
+/// Returns the [`std::process::Child`] so the caller can kill/wait it.
+fn netns_spawn_bg(
+    ns: &str,
+    program: &str,
+    args: &[&str],
+) -> Result<std::process::Child, FixtureError> {
+    use std::process::Stdio;
+    let ns_subcmd = "netns";
+    let exec_subcmd = "exec";
+    let mut full_args: Vec<&str> = vec![ns_subcmd, exec_subcmd, ns, program];
+    full_args.extend_from_slice(args);
+    std::process::Command::new("ip")
+        .args(&full_args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| FixtureError::Command {
+            program: program.to_string(),
+            detail: format!("could not spawn in ns {ns}: {e}"),
+        })
+}

--- a/crates/spar-trace-topology/src/fixtures/mod.rs
+++ b/crates/spar-trace-topology/src/fixtures/mod.rs
@@ -1,0 +1,104 @@
+//! Fixture-generation helpers for the `gen-fixtures` binary.
+//!
+//! The sub-modules are split so the pure transformer logic (`transform`)
+//! is unit-testable without any network namespace involvement, and the
+//! RAII netns wrappers (`netns`) are kept isolated behind a thin
+//! orchestration layer.
+//!
+//! # Module layout
+//!
+//! ```text
+//! fixtures/
+//!   mod.rs        — re-exports + shared error type
+//!   netns.rs      — NetnsGuard (RAII ip-netns-add/del) + Command helpers
+//!   transform.rs  — pure tc→Qcc-YANG + pmc-text→gPTP-JSON transformers
+//! ```
+
+pub mod netns;
+pub mod transform;
+
+use std::{io, path::PathBuf};
+
+/// Top-level error type for the fixture generator.
+#[derive(Debug)]
+pub enum FixtureError {
+    /// I/O error (file write, directory creation, …).
+    Io(io::Error),
+    /// A subprocess exited with non-zero status or could not be spawned.
+    Command { program: String, detail: String },
+    /// JSON serialise/deserialise error.
+    Json(serde_json::Error),
+    /// A required capability (netns, taprio, …) is not available on
+    /// this host.
+    CapabilityMissing(String),
+    /// Input data could not be parsed / transformed.
+    Transform(String),
+}
+
+impl std::fmt::Display for FixtureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Command { program, detail } => {
+                write!(f, "command `{program}` failed: {detail}")
+            }
+            Self::Json(e) => write!(f, "JSON error: {e}"),
+            Self::CapabilityMissing(msg) => write!(f, "capability missing: {msg}"),
+            Self::Transform(msg) => write!(f, "transform error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for FixtureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Json(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for FixtureError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for FixtureError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+/// Resolved output paths for a single gen-fixtures run.
+#[derive(Debug, Clone)]
+pub struct OutputPaths {
+    /// Directory that receives all fixture files.
+    pub dir: PathBuf,
+    /// `<dir>/capture.pcapng`
+    pub pcapng: PathBuf,
+    /// `<dir>/lldp.json`
+    pub lldp_json: PathBuf,
+    /// `<dir>/qcc-yang.json`
+    pub qcc_json: PathBuf,
+    /// `<dir>/gptp.json`
+    pub gptp_json: PathBuf,
+}
+
+impl OutputPaths {
+    /// Build from a base directory.
+    pub fn new(dir: PathBuf) -> Self {
+        let pcapng = dir.join("capture.pcapng");
+        let lldp_json = dir.join("lldp.json");
+        let qcc_json = dir.join("qcc-yang.json");
+        let gptp_json = dir.join("gptp.json");
+        Self {
+            dir,
+            pcapng,
+            lldp_json,
+            qcc_json,
+            gptp_json,
+        }
+    }
+}

--- a/crates/spar-trace-topology/src/fixtures/netns.rs
+++ b/crates/spar-trace-topology/src/fixtures/netns.rs
@@ -1,0 +1,185 @@
+//! RAII network-namespace management and subprocess helpers.
+//!
+//! # NetnsGuard
+//!
+//! Constructing a [`NetnsGuard`] calls `ip netns add <name>` and stores the
+//! name.  Its `Drop` impl calls `ip netns del <name>`, so the namespace is
+//! torn down even on a panic or `?`-propagated early return.
+//!
+//! The CI workflow also runs a belt-and-suspenders `ip netns del` step with
+//! `if: always()` in case the Rust process is SIGKILL'd before `Drop` runs.
+//!
+//! # Namespace naming
+//!
+//! Names are derived from `$GITHUB_RUN_ID` (set by GitHub Actions) or from
+//! the process PID + a microsecond timestamp when the env-var is absent (for
+//! local / non-CI runs).  A short prefix `ts-gm-`, `ts-sw-`, `ts-ep-` is
+//! prepended so the cleanup step can glob `ts-*`.
+
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::FixtureError;
+
+// ── Name generation ───────────────────────────────────────────────────────
+
+/// Generate a collision-resistant run-id string.
+///
+/// Prefers `$GITHUB_RUN_ID` (present in every GitHub Actions job).
+/// Falls back to `<pid>-<microseconds-since-epoch>` for local runs.
+pub fn run_id() -> String {
+    if let Ok(id) = std::env::var("GITHUB_RUN_ID")
+        && !id.is_empty()
+    {
+        return id;
+    }
+    let pid = std::process::id();
+    let us = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_micros();
+    format!("{pid}-{us}")
+}
+
+// ── RAII guard ────────────────────────────────────────────────────────────
+
+/// RAII owner of a Linux network namespace.
+///
+/// The namespace is created in [`NetnsGuard::create`] and deleted (best-
+/// effort) in [`Drop`].  The guard intentionally does NOT implement `Clone`
+/// to prevent double-deletion.
+#[must_use]
+pub struct NetnsGuard {
+    /// The namespace name as passed to `ip netns add`.
+    pub name: String,
+    deleted: bool,
+}
+
+impl NetnsGuard {
+    /// Create a new network namespace named `name`.
+    ///
+    /// Runs: `ip netns add <name>`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FixtureError::Command`] if `ip` is not found or exits
+    /// non-zero.
+    pub fn create(name: impl Into<String>) -> Result<Self, FixtureError> {
+        let name = name.into();
+        run_cmd("ip", &["netns", "add", &name])?;
+        Ok(Self {
+            name,
+            deleted: false,
+        })
+    }
+
+    /// Delete the namespace immediately (rather than waiting for `Drop`).
+    ///
+    /// After calling this the guard is in a "already-deleted" state and
+    /// `Drop` will be a no-op.
+    pub fn delete(mut self) -> Result<(), FixtureError> {
+        self.do_delete()
+    }
+
+    fn do_delete(&mut self) -> Result<(), FixtureError> {
+        if self.deleted {
+            return Ok(());
+        }
+        self.deleted = true;
+        run_cmd("ip", &["netns", "del", &self.name])
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        if !self.deleted {
+            // Best-effort: ignore errors in Drop (cannot propagate).
+            let _ = self.do_delete();
+        }
+    }
+}
+
+// ── Probe ─────────────────────────────────────────────────────────────────
+
+/// Fail-fast capability probe.
+///
+/// Creates a temporary namespace `probe-<run_id>` and immediately deletes
+/// it.  Returns [`FixtureError::CapabilityMissing`] if either operation
+/// fails so the tool exits early with a clear diagnostic rather than
+/// failing mid-run.
+///
+/// The caller should invoke this before any topology setup.
+pub fn probe_netns_capability() -> Result<(), FixtureError> {
+    let probe = format!("probe-{}", run_id());
+    let guard = NetnsGuard::create(&probe).map_err(|e| {
+        FixtureError::CapabilityMissing(format!(
+            "cannot create network namespace \
+             (is this runner12 with the `netns` label?): {e}"
+        ))
+    })?;
+    guard
+        .delete()
+        .map_err(|e| FixtureError::CapabilityMissing(format!("cannot delete probe namespace: {e}")))
+}
+
+// ── Command helpers ───────────────────────────────────────────────────────
+
+/// Run a command, returning `Ok(())` on exit-status 0 or a descriptive
+/// [`FixtureError::Command`] on failure.
+pub fn run_cmd(program: &str, args: &[&str]) -> Result<(), FixtureError> {
+    let out = spawn(program, args)?;
+    check_output(program, out)
+}
+
+/// Run a command and capture its stdout as a UTF-8 `String`.
+pub fn capture_stdout(program: &str, args: &[&str]) -> Result<String, FixtureError> {
+    let out = spawn(program, args)?;
+    let stdout_bytes = out.stdout.clone();
+    check_output(program, out)?;
+    String::from_utf8(stdout_bytes).map_err(|e| FixtureError::Command {
+        program: program.to_string(),
+        detail: format!("stdout is not valid UTF-8: {e}"),
+    })
+}
+
+/// Run `ip netns exec <ns> <program> [args...]`.
+pub fn netns_exec(ns: &str, program: &str, args: &[&str]) -> Result<(), FixtureError> {
+    let mut full_args = vec!["netns", "exec", ns, program];
+    full_args.extend_from_slice(args);
+    run_cmd("ip", &full_args)
+}
+
+/// Run `ip netns exec <ns> <program> [args...]` and capture stdout.
+pub fn netns_capture(ns: &str, program: &str, args: &[&str]) -> Result<String, FixtureError> {
+    let mut full_args = vec!["netns", "exec", ns, program];
+    full_args.extend_from_slice(args);
+    capture_stdout("ip", &full_args)
+}
+
+fn spawn(program: &str, args: &[&str]) -> Result<Output, FixtureError> {
+    Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| FixtureError::Command {
+            program: program.to_string(),
+            detail: format!("could not spawn: {e}"),
+        })
+}
+
+fn check_output(program: &str, out: Output) -> Result<(), FixtureError> {
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let code = out
+        .status
+        .code()
+        .map_or_else(|| "(signal)".to_string(), |c| c.to_string());
+    Err(FixtureError::Command {
+        program: program.to_string(),
+        detail: format!("exit {code}: stderr={stderr:?} stdout={stdout:?}"),
+    })
+}

--- a/crates/spar-trace-topology/src/fixtures/transform.rs
+++ b/crates/spar-trace-topology/src/fixtures/transform.rs
@@ -1,0 +1,565 @@
+//! Pure transformer functions: `tc -j qdisc show` JSON → Qcc YANG JSON,
+//! and `pmc` text → gPTP JSON.
+//!
+//! These functions have no I/O and no network-namespace involvement, so they
+//! can be unit-tested on any platform (including macOS dev boxes).
+//!
+//! # Determinism for gPTP timestamps
+//!
+//! Real gPTP captures produce jittery `timestamp_ns` values that change on
+//! every run, making fixture diffs noisy.  The [`pmc_to_gptp_json`] function
+//! replaces every `timestamp_ns` with a value derived from a fixed epoch
+//! (`TIMESTAMP_EPOCH_NS`) plus a per-sample step (`TIMESTAMP_STEP_NS`).
+//! The meaningful field `sync_error_ns` (the absolute master offset) is kept
+//! as captured.
+//!
+//! # Qci stream-filter synthesis
+//!
+//! Linux's `sch_taprio` has no direct Qci (IEEE 802.1Qci) stream-filter
+//! equivalent.  The [`STATIC_STREAM_FILTERS`] constant provides a small
+//! synthesised list; the Qcc YANG fixture documents clearly in comments that
+//! these entries are synthesised, not observed from the kernel.
+
+use serde_json::{Value, json};
+
+use super::FixtureError;
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+/// Fixed epoch for synthetic gPTP `timestamp_ns` values (2024-01-01 00:00:00 UTC).
+pub const TIMESTAMP_EPOCH_NS: u64 = 1_704_067_200_000_000_000;
+
+/// Per-sample step for synthetic timestamps (100 ms).
+pub const TIMESTAMP_STEP_NS: u64 = 100_000_000;
+
+/// Static Qci stream filters injected into the Qcc YANG fixture.
+///
+/// There is no Linux kernel equivalent for Qci stream filters; these entries
+/// are synthesised from the 3-node topology's stream-handle / priority pairs
+/// and are clearly marked as synthesised in the generated fixture.
+pub const STATIC_STREAM_FILTERS: &[(u32, u8)] = &[
+    (1, 6), // critical control traffic, PCP 6
+    (2, 5), // audio-video bridging, PCP 5
+    (3, 0), // best-effort, PCP 0
+];
+
+// ── tc → Qcc YANG ─────────────────────────────────────────────────────────
+
+/// Transform `tc -j qdisc show dev <dev>` JSON into the Qcc YANG shape
+/// expected by [`crate::ingest::QccYangSwitchConfigSource`].
+///
+/// Input: the JSON array produced by `tc -j qdisc show`.
+///
+/// Output shape:
+/// ```json
+/// { "interfaces": [
+///     { "name": "<port>",
+///       "tsn": {
+///         "gate-control-list": [ {"gate-states-value": u8, "time-interval-value": u64} ],
+///         "bandwidth-reservation-permille": u32,
+///         "max-frame-size": 1518,
+///         "stream-filters": [ {"stream-handle": u32, "priority-spec": u8} ]
+///       }
+///     }
+/// ]}
+/// ```
+///
+/// Only `taprio` qdiscs are processed for the gate-control list; `cbs` qdiscs
+/// supply the bandwidth-reservation.  A port that has neither taprio nor cbs
+/// yields a bare `{"name": "..."}` entry (no `tsn` block).
+///
+/// The `stream-filters` field is always populated from [`STATIC_STREAM_FILTERS`]
+/// for taprio ports and is absent on non-taprio ports.
+pub fn tc_qdisc_json_to_qcc(port_name: &str, tc_json: &str) -> Result<Value, FixtureError> {
+    let arr: Value = serde_json::from_str(tc_json)
+        .map_err(|e| FixtureError::Transform(format!("tc JSON parse error: {e}")))?;
+    let qdiscs = arr
+        .as_array()
+        .ok_or_else(|| FixtureError::Transform("tc output is not a JSON array".to_string()))?;
+
+    let mut gcl: Option<Vec<Value>> = None;
+    let mut bandwidth_permille: Option<u32> = None;
+    let max_frame_size: u16 = 1518;
+
+    for qdisc in qdiscs {
+        let kind = qdisc
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+
+        if kind == "taprio" {
+            gcl = Some(extract_taprio_gcl(qdisc)?);
+        } else if kind == "cbs" {
+            bandwidth_permille = Some(extract_cbs_permille(qdisc)?);
+        }
+    }
+
+    let tsn_block = build_tsn_block(gcl, bandwidth_permille, max_frame_size);
+    let iface = if let Some(tsn) = tsn_block {
+        json!({ "name": port_name, "tsn": tsn })
+    } else {
+        json!({ "name": port_name })
+    };
+
+    Ok(json!({ "interfaces": [iface] }))
+}
+
+fn extract_taprio_gcl(qdisc: &Value) -> Result<Vec<Value>, FixtureError> {
+    // `tc -j qdisc show` taprio output embeds sched-entry-list under options.
+    // Real `tc -j` output shape (iproute2 6.1):
+    //   { "kind": "taprio", "options": { "sched-entry-list": [
+    //       { "command": "S", "gatemask": "0x01", "interval": 500000 }
+    //   ]}}
+    let entries = qdisc
+        .get("options")
+        .and_then(|o| o.get("sched-entry-list"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            FixtureError::Transform(
+                "taprio qdisc missing options.sched-entry-list array".to_string(),
+            )
+        })?;
+
+    let mut gcl = Vec::with_capacity(entries.len());
+    for (i, entry) in entries.iter().enumerate() {
+        // gatemask is a hex string like "0xff" or a number depending on kernel version.
+        let gate_states_value: u8 = match entry.get("gatemask") {
+            Some(Value::String(s)) => {
+                let s = s.trim_start_matches("0x").trim_start_matches("0X");
+                u8::from_str_radix(s, 16).map_err(|e| {
+                    FixtureError::Transform(format!(
+                        "sched-entry-list[{i}] gatemask {s:?} is not a hex u8: {e}"
+                    ))
+                })?
+            }
+            Some(Value::Number(n)) => {
+                let v = n.as_u64().ok_or_else(|| {
+                    FixtureError::Transform(format!(
+                        "sched-entry-list[{i}] gatemask is not a non-negative integer"
+                    ))
+                })?;
+                if v > u64::from(u8::MAX) {
+                    return Err(FixtureError::Transform(format!(
+                        "sched-entry-list[{i}] gatemask {v} exceeds u8::MAX"
+                    )));
+                }
+                v as u8
+            }
+            _ => {
+                return Err(FixtureError::Transform(format!(
+                    "sched-entry-list[{i}] missing or non-string gatemask"
+                )));
+            }
+        };
+
+        let time_interval_value =
+            entry
+                .get("interval")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| {
+                    FixtureError::Transform(format!("sched-entry-list[{i}] missing `interval` u64"))
+                })?;
+
+        gcl.push(json!({
+            "gate-states-value": gate_states_value,
+            "time-interval-value": time_interval_value,
+        }));
+    }
+    Ok(gcl)
+}
+
+fn extract_cbs_permille(qdisc: &Value) -> Result<u32, FixtureError> {
+    // `tc -j qdisc show` cbs output:
+    //   { "kind": "cbs", "options": { "idleslope": <i32 kbps>,
+    //                                  "sendslope": ..., "hicredit": ..., ... } }
+    // We approximate bandwidth reservation as idleslope / port_speed_kbps * 1000.
+    // For a 1 Gbps (1_000_000 kbps) port with idleslope = 750000 → 750 permille.
+    // If idleslope is absent, fall back to 0.
+    const PORT_SPEED_KBPS: i64 = 1_000_000; // 1 Gbps in kbps
+    let idleslope = qdisc
+        .get("options")
+        .and_then(|o| o.get("idleslope"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let idleslope = idleslope.max(0);
+    let permille = (idleslope * 1000 / PORT_SPEED_KBPS).clamp(0, 1000) as u32;
+    Ok(permille)
+}
+
+fn build_tsn_block(
+    gcl: Option<Vec<Value>>,
+    bandwidth_permille: Option<u32>,
+    max_frame_size: u16,
+) -> Option<Value> {
+    if gcl.is_none() && bandwidth_permille.is_none() {
+        return None;
+    }
+
+    let mut tsn = serde_json::Map::new();
+
+    if let Some(gcl_list) = gcl {
+        tsn.insert("gate-control-list".to_string(), Value::Array(gcl_list));
+        // Inject synthesised Qci stream-filters for taprio ports.
+        // NOTE: Linux sch_taprio has no Qci equivalent; these entries are
+        // synthesised from the 3-node topology config and do NOT reflect
+        // observed kernel state.
+        let filters: Vec<Value> = STATIC_STREAM_FILTERS
+            .iter()
+            .map(|(handle, prio)| json!({ "stream-handle": handle, "priority-spec": prio }))
+            .collect();
+        tsn.insert("stream-filters".to_string(), Value::Array(filters));
+        tsn.insert("max-frame-size".to_string(), json!(max_frame_size));
+    }
+
+    if let Some(bw) = bandwidth_permille {
+        tsn.insert("bandwidth-reservation-permille".to_string(), json!(bw));
+    }
+
+    Some(Value::Object(tsn))
+}
+
+// ── pmc text → gPTP JSON ──────────────────────────────────────────────────
+
+/// A single parsed pmc sample (before deterministic-timestamp substitution).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PmcRawSample {
+    sync_error_ns: u64,
+}
+
+/// Transform multiple rounds of `pmc -u -b 0 'GET TIME_STATUS_NP'` text
+/// output into the gPTP JSON shape expected by
+/// [`crate::ingest::GptpJsonPtpTimeSource`].
+///
+/// Each `pmc_rounds` entry is the stdout of one `pmc` invocation;
+/// successive rounds produce successive samples for the port.
+///
+/// The `timestamp_ns` for each sample is replaced by a deterministic counter
+/// starting at [`TIMESTAMP_EPOCH_NS`] with step [`TIMESTAMP_STEP_NS`].
+/// This prevents noisy diffs while still preserving the relative ordering.
+///
+/// The `sync_error_ns` value is taken as `abs(masterOffset)` from the pmc
+/// output.
+///
+/// Output shape matches [`crate::ingest::GptpJsonPtpTimeSource`]:
+/// ```json
+/// { "gptp": { "grandmaster": "...", "domain": 0,
+///             "ports": [ { "name": "...", "samples": [
+///               {"timestamp_ns": u64, "sync_error_ns": u64} ] } ] } }
+/// ```
+pub fn pmc_to_gptp_json(
+    port_name: &str,
+    grandmaster: Option<&str>,
+    domain: u8,
+    pmc_rounds: &[&str],
+) -> Result<Value, FixtureError> {
+    let mut samples: Vec<Value> = Vec::with_capacity(pmc_rounds.len());
+
+    for (idx, &round_text) in pmc_rounds.iter().enumerate() {
+        let raw = parse_pmc_round(round_text)
+            .map_err(|e| FixtureError::Transform(format!("pmc round {idx}: {e}")))?;
+        let timestamp_ns = TIMESTAMP_EPOCH_NS + (idx as u64) * TIMESTAMP_STEP_NS;
+        samples.push(json!({
+            "timestamp_ns": timestamp_ns,
+            "sync_error_ns": raw.sync_error_ns,
+        }));
+    }
+
+    let port = json!({ "name": port_name, "samples": samples });
+
+    let gptp_inner = match grandmaster {
+        Some(gm) => json!({
+            "grandmaster": gm,
+            "domain": domain,
+            "ports": [port],
+        }),
+        None => json!({
+            "domain": domain,
+            "ports": [port],
+        }),
+    };
+
+    Ok(json!({ "gptp": gptp_inner }))
+}
+
+/// Parse a single `pmc -u -b 0 'GET TIME_STATUS_NP'` text block.
+///
+/// The relevant line has the form:
+/// ```text
+///     masterOffset              -42
+/// ```
+/// We take the absolute value to satisfy the schema's requirement for
+/// non-negative `sync_error_ns`.
+fn parse_pmc_round(text: &str) -> Result<PmcRawSample, String> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("masterOffset") {
+            let val_str = rest.trim();
+            let val: i64 = val_str
+                .parse()
+                .map_err(|e| format!("cannot parse masterOffset {val_str:?}: {e}"))?;
+            return Ok(PmcRawSample {
+                sync_error_ns: val.unsigned_abs(),
+            });
+        }
+    }
+    Err("pmc output missing `masterOffset` line".to_string())
+}
+
+// ── LLDP JSON reshaping ───────────────────────────────────────────────────
+
+/// Reshape `lldpctl -f json` output into a normalised form.
+///
+/// lldpd already emits the canonical shape; this function is a pass-through
+/// that validates the top-level `lldp.interface` key exists, then returns
+/// the value unchanged.  It exists as a named function so callers can pipe
+/// through it and so that unit tests can assert against known shapes.
+pub fn validate_lldp_json(lldp_raw: &str) -> Result<Value, FixtureError> {
+    let v: Value = serde_json::from_str(lldp_raw)
+        .map_err(|e| FixtureError::Transform(format!("lldp JSON parse error: {e}")))?;
+    // Validate top-level structure so errors surface here, not in ingest.
+    v.get("lldp")
+        .and_then(|l| l.get("interface"))
+        .ok_or_else(|| {
+            FixtureError::Transform(
+                "lldpctl JSON missing `lldp.interface` key — \
+                 is lldpd running and has it observed any neighbors?"
+                    .to_string(),
+            )
+        })?;
+    Ok(v)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ingest::{
+        GptpJsonPtpTimeSource, PtpTimeSource, QccYangSwitchConfigSource, SwitchConfigSource,
+    };
+
+    // ── tc → Qcc YANG ──────────────────────────────────────────────────────
+
+    /// Realistic `tc -j qdisc show` output with one taprio and one cbs qdisc.
+    /// Values taken from iproute2 6.1 manual examples.
+    const TC_TAPRIO_CBS_JSON: &str = r#"[
+        {
+            "kind": "taprio",
+            "handle": "100:",
+            "parent": "root",
+            "options": {
+                "num_tc": 4,
+                "map": [0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                "queues": [{ "count": 1, "offset": 0 }],
+                "base-time": 0,
+                "clockid": "TAI",
+                "flags": "0x0",
+                "sched-entry-list": [
+                    { "command": "S", "gatemask": "0xff", "interval": 400000 },
+                    { "command": "S", "gatemask": "0x01", "interval": 100000 }
+                ]
+            }
+        },
+        {
+            "kind": "cbs",
+            "handle": "200:",
+            "parent": "100:1",
+            "options": {
+                "idleslope": 750000,
+                "sendslope": -250000,
+                "hicredit": 34,
+                "locredit": -15
+            }
+        }
+    ]"#;
+
+    #[test]
+    fn tc_taprio_cbs_round_trips_qcc() {
+        let out = tc_qdisc_json_to_qcc("swp1", TC_TAPRIO_CBS_JSON).unwrap();
+        let json_str = serde_json::to_string(&out).unwrap();
+
+        // Must parse cleanly through QccYangSwitchConfigSource.
+        let src = QccYangSwitchConfigSource::from_json_str(&json_str).unwrap();
+        let ports = src.ports();
+        assert_eq!(ports.len(), 1);
+
+        let p = &ports[0];
+        assert_eq!(p.port_name, "swp1");
+
+        // Two GCL entries: 0xff / 400000 ns, 0x01 / 100000 ns.
+        let gcl = p.gate_control_list.as_ref().unwrap();
+        assert_eq!(gcl.len(), 2);
+        assert_eq!(gcl[0].gate_states_value, 0xff);
+        assert_eq!(gcl[0].time_interval_value, 400_000);
+        assert_eq!(gcl[1].gate_states_value, 0x01);
+        assert_eq!(gcl[1].time_interval_value, 100_000);
+
+        // CBS: 750000 kbps / 1000000 kbps * 1000 = 750 permille.
+        assert_eq!(p.bandwidth_reservation_permille, Some(750));
+        assert_eq!(p.max_frame_size, Some(1518));
+
+        // Synthesised Qci stream filters.
+        let filters = p.streams.as_ref().unwrap();
+        assert_eq!(filters.len(), STATIC_STREAM_FILTERS.len());
+        for (filter, &(expected_handle, expected_prio)) in
+            filters.iter().zip(STATIC_STREAM_FILTERS.iter())
+        {
+            assert_eq!(filter.stream_handle, expected_handle);
+            assert_eq!(filter.priority_spec, expected_prio);
+        }
+    }
+
+    #[test]
+    fn tc_no_taprio_no_cbs_yields_bare_port() {
+        let tc_json =
+            r#"[{"kind": "pfifo_fast", "handle": "0:", "parent": "root", "options": {}}]"#;
+        let out = tc_qdisc_json_to_qcc("swp2", tc_json).unwrap();
+        let json_str = serde_json::to_string(&out).unwrap();
+        let src = QccYangSwitchConfigSource::from_json_str(&json_str).unwrap();
+        let p = &src.ports()[0];
+        assert_eq!(p.port_name, "swp2");
+        assert!(p.gate_control_list.is_none());
+        assert!(p.bandwidth_reservation_permille.is_none());
+        assert!(p.streams.is_none());
+    }
+
+    #[test]
+    fn tc_gatemask_as_number_parsed() {
+        let tc_json = r#"[{
+            "kind": "taprio",
+            "options": {
+                "sched-entry-list": [
+                    { "command": "S", "gatemask": 255, "interval": 200000 }
+                ]
+            }
+        }]"#;
+        let out = tc_qdisc_json_to_qcc("swp3", tc_json).unwrap();
+        let json_str = serde_json::to_string(&out).unwrap();
+        let src = QccYangSwitchConfigSource::from_json_str(&json_str).unwrap();
+        let gcl = src.ports()[0].gate_control_list.as_ref().unwrap();
+        assert_eq!(gcl[0].gate_states_value, 0xff);
+    }
+
+    // ── pmc → gPTP JSON ───────────────────────────────────────────────────
+
+    /// Realistic `pmc -u -b 0 'GET TIME_STATUS_NP'` output fragment.
+    /// Format from linuxptp 4.x.
+    const PMC_ROUND_1: &str = r#"
+sending: GET TIME_STATUS_NP
+    7cfe90.fffe.000001-0 seq 0 RESPONSE MANAGEMENT TIME_STATUS_NP
+        master_offset              -42
+        ingress_time               1704067200100000000
+        cumulativeScaledRateOffset +0.000000000
+        scaledLastGmPhaseChange    0
+        gmTimeBaseIndicator        0
+        lastGmPhaseChange          0x0000'0000000000000000.0000
+        gmPresent                  true
+        gmIdentity                 00:1b:21:ff:fe:01:02:03
+    masterOffset              -42
+    ingress_time               1704067200100000000
+"#;
+
+    const PMC_ROUND_2: &str = r#"
+sending: GET TIME_STATUS_NP
+    7cfe90.fffe.000001-0 seq 1 RESPONSE MANAGEMENT TIME_STATUS_NP
+    masterOffset              15
+    ingress_time               1704067200200000000
+"#;
+
+    #[test]
+    fn pmc_parses_negative_master_offset_as_abs() {
+        let result =
+            pmc_to_gptp_json("eth0", Some("00:1b:21:ff:fe:01:02:03"), 0, &[PMC_ROUND_1]).unwrap();
+        let json_str = serde_json::to_string(&result).unwrap();
+        let src = GptpJsonPtpTimeSource::from_json_str(&json_str).unwrap();
+        assert_eq!(src.grandmaster(), Some("00:1b:21:ff:fe:01:02:03"));
+        assert_eq!(src.domain(), Some(0));
+        let samples = &src.ports()[0].samples;
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].sync_error_ns, 42); // abs(-42)
+    }
+
+    #[test]
+    fn pmc_positive_master_offset_unchanged() {
+        let result = pmc_to_gptp_json("eth0", None, 20, &[PMC_ROUND_2]).unwrap();
+        let json_str = serde_json::to_string(&result).unwrap();
+        let src = GptpJsonPtpTimeSource::from_json_str(&json_str).unwrap();
+        assert_eq!(src.ports()[0].samples[0].sync_error_ns, 15);
+    }
+
+    #[test]
+    fn pmc_timestamp_determinism_two_rounds() {
+        // Same input twice → identical timestamp_ns sequence both times.
+        let rounds = &[PMC_ROUND_1, PMC_ROUND_2];
+        let result1 = pmc_to_gptp_json("eth0", None, 0, rounds).unwrap();
+        let result2 = pmc_to_gptp_json("eth0", None, 0, rounds).unwrap();
+
+        // The timestamps are derived from a fixed epoch, not wall-clock.
+        assert_eq!(result1, result2);
+
+        // Verify exact values.
+        let samples = result1["gptp"]["ports"][0]["samples"].as_array().unwrap();
+        assert_eq!(
+            samples[0]["timestamp_ns"].as_u64().unwrap(),
+            TIMESTAMP_EPOCH_NS
+        );
+        assert_eq!(
+            samples[1]["timestamp_ns"].as_u64().unwrap(),
+            TIMESTAMP_EPOCH_NS + TIMESTAMP_STEP_NS
+        );
+    }
+
+    #[test]
+    fn pmc_round_trips_gptp_ingest() {
+        let result = pmc_to_gptp_json(
+            "eth0",
+            Some("00:1b:21:ff:fe:01:02:03"),
+            0,
+            &[PMC_ROUND_1, PMC_ROUND_2],
+        )
+        .unwrap();
+        let json_str = serde_json::to_string(&result).unwrap();
+        let src = GptpJsonPtpTimeSource::from_json_str(&json_str).unwrap();
+        assert_eq!(src.ports().len(), 1);
+        assert_eq!(src.ports()[0].name, "eth0");
+        assert_eq!(src.ports()[0].samples.len(), 2);
+        // First sample: abs(-42) = 42.
+        assert_eq!(src.ports()[0].samples[0].sync_error_ns, 42);
+        // Second sample: abs(15) = 15.
+        assert_eq!(src.ports()[0].samples[1].sync_error_ns, 15);
+    }
+
+    // ── LLDP passthrough ──────────────────────────────────────────────────
+
+    const LLDP_JSON: &str = r#"{
+        "lldp": {
+            "interface": [
+                {
+                    "name": "veth0",
+                    "chassis": {
+                        "switch": {
+                            "id": {"type": "mac", "value": "aa:bb:cc:dd:ee:01"},
+                            "name": "grandmaster"
+                        }
+                    },
+                    "port": {
+                        "id": {"type": "ifname", "value": "veth1"}
+                    }
+                }
+            ]
+        }
+    }"#;
+
+    #[test]
+    fn lldp_validate_passthrough() {
+        let v = validate_lldp_json(LLDP_JSON).unwrap();
+        assert!(v.get("lldp").is_some());
+    }
+
+    #[test]
+    fn lldp_validate_rejects_missing_interface() {
+        let bad = r#"{"lldp": {}}"#;
+        let err = validate_lldp_json(bad).unwrap_err();
+        assert!(matches!(err, FixtureError::Transform(_)));
+    }
+}

--- a/crates/spar-trace-topology/src/lib.rs
+++ b/crates/spar-trace-topology/src/lib.rs
@@ -37,6 +37,7 @@
 //! Out of scope for v1: PCAP-classic, BLF, OPC-UA, deep packet
 //! inspection. See the design doc §"Out-of-scope for v1".
 
+pub mod fixtures;
 pub mod identity;
 pub mod ingest;
 pub mod reconcile;


### PR DESCRIPTION
## Summary

**v0.11.0 PR 1.** A Rust binary — `gen-fixtures`, in the `spar-trace-topology` crate — that produces the four runtime artefacts the reconciliation engine will test against, from a synthetic 3-node TSN topology (grandmaster / switch / endpoint) built in Linux network namespaces.

## Why Rust, not a shell script

The maintainer's standing preference — and it earns its keep here:
- Typed config; `Result` error propagation with context on every fallible step.
- **`NetnsGuard` RAII** — `Drop` runs `ip netns del`, so a panic or `?`-propagated error still tears the topology down. A shell `trap` silently no-ops on a crash and leaves stale `/run/netns` handles for the next run to collide with.
- The two transform steps are pure, unit-tested functions.

## What it generates

| Fixture | Source |
|---|---|
| `capture.pcapng` | `tcpdump` on the GM veth |
| `lldp.json` | `lldpd -H 0` + `lldpctl -f json` |
| `qcc-yang.json` | `tc taprio`/`cbs` → `tc -j qdisc show` → transformed to the `QccYangSwitchConfigSource` shape |
| `gptp.json` | `ptp4l` + `pmc` → transformed to the `GptpJsonPtpTimeSource` shape |

Two gotchas baked in from smithy's live testing: veths are created **multi-queue** (`numtxqueues/numrxqueues 4`) because `sch_taprio` rejects single-queue devices; taprio runs in **software mode** (`flags 0x0`) — no TSN NIC.

gPTP `timestamp_ns` is replaced by a deterministic synthetic counter (fixed epoch + step) so fixture diffs aren't noisy; `sync_error_ns` (abs master offset) is kept as observed. Qci `stream-filters` have no Linux kernel equivalent — synthesised from a static config, documented as such in the code.

## Scope

Tool only. The 9 transformer unit tests run on any host (no netns dependency) and every generated JSON round-trips through the `ingest.rs` parsers. The **CI harness** that runs the netns-touching path is deliberately a follow-up: per the smithy QEMU enablement it'll be a KVM guest, not the `netns` runner — building that workflow now would be rework.

## Test plan

- [x] `cargo build -p spar-trace-topology --bins` clean
- [x] `cargo test -p spar-trace-topology` — 34 tests pass (9 new transformer tests)
- [x] `cargo clippy -p spar-trace-topology --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `rivet validate` PASS
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>