### PR TITLE
feat(trace-topology): NixOS guest + QEMU harness for fixture generation (v0.11.0 PR 2)

### DIFF
--- a/.github/workflows/fixture-vm-flake-lock.yml
+++ b/.github/workflows/fixture-vm-flake-lock.yml
@@ -1,0 +1,63 @@
+# .github/workflows/fixture-vm-flake-lock.yml
+#
+# Resolves tools/fixture-vm/flake.nix inputs and produces flake.lock.
+#
+# This is a deliberate, occasional action — the Nix equivalent of
+# `cargo update`. The nightly Trace-Topology Fixture Generation workflow
+# builds ONLY against a committed flake.lock and never re-resolves inputs
+# itself; that lock is the determinism pin (pinned nixpkgs, kernel, the
+# whole closure).
+#
+# Usage:
+#   1. Dispatch this workflow (manually).
+#   2. Download the `fixture-vm-flake-lock` artifact.
+#   3. Commit the contained flake.lock to tools/fixture-vm/ in a reviewed PR.
+#
+# The first run bootstraps the lock (none committed yet); later runs bump it.
+#
+# Security note: the only ${{ }} interpolation is github.workspace — a
+# trusted, runner-set checkout path — and it is routed through an env var,
+# never inlined into a shell command.
+
+name: fixture-vm flake.lock
+
+on:
+  workflow_dispatch:
+
+jobs:
+  resolve-lock:
+    name: Resolve flake inputs
+    runs-on: [self-hosted, linux, x64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Resolving inputs does not build the image, so no /dev/kvm is needed
+      # here — only the nightly build step boots a builder VM.
+      - name: nix flake update (digest-pinned nixos/nix container)
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          DIGEST="sha256:4aba8f0048d5af9623dd61d8c8c80d61765c1a8a26f81afb33e28e2a4d5e9dbf"
+          podman run --rm \
+            --security-opt label=disable \
+            -v "${WORKSPACE}:/spar:Z" \
+            "docker.io/nixos/nix@${DIGEST}" \
+            sh -c '
+              set -euo pipefail
+              mkdir -p /etc/nix
+              echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+              cd /spar/tools/fixture-vm
+              nix flake update
+            '
+
+      - name: Show resolved lock
+        run: cat tools/fixture-vm/flake.lock
+
+      - name: Upload flake.lock
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixture-vm-flake-lock
+          path: tools/fixture-vm/flake.lock
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/trace-fixtures.yml
+++ b/.github/workflows/trace-fixtures.yml
@@ -15,6 +15,13 @@
 # The Nix store is ephemeral (no persistent named volume) — it is rebuilt
 # cold from cache.nixos.org on each run.  This keeps PR 2 simple; a
 # persistent volume can be layered in once the workflow is proven.
+#
+# Determinism: this job builds ONLY against the committed
+# tools/fixture-vm/flake.lock — it never runs `nix flake update`.  The lock
+# IS the pin (the whole reason for the NixOS approach); re-resolving inputs
+# per run would silently un-pin nixpkgs / the kernel.  Updating the lock is
+# a deliberate, reviewed action — see the `fixture-vm flake.lock` workflow
+# (.github/workflows/fixture-vm-flake-lock.yml).
 
 name: Trace-Topology Fixture Generation
 
@@ -38,7 +45,23 @@ jobs:
       # ── 1. Checkout ──────────────────────────────────────────────────────
       - uses: actions/checkout@v4
 
-      # ── 2. Build the NixOS guest qcow2 via rootless podman ───────────────
+      # ── 2. Require a committed flake.lock (the determinism pin) ──────────
+      #
+      # The nightly build never re-resolves flake inputs. If the lock is
+      # absent the build must FAIL with a clear pointer rather than silently
+      # run un-pinned.
+      - name: Require committed flake.lock
+        run: |
+          if [ ! -f tools/fixture-vm/flake.lock ]; then
+            echo "::error::tools/fixture-vm/flake.lock is missing."
+            echo "::error::The nightly build runs only against a committed,"
+            echo "::error::reviewed lock. Dispatch the 'fixture-vm flake.lock'"
+            echo "::error::workflow, download its artifact, and commit the"
+            echo "::error::resulting flake.lock in a PR."
+            exit 1
+          fi
+
+      # ── 3. Build the NixOS guest qcow2 via rootless podman ───────────────
       #
       # The nixos/nix image is pinned by digest for determinism — the image
       # is part of the Nix closure, and :latest would silently pull a
@@ -53,6 +76,10 @@ jobs:
       # Without it, Nix's sandboxed builds fail inside the already-
       # containerised environment.  --device /dev/kvm is required because
       # the NixOS qcow2 builder boots a transient builder VM.
+      #
+      # --no-update-lock-file makes `nix build` FAIL rather than re-resolve
+      # if the committed lock is stale/incomplete — belt-and-suspenders with
+      # the guard step above.
       - name: Build NixOS fixture-vm qcow2
         env:
           WORKSPACE: ${{ github.workspace }}
@@ -70,10 +97,9 @@ jobs:
               echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
               echo "sandbox = false" >> /etc/nix/nix.conf
               cd /spar/tools/fixture-vm
-              # Generate/update the lockfile on first run (or if inputs changed).
-              nix flake update
-              # Build the qcow2 image.
-              nix build .#nixosConfigurations.fixture-vm.config.system.build.qcow2 \
+              # Build the qcow2 image against the committed flake.lock.
+              nix build --no-update-lock-file \
+                .#nixosConfigurations.fixture-vm.config.system.build.qcow2 \
                 --out-link /spar/tools/fixture-vm/result
             '
 

--- a/.github/workflows/trace-fixtures.yml
+++ b/.github/workflows/trace-fixtures.yml
@@ -1,0 +1,130 @@
+# .github/workflows/trace-fixtures.yml
+#
+# Nightly job that builds the NixOS KVM guest, runs gen-fixtures inside it,
+# verifies the four fixture files, and uploads them as a CI artefact.
+#
+# Triggers: workflow_dispatch (manual) + schedule (nightly).
+# NOT pull_request — this is a build-and-execute job, not a per-PR check.
+#
+# All 12 CI runners are KVM-capable (bare-metal, /dev/kvm present, runner
+# user in the kvm group, qemu-system-x86_64 8.2.2 installed).  The NixOS
+# guest is built inside a rootless podman container from a digest-pinned
+# nixos/nix image; the container receives --device /dev/kvm because the
+# NixOS qcow2 builder internally boots a transient builder VM.
+#
+# The Nix store is ephemeral (no persistent named volume) — it is rebuilt
+# cold from cache.nixos.org on each run.  This keeps PR 2 simple; a
+# persistent volume can be layered in once the workflow is proven.
+
+name: Trace-Topology Fixture Generation
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 02:30 UTC every day.
+    - cron: "30 2 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  FIXTURE_OUTPUT_DIR: fixture-output
+
+jobs:
+  generate-fixtures:
+    name: Build guest + generate fixtures
+    runs-on: [self-hosted, linux, x64]
+
+    steps:
+      # ── 1. Checkout ──────────────────────────────────────────────────────
+      - uses: actions/checkout@v4
+
+      # ── 2. Build the NixOS guest qcow2 via rootless podman ───────────────
+      #
+      # The nixos/nix image is pinned by digest for determinism — the image
+      # is part of the Nix closure, and :latest would silently pull a
+      # different version.  Update the digest here when a newer Nix release
+      # is needed.
+      #
+      # sha256 digest of docker.io/nixos/nix:2.24.9 (amd64).
+      # Resolve with: podman manifest inspect docker.io/nixos/nix:2.24.9
+      #
+      # Note: "sandbox = false" in nix.conf drops Nix's in-container build
+      # sandbox (not host root — the container is already rootless).
+      # Without it, Nix's sandboxed builds fail inside the already-
+      # containerised environment.  --device /dev/kvm is required because
+      # the NixOS qcow2 builder boots a transient builder VM.
+      - name: Build NixOS fixture-vm qcow2
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          DIGEST="sha256:4aba8f0048d5af9623dd61d8c8c80d61765c1a8a26f81afb33e28e2a4d5e9dbf"
+          podman run --rm \
+            --device /dev/kvm \
+            --security-opt label=disable \
+            -v "${WORKSPACE}:/spar:Z" \
+            "docker.io/nixos/nix@${DIGEST}" \
+            sh -c '
+              set -euo pipefail
+              # Enable flakes + nix-command.
+              mkdir -p /etc/nix
+              echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+              echo "sandbox = false" >> /etc/nix/nix.conf
+              cd /spar/tools/fixture-vm
+              # Generate/update the lockfile on first run (or if inputs changed).
+              nix flake update
+              # Build the qcow2 image.
+              nix build .#nixosConfigurations.fixture-vm.config.system.build.qcow2 \
+                --out-link /spar/tools/fixture-vm/result
+            '
+
+      - name: Locate qcow2
+        id: qcow2
+        run: |
+          QCOW2="$(readlink -f tools/fixture-vm/result/nixos.qcow2)"
+          echo "path=${QCOW2}" >> "$GITHUB_OUTPUT"
+          echo "fixture-vm: qcow2 = ${QCOW2}"
+          ls -lh "${QCOW2}"
+
+      # ── 3. Build the fixture-vm Rust harness ─────────────────────────────
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build fixture-vm harness
+        run: cargo build -p spar-trace-topology --bins --release
+
+      # ── 4. Run the harness (boots VM, collects fixtures) ─────────────────
+      - name: Create fixture output directory
+        run: mkdir -p "$FIXTURE_OUTPUT_DIR"
+
+      - name: Run fixture-vm (boot NixOS guest, generate fixtures)
+        env:
+          QCOW2_PATH: ${{ steps.qcow2.outputs.path }}
+        run: |
+          ./target/release/fixture-vm \
+            --base-qcow2 "${QCOW2_PATH}" \
+            --output-dir "${FIXTURE_OUTPUT_DIR}"
+
+      # ── 5. Verify: tshark -r capture.pcapng ──────────────────────────────
+      - name: Verify capture.pcapng with tshark
+        run: |
+          tshark -r "${FIXTURE_OUTPUT_DIR}/capture.pcapng" \
+            -q -z io,stat,0 2>&1 | tee /tmp/tshark-out.txt
+          # tshark exits non-zero if the file is corrupt or empty.
+
+      # ── 6. Round-trip: parse all four fixtures through ingest parsers ─────
+      - name: Verify all four fixtures parse cleanly (ingest round-trip)
+        run: |
+          ./target/release/fixture-vm --verify "${FIXTURE_OUTPUT_DIR}"
+
+      # ── 7. Upload fixtures as a CI artefact ──────────────────────────────
+      - name: Upload fixture artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trace-topology-fixtures-${{ github.run_number }}
+          path: |
+            ${{ env.FIXTURE_OUTPUT_DIR }}/capture.pcapng
+            ${{ env.FIXTURE_OUTPUT_DIR }}/lldp.json
+            ${{ env.FIXTURE_OUTPUT_DIR }}/qcc-yang.json
+            ${{ env.FIXTURE_OUTPUT_DIR }}/gptp.json
+          retention-days: 30
+          if-no-files-found: error

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2165,6 +2165,28 @@ artifacts:
 
   # ── Trace-topology fixtures (v0.11.0) ────────────────────────────────────
 
+  - id: REQ-FIXTURE-VM-001
+    type: requirement
+    title: KVM harness that runs gen-fixtures inside a NixOS guest
+    description: >
+      spar shall provide a CI harness that executes `gen-fixtures` inside a
+      KVM-accelerated NixOS virtual machine, collects the four trace-topology
+      fixture files (capture.pcapng, lldp.json, qcc-yang.json, gptp.json) via
+      a virtio-9p share, and verifies that all four parse cleanly through the
+      spar-trace-topology ingest parsers.  The harness is a Rust binary
+      (`fixture-vm`) that creates a copy-on-write QEMU overlay over a
+      base qcow2 (so each run is pristine), boots qemu-system-x86_64 with
+      -enable-kvm -nographic, applies a 15-minute wall-clock timeout, and
+      cleans up the overlay on exit/drop.  The NixOS guest image is built by a
+      Nix flake in tools/fixture-vm/ and contains the full TSN fixture
+      toolchain (iproute2, lldpd, linuxptp, tcpdump, tshark) plus the
+      gen-fixtures binary built via rustPlatform.buildRustPackage.  The guest
+      runs gen-fixtures as a systemd oneshot service and powers off on
+      completion.  The workflow that drives this runs nightly and on
+      workflow_dispatch; fixtures are uploaded as a CI artefact.
+    status: implemented
+    tags: [trace-topology, fixtures, ci, v0110]
+
   - id: REQ-TRACE-FIXTURES-001
     type: requirement
     title: Rust trace-fixture generator (netns + TSN)

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2873,3 +2873,24 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-TRACE-FIXTURES-001
+
+  - id: TEST-FIXTURE-VM
+    type: feature
+    title: KVM fixture-vm harness build and verify
+    description: >
+      Verifies the fixture-vm Rust harness (crates/spar-trace-topology/src/bin/fixture-vm.rs)
+      builds cleanly alongside gen-fixtures.  The --verify mode parses all
+      four fixture files through the spar-trace-topology ingest parsers and
+      asserts Ok.  The full VM boot and fixture-generation path (NixOS guest,
+      KVM, virtio-9p) runs only in the nightly trace-fixtures workflow on the
+      self-hosted KVM-capable runners; that path is unvalidated in this PR and
+      will be exercised by the first nightly run.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo build -p spar-trace-topology --bin fixture-vm
+    status: passing
+    tags: [trace-topology, fixtures, ci, v0110]
+    links:
+      - type: satisfies
+        target: REQ-FIXTURE-VM-001

--- a/crates/spar-trace-topology/Cargo.toml
+++ b/crates/spar-trace-topology/Cargo.toml
@@ -18,5 +18,9 @@ pcap-parser = "0.16"
 name = "gen-fixtures"
 path = "src/bin/gen-fixtures.rs"
 
+[[bin]]
+name = "fixture-vm"
+path = "src/bin/fixture-vm.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/spar-trace-topology/src/bin/fixture-vm.rs
+++ b/crates/spar-trace-topology/src/bin/fixture-vm.rs
@@ -1,0 +1,406 @@
+//! `fixture-vm` — QEMU harness that boots the NixOS fixture-generation
+//! guest and retrieves the four trace-topology fixture files.
+//!
+//! # Usage
+//!
+//! ```text
+//! fixture-vm --base-qcow2 <path/to/base.qcow2> --output-dir <dir>
+//! fixture-vm --verify <dir>
+//! ```
+//!
+//! ## Normal mode (`--base-qcow2` + `--output-dir`)
+//!
+//! 1. Creates a copy-on-write QEMU overlay over `<base.qcow2>` so each
+//!    run starts from a clean image (the base is never mutated).
+//! 2. Boots `qemu-system-x86_64` with `-enable-kvm -nographic`, the
+//!    overlay disk, and a virtio-9p share whose host path is `<output-dir>`.
+//!    The guest mounts the share under `/fixtures` and the `gen-fixtures`
+//!    service writes the four fixture files there.
+//! 3. Waits for the QEMU process to exit (the guest powers off when
+//!    `gen-fixtures` completes). A 15-minute wall-clock timeout kills
+//!    QEMU and returns an error if the guest does not shut down in time.
+//! 4. After exit: asserts that all four fixture files exist in
+//!    `<output-dir>` and are non-empty.
+//!
+//! ## Verify mode (`--verify`)
+//!
+//! Round-trips each fixture file through the corresponding
+//! `spar-trace-topology` ingest parser and asserts `Ok`.  Exits 0 if all
+//! four parse cleanly, non-zero with a descriptive message otherwise.
+//!
+//! # RAII guarantees
+//!
+//! The QEMU child process and the overlay temp-file are both wrapped in
+//! RAII guards whose `Drop` implementations clean up unconditionally, so
+//! a panic or early `?` return never leaves a stale process or tmp file.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command, Stdio};
+use std::time::{Duration, Instant};
+
+// ── Public re-export so the verify helper can use ingest parsers ──────────
+
+use spar_trace_topology::{
+    FrameSource, GptpJsonPtpTimeSource, LldpJsonTopologySource, PcapngFrameSource, PtpTimeSource,
+    QccYangSwitchConfigSource, SwitchConfigSource, TopologySource,
+};
+
+// ── Error type ────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum HarnessError {
+    Io(io::Error),
+    Ingest(spar_trace_topology::IngestError),
+    Other(String),
+}
+
+impl std::fmt::Display for HarnessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Ingest(e) => write!(f, "ingest parse error: {e}"),
+            Self::Other(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl From<io::Error> for HarnessError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<spar_trace_topology::IngestError> for HarnessError {
+    fn from(e: spar_trace_topology::IngestError) -> Self {
+        Self::Ingest(e)
+    }
+}
+
+// ── CLI config ────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum Mode {
+    /// Boot the NixOS guest and collect fixtures.
+    Run {
+        base_qcow2: PathBuf,
+        output_dir: PathBuf,
+    },
+    /// Parse already-present fixtures and assert Ok.
+    Verify { fixture_dir: PathBuf },
+}
+
+fn parse_args() -> Result<Mode, HarnessError> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut iter = args.iter().skip(1).peekable();
+
+    match iter.next().map(String::as_str) {
+        Some("--verify") => {
+            let dir = iter.next().ok_or_else(|| {
+                HarnessError::Other("--verify requires a directory argument".to_string())
+            })?;
+            Ok(Mode::Verify {
+                fixture_dir: PathBuf::from(dir),
+            })
+        }
+        Some("--base-qcow2") => {
+            let base = iter.next().ok_or_else(|| {
+                HarnessError::Other("--base-qcow2 requires a path argument".to_string())
+            })?;
+            let output_dir = match (iter.next().map(String::as_str), iter.next()) {
+                (Some("--output-dir"), Some(d)) => PathBuf::from(d),
+                _ => {
+                    return Err(HarnessError::Other(
+                        "--output-dir <path> is required after --base-qcow2".to_string(),
+                    ))
+                }
+            };
+            Ok(Mode::Run {
+                base_qcow2: PathBuf::from(base),
+                output_dir,
+            })
+        }
+        _ => Err(HarnessError::Other(
+            "Usage:\n  fixture-vm --base-qcow2 <path> --output-dir <dir>\n  fixture-vm --verify <dir>".to_string(),
+        )),
+    }
+}
+
+// ── RAII overlay file ─────────────────────────────────────────────────────
+
+/// A temporary QEMU qcow2 overlay file that is deleted on `Drop`.
+///
+/// Created with `qemu-img create -f qcow2 -b <base> -F qcow2 <overlay>`.
+/// Each invocation of `fixture-vm` creates a fresh overlay, so the base
+/// image is never mutated and multiple concurrent runs don't collide.
+struct OverlayFile {
+    path: PathBuf,
+}
+
+impl OverlayFile {
+    fn create(base: &Path) -> Result<Self, HarnessError> {
+        let overlay_path = {
+            let dir = base.parent().unwrap_or_else(|| Path::new("."));
+            dir.join(format!(
+                "fixture-vm-overlay-{}.qcow2",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_nanos()
+            ))
+        };
+
+        let status = Command::new("qemu-img")
+            .args([
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                &base.to_string_lossy(),
+                "-F",
+                "qcow2",
+                &overlay_path.to_string_lossy(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .status()?;
+
+        if !status.success() {
+            return Err(HarnessError::Other(format!(
+                "qemu-img create failed (exit {})",
+                status.code().unwrap_or(-1)
+            )));
+        }
+
+        Ok(Self { path: overlay_path })
+    }
+}
+
+impl Drop for OverlayFile {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+// ── RAII QEMU child ───────────────────────────────────────────────────────
+
+/// A running QEMU process that is killed + waited on `Drop` if it has
+/// not already exited.
+struct QemuChild {
+    inner: process::Child,
+}
+
+impl QemuChild {
+    fn spawn(overlay: &OverlayFile, fixture_dir: &Path) -> Result<Self, HarnessError> {
+        let child = Command::new("qemu-system-x86_64")
+            .args([
+                // KVM acceleration (requires /dev/kvm + kvm group).
+                "-enable-kvm",
+                // No graphical window — all output on stdio.
+                "-nographic",
+                // 2 vCPUs, 1 GiB RAM — enough for lldpd/ptp4l/tcpdump.
+                "-smp",
+                "2",
+                "-m",
+                "1G",
+                // Boot disk: CoW overlay over the NixOS base qcow2.
+                "-drive",
+                &format!(
+                    "file={},format=qcow2,if=virtio",
+                    overlay.path.to_string_lossy()
+                ),
+                // virtio-9p share: the host-side fixture directory is
+                // exported with mount_tag="fixtures". The guest's NixOS
+                // systemd unit mounts this and writes the four fixture
+                // files there.
+                "-virtfs",
+                &format!(
+                    "local,path={},mount_tag=fixtures,security_model=none",
+                    fixture_dir.to_string_lossy()
+                ),
+                // Serial console on stdio; the guest's kernel console
+                // output appears here for debugging.
+                "-serial",
+                "mon:stdio",
+            ])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        Ok(Self { inner: child })
+    }
+
+    /// Wait for the QEMU process to exit, with a wall-clock timeout.
+    ///
+    /// Returns `Ok(exit_status)` when the guest exits within the
+    /// deadline, `Err` with a clear message if the timeout fires (QEMU
+    /// is killed before returning).
+    fn wait_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<process::ExitStatus, HarnessError> {
+        let start = Instant::now();
+        loop {
+            match self.inner.try_wait()? {
+                Some(status) => return Ok(status),
+                None => {
+                    if start.elapsed() >= timeout {
+                        let _ = self.inner.kill();
+                        let _ = self.inner.wait();
+                        return Err(HarnessError::Other(format!(
+                            "QEMU guest did not shut down within {} seconds; killed",
+                            timeout.as_secs()
+                        )));
+                    }
+                    std::thread::sleep(Duration::from_secs(2));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for QemuChild {
+    fn drop(&mut self) {
+        // Best-effort kill — ignore errors (process may already be gone).
+        let _ = self.inner.kill();
+        let _ = self.inner.wait();
+    }
+}
+
+// ── Expected fixture file names ───────────────────────────────────────────
+
+const FIXTURE_FILES: &[&str] = &["capture.pcapng", "lldp.json", "qcc-yang.json", "gptp.json"];
+
+// ── Run mode ──────────────────────────────────────────────────────────────
+
+fn run_vm(base_qcow2: &Path, output_dir: &Path) -> Result<(), HarnessError> {
+    // Resolve paths.
+    if !base_qcow2.exists() {
+        return Err(HarnessError::Other(format!(
+            "base qcow2 not found: {}",
+            base_qcow2.display()
+        )));
+    }
+    fs::create_dir_all(output_dir)?;
+
+    eprintln!("fixture-vm: base image  = {}", base_qcow2.display());
+    eprintln!("fixture-vm: output dir  = {}", output_dir.display());
+
+    // 1. Create a CoW overlay so the base is never written.
+    let overlay = OverlayFile::create(base_qcow2)?;
+    eprintln!("fixture-vm: overlay      = {}", overlay.path.display());
+
+    // 2. Boot the guest.
+    eprintln!("fixture-vm: booting QEMU guest …");
+    let mut qemu = QemuChild::spawn(&overlay, output_dir)?;
+
+    // 3. Wait up to 15 minutes for the guest to run gen-fixtures and
+    //    power off.
+    let timeout = Duration::from_secs(15 * 60);
+    let status = qemu.wait_with_timeout(timeout)?;
+    eprintln!("fixture-vm: QEMU exited with {status}");
+
+    if !status.success() {
+        return Err(HarnessError::Other(format!(
+            "QEMU process exited non-zero: {status}"
+        )));
+    }
+
+    // 4. Assert all four fixture files exist and are non-empty.
+    check_fixtures(output_dir)?;
+
+    eprintln!("fixture-vm: all fixture files present and non-empty — done.");
+    Ok(())
+}
+
+// ── Verify mode ───────────────────────────────────────────────────────────
+
+fn verify_fixtures(fixture_dir: &Path) -> Result<(), HarnessError> {
+    eprintln!(
+        "fixture-vm --verify: checking fixtures in {}",
+        fixture_dir.display()
+    );
+
+    // First check raw presence / non-empty.
+    check_fixtures(fixture_dir)?;
+
+    let pcapng_path = fixture_dir.join("capture.pcapng");
+    let lldp_path = fixture_dir.join("lldp.json");
+    let qcc_path = fixture_dir.join("qcc-yang.json");
+    let gptp_path = fixture_dir.join("gptp.json");
+
+    // Parse capture.pcapng through PcapngFrameSource.
+    let mut pcapng_src = PcapngFrameSource::open(&pcapng_path)?;
+    let mut frame_count = 0usize;
+    for result in pcapng_src.frames() {
+        result?;
+        frame_count += 1;
+    }
+    eprintln!("fixture-vm --verify: capture.pcapng OK ({frame_count} frames)");
+
+    // Parse lldp.json through LldpJsonTopologySource.
+    let lldp_src = LldpJsonTopologySource::open(&lldp_path)?;
+    let neighbor_count = lldp_src.neighbors().len();
+    eprintln!("fixture-vm --verify: lldp.json OK ({neighbor_count} neighbors)");
+
+    // Parse qcc-yang.json through QccYangSwitchConfigSource.
+    let qcc_src = QccYangSwitchConfigSource::open(&qcc_path)?;
+    let port_count = qcc_src.ports().len();
+    eprintln!("fixture-vm --verify: qcc-yang.json OK ({port_count} ports)");
+
+    // Parse gptp.json through GptpJsonPtpTimeSource.
+    let gptp_src = GptpJsonPtpTimeSource::open(&gptp_path)?;
+    let ptp_port_count = gptp_src.ports().len();
+    eprintln!("fixture-vm --verify: gptp.json OK ({ptp_port_count} ptp ports)");
+
+    eprintln!("fixture-vm --verify: all four fixtures parse cleanly.");
+    Ok(())
+}
+
+// ── Shared fixture-presence check ─────────────────────────────────────────
+
+fn check_fixtures(dir: &Path) -> Result<(), HarnessError> {
+    for name in FIXTURE_FILES {
+        let path = dir.join(name);
+        if !path.exists() {
+            return Err(HarnessError::Other(format!(
+                "fixture file missing: {}",
+                path.display()
+            )));
+        }
+        let metadata = fs::metadata(&path)?;
+        if metadata.len() == 0 {
+            return Err(HarnessError::Other(format!(
+                "fixture file is empty: {}",
+                path.display()
+            )));
+        }
+        eprintln!(
+            "fixture-vm: {} ({} bytes) ✓",
+            path.display(),
+            metadata.len()
+        );
+    }
+    Ok(())
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────
+
+fn main() {
+    let result = match parse_args() {
+        Ok(Mode::Run {
+            base_qcow2,
+            output_dir,
+        }) => run_vm(&base_qcow2, &output_dir),
+        Ok(Mode::Verify { fixture_dir }) => verify_fixtures(&fixture_dir),
+        Err(e) => Err(e),
+    };
+
+    if let Err(e) = result {
+        eprintln!("fixture-vm: error: {e}");
+        process::exit(1);
+    }
+}

--- a/tools/fixture-vm/flake.nix
+++ b/tools/fixture-vm/flake.nix
@@ -1,0 +1,206 @@
+# tools/fixture-vm/flake.nix
+#
+# NixOS guest image for the spar trace-topology fixture generator.
+#
+# This flake builds a bootable qcow2 NixOS disk image containing the full
+# fixture-generation toolchain and the `gen-fixtures` binary from the spar
+# workspace.  The image is used by the `fixture-vm` Rust harness
+# (crates/spar-trace-topology/src/bin/fixture-vm.rs): the harness boots the
+# image under QEMU/KVM, the guest runs `gen-fixtures` once as a systemd
+# oneshot service, writes four fixture files to a virtio-9p share, and then
+# powers off.
+#
+# == Approach for gen-fixtures ==
+#
+# We chose approach (a): build gen-fixtures via rustPlatform.buildRustPackage
+# inside the flake, then include the resulting package in
+# environment.systemPackages.  Rationale:
+#
+#   - NixOS has a non-standard dynamic-linker path (/nix/store/…/ld-linux-x86-64.so.2);
+#     a glibc binary built on Ubuntu will not run there without patching.
+#   - Building inside the flake avoids the need for a musl cross-compilation
+#     step on the host, keeping CI simpler.
+#   - The binary and its full closure are pinned by the flake.lock, giving
+#     complete reproducibility.
+#   - Approach (b) (musl static binary via 9p share) is simpler for rapid
+#     iteration but requires a separate host build step and two separate
+#     pinning points.  For this PR, approach (a) is preferred.
+#
+# == Guest boot behaviour ==
+#
+# On every boot a systemd oneshot service (`gen-fixtures.service`) runs
+# gen-fixtures /fixtures, where /fixtures is the virtio-9p mount that the
+# QEMU harness exports from the host.  After the service exits the system
+# powers off via ExecStartPost=systemctl poweroff.  The service is
+# wantedBy = ["multi-user.target"] so it runs at the end of normal boot
+# without a special target.
+#
+# == Usage ==
+#
+#   nix build .#nixosConfigurations.fixture-vm.config.system.build.qcow2
+#
+# The resulting qcow2 is at result/nixos.qcow2 (symlink from ./result).
+# The fixture-vm Rust harness wraps this in a per-run CoW overlay.
+#
+# == Building inside podman (CI) ==
+#
+# The CI workflow builds this flake inside a rootless podman container:
+#
+#   podman run --rm \
+#     --device /dev/kvm \
+#     --security-opt label=disable \
+#     -v $PWD:/spar:Z \
+#     docker.io/nixos/nix@sha256:<pinned-digest> \
+#     sh -c 'echo "sandbox = false" >> /etc/nix/nix.conf && \
+#            cd /spar/tools/fixture-vm && \
+#            nix build .#nixosConfigurations.fixture-vm.config.system.build.qcow2 \
+#              --extra-experimental-features "nix-command flakes"'
+#
+# --device /dev/kvm is passed because the NixOS qcow2 builder internally
+# boots a transient builder VM.  sandbox = false drops Nix's in-container
+# build sandbox (not host root — the container is still rootless); without
+# it Nix's sandboxed builds fail inside the already-containerised environment.
+{
+  description = "NixOS KVM guest for spar trace-topology fixture generation";
+
+  inputs = {
+    # Pin nixpkgs to a specific revision for reproducibility.
+    # nixos-24.05 is a stable release channel; update the rev + sha256
+    # when a newer release is needed.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  };
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+
+    # Build gen-fixtures from the spar workspace.  The flake is located at
+    # tools/fixture-vm/ so the workspace root is two levels up (../../).
+    # We pass a cargoLock literal so the Nix sandbox can reproduce the
+    # exact dependency closure without network access during the build.
+    gen-fixtures = pkgs.rustPlatform.buildRustPackage {
+      pname = "gen-fixtures";
+      version = "0.10.0";
+
+      # Source is the entire spar workspace (Cargo workspace resolver needs
+      # the root Cargo.toml).  Filter out the target/ directory to keep
+      # source hashes stable across partial host builds.
+      src = pkgs.lib.cleanSourceWith {
+        src = ../..;
+        filter = path: type:
+          !(pkgs.lib.hasSuffix "/target" path)
+          && !(pkgs.lib.hasInfix "/.git/" path)
+          && !(pkgs.lib.hasSuffix "/.git" path);
+      };
+
+      # cargoLock.lockFile points to the workspace Cargo.lock.  Nix reads
+      # this to reproduce the exact crate set without running `cargo fetch`
+      # inside the sandbox.
+      cargoLock.lockFile = ../../Cargo.lock;
+
+      # Build only the gen-fixtures binary from spar-trace-topology.
+      cargoBuildFlags = [
+        "-p"
+        "spar-trace-topology"
+        "--bin"
+        "gen-fixtures"
+      ];
+
+      # Disable tests (they require Linux netns — only valid inside the VM).
+      doCheck = false;
+
+      # Runtime toolchain executables that gen-fixtures invokes via PATH.
+      # These are linked into the build environment so the resulting binary
+      # can find them at runtime.
+      nativeBuildInputs = [ pkgs.pkg-config ];
+    };
+
+  in {
+    nixosConfigurations.fixture-vm = nixpkgs.lib.nixosSystem {
+      inherit system;
+
+      modules = [
+        # ── Base NixOS configuration ──────────────────────────────────────
+
+        ({ config, pkgs, lib, ... }: {
+          # Pin the kernel to a recent stable version that includes
+          # sch_taprio and CLOCK_TAI (present since Linux 4.18;
+          # linuxPackages_latest tracks the latest stable).
+          boot.kernelPackages = pkgs.linuxPackages_latest;
+
+          # Enable sch_taprio and CBS as kernel modules.
+          boot.kernelModules = [ "sch_taprio" "sch_cbs" ];
+
+          # Boot directly from the qcow2's virtio disk (no PXE/UEFI menu).
+          boot.loader.grub = {
+            enable = true;
+            device = "/dev/vda";
+            timeout = 0;
+          };
+
+          # Filesystem: a single ext4 root on vda.
+          fileSystems."/" = {
+            device = "/dev/vda1";
+            fsType = "ext4";
+          };
+
+          # virtio-9p mount for the fixture output directory.  The QEMU
+          # harness exports the host fixture dir with mount_tag="fixtures".
+          fileSystems."/fixtures" = {
+            device = "fixtures";
+            fsType = "9p";
+            options = [ "trans=virtio" "version=9p2000.L" "nofail" ];
+          };
+
+          # No swap.
+          swapDevices = [];
+
+          # Minimal networking — not needed for the fixture run.
+          networking.useDHCP = false;
+
+          # The fixture toolchain.
+          environment.systemPackages = [
+            gen-fixtures
+            pkgs.iproute2        # ip netns, ip link
+            pkgs.lldpd           # lldpd, lldpctl
+            pkgs.linuxptp        # ptp4l, pmc
+            pkgs.tcpdump         # tcpdump
+            pkgs.tshark          # tshark (for CI verification step)
+          ];
+
+          # Allow gen-fixtures to create network namespaces and configure
+          # taprio without an explicit sudo step — the guest is already root.
+          security.wrappers = {};
+
+          # ── gen-fixtures systemd service ─────────────────────────────────
+          #
+          # Runs once at boot, writes the four fixture files to /fixtures
+          # (the 9p share), then powers the system off.
+
+          systemd.services.gen-fixtures = {
+            description = "spar trace-topology fixture generator";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" "local-fs.target" ];
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = false;
+              ExecStart = "${gen-fixtures}/bin/gen-fixtures /fixtures";
+              # Power off after gen-fixtures exits (success or failure).
+              ExecStartPost = "${pkgs.systemd}/bin/systemctl poweroff --force";
+              StandardOutput = "journal+console";
+              StandardError = "journal+console";
+            };
+          };
+
+          # Serial console for QEMU -serial mon:stdio — lets the CI log
+          # show kernel + service output without a graphical window.
+          services.getty.autologinUser = null;
+          systemd.services."serial-getty@ttyS0".enable = true;
+
+          system.stateVersion = "24.05";
+        })
+      ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- **`crates/spar-trace-topology/src/bin/fixture-vm.rs`** — Rust binary that creates a CoW qcow2 overlay, boots `qemu-system-x86_64` with `-enable-kvm -nographic` and a virtio-9p share (`mount_tag=fixtures`), waits ≤15 min for the guest to power off, then asserts all four fixture files are present and non-empty. A `--verify <dir>` mode round-trips each file through the `spar-trace-topology` ingest parsers. RAII `OverlayFile` and `QemuChild` guards clean up unconditionally on drop.
- **`tools/fixture-vm/flake.nix`** — NixOS guest image: `linuxPackages_latest` (includes `sch_taprio`/`CLOCK_TAI`), fixture toolchain (`iproute2`, `lldpd`, `linuxptp`, `tcpdump`, `tshark`), `gen-fixtures` built via `rustPlatform.buildRustPackage` (approach **a** — flake-native, correct glibc/loader path). Systemd oneshot service runs `gen-fixtures /fixtures` then `systemctl poweroff --force`. Built inside a digest-pinned rootless `podman` container (`docker.io/nixos/nix@sha256:4aba8f0…`) with `--device /dev/kvm`.
- **`.github/workflows/trace-fixtures.yml`** — nightly (`02:30 UTC`) + `workflow_dispatch`; builds qcow2 via podman, `cargo build --bins`, boots VM, verifies with `tshark -r capture.pcapng`, runs `--verify`, uploads all four fixtures as `actions/upload-artifact@v4`.
- **`artifacts/`** — `REQ-FIXTURE-VM-001` (requirement, implemented, v0110) + `TEST-FIXTURE-VM` (feature, passing, satisfies REQ). `rivet validate` passes.

## gen-fixtures approach

Chose **(a) flake-built** via `rustPlatform.buildRustPackage`. NixOS has a non-standard dynamic linker path; a glibc binary built on Ubuntu will not run there without patching. Building inside the flake gives the correct NixOS-native binary, pins the entire closure in `flake.lock`, and avoids a separate musl cross-compilation step on the host.

## QEMU invocation

```
qemu-system-x86_64
  -enable-kvm
  -nographic
  -smp 2 -m 1G
  -drive file=<overlay.qcow2>,format=qcow2,if=virtio
  -virtfs local,path=<fixture-output-dir>,mount_tag=fixtures,security_model=none
  -serial mon:stdio
```

Overlay created with `qemu-img create -f qcow2 -b <base.qcow2> -F qcow2 <overlay.qcow2>`. Deleted on drop via `OverlayFile`.

## What was verified locally

- `cargo build -p spar-trace-topology --bins` — **clean** (both `gen-fixtures` and `fixture-vm`)
- `cargo clippy -p spar-trace-topology --all-targets -- -D warnings` — **clean**
- `cargo fmt -p spar-trace-topology -- --check` — **clean**
- `rivet validate` — **PASS** (99 pre-existing warnings, no errors)

## What is unvalidated and awaits the first nightly CI run

- The `nix build` inside the podman container (flake.nix is untested without a Nix install)
- The `flake.lock` generation (`nix flake update` runs as the first step inside the container)
- The NixOS qcow2 boots and mounts the virtio-9p share at `/fixtures`
- The `gen-fixtures.service` systemd oneshot runs and writes the four files
- The guest powers off after service completion
- The `fixture-vm` harness successfully waits for QEMU exit and asserts fixtures
- The `tshark -r capture.pcapng` step reports no errors on a real capture
- End-to-end `--verify` round-trip on real fixture data

The nightly workflow on Smithy's KVM-capable runners is the integration test for all of the above. PR 2 is expected to iterate against CI (as PR 1 did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)