### PR TITLE
feat(trace-topology): IdentityUnknown reconciliation check (v0.11.0)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1946,6 +1946,28 @@ artifacts:
     status: implemented
     tags: [trace-topology, properties, identity, ip, v0100]
 
+  - id: REQ-TRACE-TOPOLOGY-008
+    type: requirement
+    title: IdentityUnknown reconciliation check (component-borne identities)
+    description: >
+      System shall provide the IdentityUnknown reconciliation check in
+      spar-trace-topology::engine — the first of the five v1
+      deterministic checks. The check builds a DeclaredModel index by
+      walking an instantiated AADL SystemInstance and reading the
+      Spar_Identity::MAC_Address and Spar_Identity::LLDP_Chassis_Id
+      properties of every component, then flags any unicast MAC observed
+      in the PCAPNG capture, or any LLDP neighbor chassis-id observed in
+      the topology snapshot, that no AADL component declares.
+      Group-addressed (multicast / broadcast) MACs are exempt — they
+      reconcile against Multicast_Group, a connection-borne surface.
+      Findings are deterministic: PCAPNG findings first then LLDP
+      findings, each ascending, each distinct identity reported once.
+      Connection-borne identities (Stream_Handle, Multicast_Group,
+      VLAN_ID) and the other four checks are deferred to sibling v0.11.0
+      commits. Per docs/designs/v0.10.0-trace-topology.md §4.1.
+    status: implemented
+    tags: [trace-topology, reconcile, engine, v0110, track-g]
+
   - id: REQ-BINDING-002
     type: requirement
     title: Actual_Processor_Binding accepts nested dotted reference paths

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2539,6 +2539,31 @@ artifacts:
       - type: satisfies
         target: REQ-TRACE-TOPOLOGY-007
 
+  - id: TEST-TRACE-TOPOLOGY-IDENTITY-UNKNOWN
+    type: feature
+    title: IdentityUnknown check flags undeclared MACs and chassis-ids
+    description: >
+      Unit tests in crates/spar-trace-topology/src/engine.rs cover MAC
+      parsing (colon / dash / case), malformed-MAC rejection, the
+      multicast group-bit filter, chassis-id normalisation, the clean
+      path, undeclared-MAC and undeclared-chassis-id findings, the
+      multicast / broadcast exemption, finding dedup + sort determinism,
+      a chassis-id equal to a declared MAC, and ingest-failure surfacing.
+      Integration tests in
+      crates/spar-trace-topology/tests/identity_reconcile.rs exercise
+      DeclaredModel::from_instance against a real instantiated AADL model
+      carrying Spar_Identity properties.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-trace-topology --lib -- engine::tests
+        - run: cargo test -p spar-trace-topology --test identity_reconcile
+    status: passing
+    tags: [trace-topology, reconcile, engine, v0110, track-g]
+    links:
+      - type: satisfies
+        target: REQ-TRACE-TOPOLOGY-008
+
   - id: TEST-BINDING-NESTED-PATH
     type: feature
     title: Nested binding paths resolve correctly

