### PR TITLE
fix(trace-fixtures): require podman label on fixture-vm workflows

### DIFF
--- a/.github/workflows/fixture-vm-flake-lock.yml
+++ b/.github/workflows/fixture-vm-flake-lock.yml
@@ -27,7 +27,11 @@ on:
 jobs:
   resolve-lock:
     name: Resolve flake inputs
-    runs-on: [self-hosted, linux, x64]
+    # `podman` constrains scheduling to a rootless-podman-capable runner
+    # (runner9 at the moment).  The default `[self-hosted, linux, x64]`
+    # set will hit runners without working rootless-podman userns setup
+    # (newuidmap EPERM) — confirmed on runner8 on 2026-05-23.
+    runs-on: [self-hosted, linux, x64, podman]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/trace-fixtures.yml
+++ b/.github/workflows/trace-fixtures.yml
@@ -39,7 +39,12 @@ env:
 jobs:
   generate-fixtures:
     name: Build guest + generate fixtures
-    runs-on: [self-hosted, linux, x64]
+    # `podman` constrains scheduling to a rootless-podman-capable runner
+    # (runner9 at the moment).  KVM access is universal on the fleet, so
+    # no `kvm` label is needed; without `podman` we land on runners whose
+    # rootless userns setup is broken (newuidmap EPERM, runner8 on
+    # 2026-05-23).
+    runs-on: [self-hosted, linux, x64, podman]
 
     steps:
       # ── 1. Checkout ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Both `fixture-vm flake.lock` runs landed on `runner8` and died at the
rootless-podman userns step (`newuidmap: write to uid_map failed:
Operation not permitted`). The image digest is correct; the failure is
in the runner's rootless-podman setup, one layer below the container.

Per smithy, rootless podman is only known-good on `runner9` right now.
This adds `podman` to the `runs-on` label set on both workflows so GHA
schedules only on a podman-capable runner. KVM access is universal on
the fleet, so no `kvm` label is needed on the nightly.

## Test plan

- [ ] Merge, then re-dispatch `fixture-vm flake.lock` — first real
      end-to-end exercise of the rootless-podman + digest-pinned
      `nixos/nix` chain. Artifact `fixture-vm-flake-lock` comes back
      on success.
- [ ] Commit the produced `flake.lock` in a follow-up PR; the nightly
      then goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)