### PR TITLE
fix(trace-fixtures): correct bogus nixos/nix container digest

### DIFF
--- a/.github/workflows/fixture-vm-flake-lock.yml
+++ b/.github/workflows/fixture-vm-flake-lock.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          DIGEST="sha256:4aba8f0048d5af9623dd61d8c8c80d61765c1a8a26f81afb33e28e2a4d5e9dbf"
+          DIGEST="sha256:fd7a5c67d396fe6bddeb9c10779d97541ab3a1b2a9d744df3754a99add4046f1"
           podman run --rm \
             --security-opt label=disable \
             -v "${WORKSPACE}:/spar:Z" \

--- a/.github/workflows/trace-fixtures.yml
+++ b/.github/workflows/trace-fixtures.yml
@@ -68,8 +68,10 @@ jobs:
       # different version.  Update the digest here when a newer Nix release
       # is needed.
       #
-      # sha256 digest of docker.io/nixos/nix:2.24.9 (amd64).
-      # Resolve with: podman manifest inspect docker.io/nixos/nix:2.24.9
+      # sha256 digest of docker.io/nixos/nix:2.24.9 — the multi-arch INDEX
+      # manifest (manifest.list.v2), not a per-arch leaf; podman resolves
+      # the right arch from it. Verified: `podman run <image> nix --version`
+      # → 2.24.9.  Resolve with: podman manifest inspect docker.io/nixos/nix:2.24.9
       #
       # Note: "sandbox = false" in nix.conf drops Nix's in-container build
       # sandbox (not host root — the container is already rootless).
@@ -84,7 +86,7 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          DIGEST="sha256:4aba8f0048d5af9623dd61d8c8c80d61765c1a8a26f81afb33e28e2a4d5e9dbf"
+          DIGEST="sha256:fd7a5c67d396fe6bddeb9c10779d97541ab3a1b2a9d744df3754a99add4046f1"
           podman run --rm \
             --device /dev/kvm \
             --security-opt label=disable \


### PR DESCRIPTION
## Summary

The `docker.io/nixos/nix@sha256:4aba8f00…` digest pinned in both the
trace-fixture workflows **does not exist** — a direct pull returns
`manifest unknown`. Every `podman run` in `trace-fixtures.yml` (the
nightly) and `fixture-vm-flake-lock.yml` would fail at the image-pull
step before doing any work.

- Replaces it with the verified multi-arch **index** digest for
  `nixos/nix:2.24.9` (`sha256:fd7a5c67…`, `manifest.list.v2` — podman
  resolves the right arch from it; a per-arch leaf would be a sharper,
  more fragile pin).
- Confirmed via `podman run <image> nix --version` → `nix (Nix) 2.24.9`.

This unblocks dispatching the `fixture-vm flake.lock` workflow, whose
artifact is the missing `tools/fixture-vm/flake.lock` that the nightly
guards on.

## Test plan

- [ ] Dispatch `fixture-vm flake.lock` after merge — first real exercise
      of the rootless-podman + digest-pinned `nixos/nix` path.
- [ ] Commit the produced `flake.lock` in a follow-up PR; nightly goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)