--- a/crates/spar-trace-topology/src/engine.rs
+++ b/crates/spar-trace-topology/src/engine.rs
@@ -1,0 +1,498 @@
+//! Reconciliation engine — the deterministic checks that compare a
+//! declared AADL model against the observed runtime artefact set.
+//!
+//! The v1 design pins five checks (`docs/designs/v0.10.0-trace-topology.md`
+//! §"Five deterministic checks"); v0.10.0 shipped only the
+//! [`ReconcileFinding`](crate::reconcile::ReconcileFinding) type surface.
+//! The v0.11.0 engine lands those checks **incrementally** — each check is
+//! a self-contained, deterministic function so a partial engine is still a
+//! useful, testable engine.
+//!
+//! ## What this module currently implements
+//!
+//! - [`DeclaredModel`] — the index of identities the AADL model declares,
+//!   built once by walking a [`SystemInstance`].
+//! - [`check_identity_unknown`] — the `IdentityUnknown` check (design
+//!   §4.1), restricted in this release to the **component-borne**
+//!   identities: `Spar_Identity::MAC_Address` and
+//!   `Spar_Identity::LLDP_Chassis_Id`, both declared on AADL devices,
+//!   processors, and buses (all of which are `ComponentInstance`s, so
+//!   their property maps are reachable via
+//!   [`SystemInstance::properties_for`]).
+//!
+//! ## Deliberately deferred
+//!
+//! - **Connection-borne identities** — `Stream_Handle`, `Multicast_Group`,
+//!   and `VLAN_ID` are declared on AADL *connections*, not components, so
+//!   they are not reachable through the component property-map surface
+//!   this module uses. They land once the connection-property surfacing
+//!   is settled, in a sibling commit.
+//! - **The other four checks** (`TopologyMissingWiring`, `ConfigDrift`,
+//!   `GptpOutOfBudget`, `BinaryMismatch`) and the orchestrating
+//!   `reconcile()` entry point that composes all five.
+//! - **SARIF 2.1.0 emission** and the **in-toto v1.0 attestation
+//!   envelope** — design §5; later v0.11.0 / v1.0 commits.
+//!
+//! ## Determinism
+//!
+//! Per the design, two runs over byte-identical inputs must produce
+//! byte-identical reports. Every check here collects observed identities
+//! into ordered ([`BTreeSet`]) collections before diffing, so finding
+//! order is a pure function of the input content, never of iteration or
+//! hashing order.
+
+use std::collections::BTreeSet;
+
+use spar_hir_def::instance::SystemInstance;
+
+use crate::identity;
+use crate::ingest::{FrameSource, IngestError, TopologySource};
+use crate::reconcile::ReconcileFinding;
+
+/// An error raised while the reconciliation engine consumes its inputs.
+///
+/// Reconciliation findings are *not* errors — they are the expected
+/// output and travel in the [`TopologyReport`](crate::report::TopologyReport).
+/// A [`ReconcileError`] means the engine could not run the check at all
+/// because an input artefact was missing or malformed; it maps to the
+/// CLI's exit code `2` (input parse failure).
+#[derive(Debug)]
+pub enum ReconcileError {
+    /// An input artefact failed to parse while the engine consumed it.
+    Ingest(IngestError),
+}
+
+impl std::fmt::Display for ReconcileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ingest(e) => write!(f, "input artefact ingest failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ReconcileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Ingest(e) => Some(e),
+        }
+    }
+}
+
+impl From<IngestError> for ReconcileError {
+    fn from(e: IngestError) -> Self {
+        Self::Ingest(e)
+    }
+}
+
+/// Parse a MAC address into its canonical six bytes.
+///
+/// Lenient on presentation: `:` and `-` separators are both accepted and
+/// stripped, and hex digits may be upper or lower case. The cleaned input
+/// must be exactly twelve hex digits — anything else returns `None`.
+///
+/// This is the single normalisation point for MAC comparison: a declared
+/// `Spar_Identity::MAC_Address` and an observed PCAPNG MAC are only ever
+/// compared after both have passed through here, so the comparison is
+/// separator- and case-insensitive by construction.
+#[must_use]
+pub fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let cleaned: String = s.chars().filter(|c| *c != ':' && *c != '-').collect();
+    if cleaned.len() != 12 || !cleaned.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut mac = [0u8; 6];
+    for (i, byte) in mac.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&cleaned[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(mac)
+}
+
+/// Format six bytes as a canonical lower-case colon-separated MAC string.
+fn format_mac(mac: &[u8; 6]) -> String {
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    )
+}
+
+/// `true` when the multicast/group bit (the least-significant bit of the
+/// first octet) is set.
+///
+/// A group-addressed MAC — broadcast `ff:ff:ff:ff:ff:ff`, the IEEE
+/// reserved `01:80:c2:…` range (LLDP, STP), `01:1b:19:…` (gPTP), the IPv4
+/// `01:00:5e:…` and IPv6 `33:33:…` multicast ranges — is *not* a unicast
+/// station identity. Such MACs are reconciled against `Multicast_Group`
+/// declarations, never against `MAC_Address`, so `IdentityUnknown` skips
+/// them. Without this filter every capture would flood findings for the
+/// protocol traffic that any real deployment carries.
+fn is_multicast_mac(mac: &[u8; 6]) -> bool {
+    mac[0] & 0x01 != 0
+}
+
+/// Normalise an LLDP chassis-id for set membership.
+///
+/// A MAC-shaped value is folded to its canonical colon form (so a
+/// chassis-id reported as `AA-BB-CC-DD-EE-FF` matches a declared
+/// `aa:bb:cc:dd:ee:ff`); anything else is trimmed and lower-cased. The
+/// identical normalisation is applied to declared and observed values, so
+/// the comparison is separator- and case-insensitive on both sides.
+fn normalise_chassis_id(s: &str) -> String {
+    let trimmed = s.trim();
+    if let Some(mac) = parse_mac(trimmed) {
+        format_mac(&mac)
+    } else {
+        trimmed.to_ascii_lowercase()
+    }
+}
+
+/// The identities an AADL model declares, indexed for reconciliation.
+///
+/// Built once — typically with [`DeclaredModel::from_instance`] — and then
+/// queried by the checks. The collections are [`BTreeSet`]s so iteration
+/// is ordered, which keeps finding emission deterministic.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeclaredModel {
+    /// Canonical six-byte MACs declared via `Spar_Identity::MAC_Address`.
+    declared_macs: BTreeSet<[u8; 6]>,
+    /// Normalised LLDP chassis-ids declared via
+    /// `Spar_Identity::LLDP_Chassis_Id`.
+    declared_chassis_ids: BTreeSet<String>,
+}
+
+impl DeclaredModel {
+    /// Create an empty model — no declared identities.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a declared `Spar_Identity::MAC_Address`.
+    ///
+    /// A value that does not parse as a MAC is dropped: the engine then
+    /// cannot recognise an observed frame carrying that address and will
+    /// (correctly, conservatively) raise an `IdentityUnknown` finding for
+    /// it — surfacing the malformed AADL declaration rather than masking
+    /// it.
+    pub fn declare_mac(&mut self, mac: &str) {
+        if let Some(m) = parse_mac(mac) {
+            self.declared_macs.insert(m);
+        }
+    }
+
+    /// Record a declared `Spar_Identity::LLDP_Chassis_Id`.
+    pub fn declare_chassis_id(&mut self, chassis_id: &str) {
+        self.declared_chassis_ids
+            .insert(normalise_chassis_id(chassis_id));
+    }
+
+    /// Build the declared model by walking every component instance of an
+    /// instantiated AADL system and reading its `Spar_Identity::*`
+    /// property surface.
+    ///
+    /// Components that declare no identity property simply contribute
+    /// nothing — no component-category filtering is needed.
+    #[must_use]
+    pub fn from_instance(instance: &SystemInstance) -> Self {
+        let mut model = Self::new();
+        for (idx, _component) in instance.all_components() {
+            let props = instance.properties_for(idx);
+            if let Some(mac) = identity::get_mac_address(props) {
+                model.declare_mac(&mac);
+            }
+            if let Some(chassis_id) = identity::get_lldp_chassis_id(props) {
+                model.declare_chassis_id(&chassis_id);
+            }
+        }
+        model
+    }
+
+    /// `true` when `mac` (in any accepted presentation) is declared.
+    #[must_use]
+    pub fn knows_mac(&self, mac: &str) -> bool {
+        parse_mac(mac).is_some_and(|m| self.declared_macs.contains(&m))
+    }
+
+    /// `true` when `chassis_id` is declared, comparing under the same
+    /// normalisation [`declare_chassis_id`](Self::declare_chassis_id) uses.
+    #[must_use]
+    pub fn knows_chassis_id(&self, chassis_id: &str) -> bool {
+        self.declared_chassis_ids
+            .contains(&normalise_chassis_id(chassis_id))
+    }
+}
+
+/// `IdentityUnknown` — design §4.1.
+///
+/// **Pass:** every unicast MAC observed in the frame capture, and every
+/// LLDP neighbor chassis-id observed in the topology snapshot, is declared
+/// by some `Spar_Identity::*` property on the AADL model.
+///
+/// **Fail:** an observed identity has no AADL declaration — one
+/// [`ReconcileFinding::IdentityUnknown`] per distinct unknown identity,
+/// carrying the observed value and the artefact context.
+///
+/// Group-addressed MACs are skipped (see [`is_multicast_mac`]). An LLDP
+/// chassis-id that is itself a declared `MAC_Address` counts as known —
+/// the chassis-id and MAC surfaces name the same physical station.
+///
+/// Findings are deterministic: PCAPNG MAC findings first (ascending by
+/// address), then LLDP chassis-id findings (ascending lexically), each
+/// distinct identity reported exactly once.
+///
+/// # Errors
+///
+/// Returns [`ReconcileError::Ingest`] if the frame capture cannot be read
+/// to completion.
+pub fn check_identity_unknown(
+    declared: &DeclaredModel,
+    frames: &mut dyn FrameSource,
+    topology: &dyn TopologySource,
+) -> Result<Vec<ReconcileFinding>, ReconcileError> {
+    // Collect distinct observed unicast MACs. BTreeSet => ordered, deduped.
+    let mut observed_macs: BTreeSet<[u8; 6]> = BTreeSet::new();
+    for frame in frames.frames() {
+        let frame = frame?;
+        for mac in [frame.mac_src, frame.mac_dst] {
+            if !is_multicast_mac(&mac) {
+                observed_macs.insert(mac);
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+    for mac in &observed_macs {
+        if !declared.declared_macs.contains(mac) {
+            findings.push(ReconcileFinding::IdentityUnknown {
+                observed: format_mac(mac),
+                context: "PCAPNG frame capture".to_string(),
+            });
+        }
+    }
+
+    // Collect distinct observed LLDP chassis-ids, normalised.
+    let mut observed_chassis: BTreeSet<String> = BTreeSet::new();
+    for neighbor in topology.neighbors() {
+        observed_chassis.insert(normalise_chassis_id(&neighbor.remote_chassis_id));
+    }
+    for chassis_id in &observed_chassis {
+        let known = declared.declared_chassis_ids.contains(chassis_id)
+            || parse_mac(chassis_id).is_some_and(|m| declared.declared_macs.contains(&m));
+        if !known {
+            findings.push(ReconcileFinding::IdentityUnknown {
+                observed: chassis_id.clone(),
+                context: "LLDP neighbor snapshot".to_string(),
+            });
+        }
+    }
+
+    Ok(findings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ingest::{CapturedFrame, LldpNeighbor};
+
+    /// In-memory [`FrameSource`] for tests — single-pass, no real I/O.
+    struct VecFrames(Vec<CapturedFrame>);
+
+    impl FrameSource for VecFrames {
+        fn frames(&mut self) -> Box<dyn Iterator<Item = Result<CapturedFrame, IngestError>> + '_> {
+            Box::new(std::mem::take(&mut self.0).into_iter().map(Ok))
+        }
+    }
+
+    /// In-memory [`TopologySource`] for tests.
+    struct VecTopology(Vec<LldpNeighbor>);
+
+    impl TopologySource for VecTopology {
+        fn neighbors(&self) -> &[LldpNeighbor] {
+            &self.0
+        }
+    }
+
+    fn frame(src: [u8; 6], dst: [u8; 6]) -> CapturedFrame {
+        CapturedFrame {
+            mac_src: src,
+            mac_dst: dst,
+            vlan_id: None,
+            pcp: None,
+            timestamp_ns: 0,
+        }
+    }
+
+    fn neighbor(remote_chassis_id: &str) -> LldpNeighbor {
+        LldpNeighbor {
+            local_port: "eth0".to_string(),
+            remote_chassis_id: remote_chassis_id.to_string(),
+            remote_chassis_id_type: "mac".to_string(),
+            remote_port_id: "p1".to_string(),
+            remote_port_id_type: "ifname".to_string(),
+            remote_system_name: None,
+        }
+    }
+
+    #[test]
+    fn parse_mac_accepts_colon_dash_and_case() {
+        let expected = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        assert_eq!(parse_mac("aa:bb:cc:dd:ee:ff"), Some(expected));
+        assert_eq!(parse_mac("AA-BB-CC-DD-EE-FF"), Some(expected));
+        assert_eq!(parse_mac("aabbccddeeff"), Some(expected));
+    }
+
+    #[test]
+    fn parse_mac_rejects_malformed() {
+        assert_eq!(parse_mac("aa:bb:cc:dd:ee"), None); // too short
+        assert_eq!(parse_mac("aa:bb:cc:dd:ee:ff:00"), None); // too long
+        assert_eq!(parse_mac("gg:bb:cc:dd:ee:ff"), None); // non-hex
+        assert_eq!(parse_mac(""), None);
+    }
+
+    #[test]
+    fn is_multicast_mac_detects_group_bit() {
+        assert!(is_multicast_mac(&[0xff; 6])); // broadcast
+        assert!(is_multicast_mac(&[0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e])); // LLDP
+        assert!(is_multicast_mac(&[0x01, 0x1b, 0x19, 0x00, 0x00, 0x00])); // gPTP
+        assert!(!is_multicast_mac(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01])); // unicast
+    }
+
+    #[test]
+    fn normalise_chassis_id_folds_mac_and_lowercases() {
+        assert_eq!(
+            normalise_chassis_id("AA-BB-CC-DD-EE-FF"),
+            "aa:bb:cc:dd:ee:ff"
+        );
+        assert_eq!(normalise_chassis_id("  Core-Switch-1 "), "core-switch-1");
+    }
+
+    #[test]
+    fn identity_unknown_clean_when_all_declared() {
+        let mut model = DeclaredModel::new();
+        model.declare_mac("02:00:00:00:00:01");
+        model.declare_mac("02:00:00:00:00:02");
+        model.declare_chassis_id("core-switch-1");
+
+        let a = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let b = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02];
+        let mut frames = VecFrames(vec![frame(a, b)]);
+        let topology = VecTopology(vec![neighbor("core-switch-1")]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn identity_unknown_flags_undeclared_mac() {
+        let mut model = DeclaredModel::new();
+        model.declare_mac("02:00:00:00:00:01");
+
+        let known = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let unknown = [0x02, 0x00, 0x00, 0x00, 0x00, 0x09];
+        let mut frames = VecFrames(vec![frame(known, unknown)]);
+        let topology = VecTopology(vec![]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        assert_eq!(
+            findings,
+            vec![ReconcileFinding::IdentityUnknown {
+                observed: "02:00:00:00:00:09".to_string(),
+                context: "PCAPNG frame capture".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn identity_unknown_exempts_multicast_and_broadcast() {
+        // Empty model: any unicast MAC would be flagged. The capture only
+        // carries group-addressed traffic, so the report stays clean.
+        let model = DeclaredModel::new();
+        let broadcast = [0xff; 6];
+        let lldp = [0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e];
+        let unicast_src = [0x02, 0x00, 0x00, 0x00, 0x00, 0x07];
+        let mut frames = VecFrames(vec![
+            frame(unicast_src, broadcast),
+            frame(unicast_src, lldp),
+        ]);
+        let topology = VecTopology(vec![]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        // Only the unicast source is flagged; the group destinations are not.
+        assert_eq!(
+            findings,
+            vec![ReconcileFinding::IdentityUnknown {
+                observed: "02:00:00:00:00:07".to_string(),
+                context: "PCAPNG frame capture".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn identity_unknown_dedups_and_sorts() {
+        let model = DeclaredModel::new();
+        let high = [0x02, 0x00, 0x00, 0x00, 0x00, 0x09];
+        let low = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        // `high` observed twice, in reverse address order.
+        let mut frames = VecFrames(vec![frame(high, high), frame(low, low)]);
+        let topology = VecTopology(vec![]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        let observed: Vec<&str> = findings
+            .iter()
+            .map(|f| match f {
+                ReconcileFinding::IdentityUnknown { observed, .. } => observed.as_str(),
+                _ => unreachable!(),
+            })
+            .collect();
+        // Each MAC once, ascending — deterministic regardless of frame order.
+        assert_eq!(observed, ["02:00:00:00:00:01", "02:00:00:00:00:09"]);
+    }
+
+    #[test]
+    fn identity_unknown_flags_undeclared_chassis_id() {
+        let mut model = DeclaredModel::new();
+        model.declare_chassis_id("core-switch-1");
+        let mut frames = VecFrames(vec![]);
+        let topology = VecTopology(vec![neighbor("rogue-switch-9")]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        assert_eq!(
+            findings,
+            vec![ReconcileFinding::IdentityUnknown {
+                observed: "rogue-switch-9".to_string(),
+                context: "LLDP neighbor snapshot".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn identity_unknown_accepts_chassis_id_equal_to_declared_mac() {
+        // A chassis-id of type `mac` names the same station as the
+        // declared MAC_Address — it must not be flagged.
+        let mut model = DeclaredModel::new();
+        model.declare_mac("aa:bb:cc:dd:ee:ff");
+        let mut frames = VecFrames(vec![]);
+        let topology = VecTopology(vec![neighbor("AA:BB:CC:DD:EE:FF")]);
+
+        let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn ingest_failure_surfaces_as_reconcile_error() {
+        struct FailingFrames;
+        impl FrameSource for FailingFrames {
+            fn frames(
+                &mut self,
+            ) -> Box<dyn Iterator<Item = Result<CapturedFrame, IngestError>> + '_> {
+                Box::new(std::iter::once(Err(IngestError::Truncated)))
+            }
+        }
+        let model = DeclaredModel::new();
+        let topology = VecTopology(vec![]);
+        let err = check_identity_unknown(&model, &mut FailingFrames, &topology).unwrap_err();
+        assert!(matches!(
+            err,
+            ReconcileError::Ingest(IngestError::Truncated)
+        ));
+    }
+}

--- a/crates/spar-trace-topology/src/lib.rs
+++ b/crates/spar-trace-topology/src/lib.rs
@@ -27,8 +27,11 @@
 //!   config source (Qcc YANG), and PTP-time source (gPTP). Real
 //!   parsing lands in v0.10.x sibling commits.
 //! - The [`reconcile`] module declares the `ReconcileFinding` enum
-//!   carrying the five deterministic check kinds. The reconciliation
-//!   engine itself ships in v0.11.0.
+//!   carrying the five deterministic check kinds.
+//! - The [`engine`] module hosts the v0.11.0 reconciliation engine —
+//!   the deterministic checks that compare a declared AADL model against
+//!   the observed runtime artefacts. It lands incrementally; see the
+//!   module docs for what is implemented and what is deferred.
 //! - The [`report`] module declares the `TopologyReport` struct that
 //!   collects findings. SARIF emission and the signed in-toto
 //!   attestation predicate (`https://pulseengine.eu/spar-trace-topology/v1`)
@@ -37,12 +40,14 @@
 //! Out of scope for v1: PCAP-classic, BLF, OPC-UA, deep packet
 //! inspection. See the design doc §"Out-of-scope for v1".
 
+pub mod engine;
 pub mod fixtures;
 pub mod identity;
 pub mod ingest;
 pub mod reconcile;
 pub mod report;
 
+pub use engine::{DeclaredModel, ReconcileError, check_identity_unknown, parse_mac};
 pub use ingest::{
     CapturedFrame, FrameSource, GateOperation, GptpJsonPtpTimeSource, IngestError,
     LldpJsonTopologySource, LldpNeighbor, PcapngFrameSource, PortConfig, PtpPortObservation,

--- a/crates/spar-trace-topology/tests/identity_reconcile.rs
+++ b/crates/spar-trace-topology/tests/identity_reconcile.rs
@@ -1,0 +1,144 @@
+//! Integration test for the `IdentityUnknown` reconciliation check.
+//!
+//! Unit tests in `engine.rs` cover the pure check logic against a
+//! hand-built [`DeclaredModel`]. This test exercises the other half: the
+//! [`DeclaredModel::from_instance`] bridge that walks a *real*
+//! instantiated AADL model and reads its `Spar_Identity::*` property
+//! surface — the path the v0.11.0 CLI subcommand will use.
+
+use spar_hir_def::{
+    HirDefDatabase, Name, file_item_tree, instance::SystemInstance, resolver::GlobalScope,
+};
+use spar_trace_topology::engine::{DeclaredModel, check_identity_unknown};
+use spar_trace_topology::ingest::{
+    CapturedFrame, FrameSource, IngestError, LldpNeighbor, TopologySource,
+};
+use spar_trace_topology::reconcile::ReconcileFinding;
+
+/// Two devices, each declaring a `Spar_Identity::MAC_Address`; one also
+/// declares a `Spar_Identity::LLDP_Chassis_Id`. The MAC on `ecu_b` is
+/// written upper-case with `-` separators on purpose — the model must
+/// fold it to canonical form.
+const IDENT_FIXTURE: &str = r#"
+package IdentFixture
+public
+
+  device ecu_a
+    properties
+      Spar_Identity::MAC_Address => "02:00:00:00:00:01";
+  end ecu_a;
+  device implementation ecu_a.impl
+  end ecu_a.impl;
+
+  device ecu_b
+    properties
+      Spar_Identity::MAC_Address     => "02-00-00-00-00-02";
+      Spar_Identity::LLDP_Chassis_Id => "core-switch-1";
+  end ecu_b;
+  device implementation ecu_b.impl
+  end ecu_b.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      a : device ecu_a.impl;
+      b : device ecu_b.impl;
+  end Sys.impl;
+end IdentFixture;
+"#;
+
+fn instantiate(aadl_src: &str, pkg: &str, sys: &str, sys_impl: &str) -> SystemInstance {
+    let db = HirDefDatabase::default();
+    let file = spar_base_db::SourceFile::new(
+        &db,
+        "identity_reconcile.aadl".to_string(),
+        aadl_src.to_string(),
+    );
+    let tree = file_item_tree(&db, file);
+    let scope = GlobalScope::from_trees(vec![tree]);
+    let inst = SystemInstance::instantiate(
+        &scope,
+        &Name::new(pkg),
+        &Name::new(sys),
+        &Name::new(sys_impl),
+    );
+    assert!(
+        inst.component_count() > 0,
+        "instantiation failed; diagnostics: {:?}",
+        inst.diagnostics
+    );
+    inst
+}
+
+struct VecFrames(Vec<CapturedFrame>);
+
+impl FrameSource for VecFrames {
+    fn frames(&mut self) -> Box<dyn Iterator<Item = Result<CapturedFrame, IngestError>> + '_> {
+        Box::new(std::mem::take(&mut self.0).into_iter().map(Ok))
+    }
+}
+
+struct VecTopology(Vec<LldpNeighbor>);
+
+impl TopologySource for VecTopology {
+    fn neighbors(&self) -> &[LldpNeighbor] {
+        &self.0
+    }
+}
+
+fn frame(src: [u8; 6], dst: [u8; 6]) -> CapturedFrame {
+    CapturedFrame {
+        mac_src: src,
+        mac_dst: dst,
+        vlan_id: None,
+        pcp: None,
+        timestamp_ns: 0,
+    }
+}
+
+#[test]
+fn from_instance_reads_spar_identity_property_surface() {
+    let inst = instantiate(IDENT_FIXTURE, "IdentFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+
+    // Both declared MACs are recognised, case- and separator-insensitively.
+    assert!(model.knows_mac("02:00:00:00:00:01"));
+    assert!(model.knows_mac("02:00:00:00:00:02"));
+    assert!(model.knows_chassis_id("CORE-SWITCH-1"));
+    assert!(!model.knows_mac("02:00:00:00:00:ff"));
+}
+
+#[test]
+fn declared_traffic_reconciles_clean() {
+    let inst = instantiate(IDENT_FIXTURE, "IdentFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+
+    let a = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+    let b = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02];
+    let mut frames = VecFrames(vec![frame(a, b)]);
+    let topology = VecTopology(vec![]);
+
+    let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+    assert!(findings.is_empty(), "{findings:?}");
+}
+
+#[test]
+fn undeclared_station_raises_identity_unknown() {
+    let inst = instantiate(IDENT_FIXTURE, "IdentFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+
+    let declared = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+    let rogue = [0x02, 0x00, 0x00, 0x00, 0x00, 0xff];
+    let mut frames = VecFrames(vec![frame(declared, rogue)]);
+    let topology = VecTopology(vec![]);
+
+    let findings = check_identity_unknown(&model, &mut frames, &topology).unwrap();
+    assert_eq!(
+        findings,
+        vec![ReconcileFinding::IdentityUnknown {
+            observed: "02:00:00:00:00:ff".to_string(),
+            context: "PCAPNG frame capture".to_string(),
+        }]
+    );
+}


### PR DESCRIPTION
## Summary

First of the five v1 deterministic checks — the start of the v0.11.0
reconciliation engine (design `docs/designs/v0.10.0-trace-topology.md`
§4.1; contract `docs/contracts/spar-trace-topology-v1.md`).

- New `engine` module:
  - `DeclaredModel` — the declared-identity index, built once by walking
    an instantiated AADL `SystemInstance` and reading every component's
    `Spar_Identity::MAC_Address` / `LLDP_Chassis_Id`.
  - `check_identity_unknown` — flags any unicast MAC observed in a PCAPNG
    capture, or any LLDP neighbor chassis-id, that no AADL component
    declares. Emits `ReconcileFinding::IdentityUnknown`.
  - `parse_mac` / `ReconcileError` — the MAC-normalisation primitive and
    the engine's input-failure error type (CLI exit code 2).
- Group-addressed (multicast / broadcast) MACs are **exempt** — they are
  reconciled against `Multicast_Group`, a connection-borne surface, not
  `MAC_Address`. Without this filter every capture would flood findings
  for LLDP / gPTP / broadcast protocol traffic.
- Findings are **deterministic**: PCAPNG findings then LLDP findings,
  each ascending, each distinct identity reported once — finding order
  is a pure function of input content.

### Deliberately deferred (documented in the module + commit)

- **Connection-borne identities** (`Stream_Handle`, `Multicast_Group`,
  `VLAN_ID`) — declared on AADL *connections*, not components, so not
  reachable through the component property-map surface this module uses.
- The other four checks (`TopologyMissingWiring`, `ConfigDrift`,
  `GptpOutOfBudget`, `BinaryMismatch`), the orchestrating `reconcile()`,
  and SARIF / in-toto emission — sibling v0.11.0 / v1.0 commits.

Artifacts: `REQ-TRACE-TOPOLOGY-008` + `TEST-TRACE-TOPOLOGY-IDENTITY-UNKNOWN`.

## Test plan

- [x] `cargo test -p spar-trace-topology --lib -- engine::tests` — 11 unit tests
- [x] `cargo test -p spar-trace-topology --test identity_reconcile` — 3 integration tests (instantiated AADL)
- [x] `cargo clippy -p spar-trace-topology --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `rivet validate` — 0 broken cross-refs; error/warning totals byte-identical to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)