### PR TITLE
feat(trace-topology): GptpOutOfBudget reconciliation check (v0.11.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "serde_json",
  "spar-base-db",
  "spar-hir-def",
+ "spar-network",
  "spar-syntax",
  "tempfile",
 ]

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1968,6 +1968,31 @@ artifacts:
     status: implemented
     tags: [trace-topology, reconcile, engine, v0110, track-g]
 
+  - id: REQ-TRACE-TOPOLOGY-009
+    type: requirement
+    title: GptpOutOfBudget reconciliation check (single-budget case)
+    description: >
+      System shall provide the GptpOutOfBudget reconciliation check in
+      spar-trace-topology::engine — the second of the five v1
+      deterministic checks. The check reads the declared
+      `Spar_TSN::Sync_Error` budget (in picoseconds, via the existing
+      spar-network::tsn::get_sync_error_ps accessor's unit conversion)
+      off every component (bus or processor) of an instantiated AADL
+      SystemInstance, then — if exactly one such budget is declared —
+      flags the owning component when any observed gPTP port's
+      worst-case sync error exceeds it. The finding's `observed_ps`
+      carries the worst-case across all over-budget ports per design
+      §4.4's "worst-case observed error" wording. Multi-budget systems
+      need port→bus ownership mapping (the feature-level
+      `LLDP_Port_Id` surface, deferred with the connection-property
+      surface elsewhere in this module); the check returns no findings
+      in the multi-budget case rather than mis-attributing the owner.
+      Boundary equality (observed == budget) is a pass per §4.4's "does
+      not exceed" wording. Per
+      docs/designs/v0.10.0-trace-topology.md §4.4.
+    status: implemented
+    tags: [trace-topology, reconcile, engine, gptp, v0110, track-g]
+
   - id: REQ-BINDING-002
     type: requirement
     title: Actual_Processor_Binding accepts nested dotted reference paths

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2564,6 +2564,34 @@ artifacts:
       - type: satisfies
         target: REQ-TRACE-TOPOLOGY-008
 
+  - id: TEST-TRACE-TOPOLOGY-GPTP-OUT-OF-BUDGET
+    type: feature
+    title: GptpOutOfBudget flags worst-case ports exceeding the declared Sync_Error budget
+    description: >
+      Unit tests in crates/spar-trace-topology/src/engine.rs cover the
+      clean path (every port below budget), the over-budget flag, the
+      no-budget-declared case (check is N/A), the multi-budget deferred
+      case (no finding emitted, owner cannot be attributed), worst-sample
+      semantics (max across each port's samples — not first / not mean),
+      max-across-violating-ports for the finding's observed_ps,
+      boundary equality (observed == budget is pass per design §4.4),
+      and the empty-samples no-flag case. Integration tests in
+      crates/spar-trace-topology/tests/gptp_out_of_budget.rs exercise
+      DeclaredModel::from_instance against an instantiated AADL model
+      carrying `Spar_TSN::Sync_Error => 1000 ns;` — confirming unit
+      conversion (ns → ps) is applied via the existing
+      spar-network::tsn::get_sync_error_ps accessor.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-trace-topology --lib -- engine::tests::gptp_
+        - run: cargo test -p spar-trace-topology --test gptp_out_of_budget
+    status: passing
+    tags: [trace-topology, reconcile, engine, gptp, v0110, track-g]
+    links:
+      - type: satisfies
+        target: REQ-TRACE-TOPOLOGY-009
+
   - id: TEST-BINDING-NESTED-PATH
     type: feature
     title: Nested binding paths resolve correctly

--- a/crates/spar-trace-topology/Cargo.toml
+++ b/crates/spar-trace-topology/Cargo.toml
@@ -10,6 +10,7 @@ description = "Runtime/declared topology reconciliation for spar (PCAPNG + LLDP 
 spar-hir-def.workspace = true
 spar-base-db.workspace = true
 spar-syntax.workspace = true
+spar-network.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pcap-parser = "0.16"

--- a/crates/spar-trace-topology/src/engine.rs
+++ b/crates/spar-trace-topology/src/engine.rs
@@ -10,8 +10,8 @@
 //!
 //! ## What this module currently implements
 //!
-//! - [`DeclaredModel`] — the index of identities the AADL model declares,
-//!   built once by walking a [`SystemInstance`].
+//! - [`DeclaredModel`] — the index of identities and budgets the AADL
+//!   model declares, built once by walking a [`SystemInstance`].
 //! - [`check_identity_unknown`] — the `IdentityUnknown` check (design
 //!   §4.1), restricted in this release to the **component-borne**
 //!   identities: `Spar_Identity::MAC_Address` and
@@ -19,6 +19,13 @@
 //!   processors, and buses (all of which are `ComponentInstance`s, so
 //!   their property maps are reachable via
 //!   [`SystemInstance::properties_for`]).
+//! - [`check_gptp_out_of_budget`] — the `GptpOutOfBudget` check (design
+//!   §4.4), restricted in this release to the **single-budget** case:
+//!   if exactly one bus or processor declares `Spar_TSN::Sync_Error`,
+//!   every observed gPTP port's worst-case sync error is checked
+//!   against that one budget. Multi-budget systems need port→bus
+//!   ownership, which lives on the same connection-property surface
+//!   deferred elsewhere in this module.
 //!
 //! ## Deliberately deferred
 //!
@@ -27,8 +34,10 @@
 //!   they are not reachable through the component property-map surface
 //!   this module uses. They land once the connection-property surfacing
 //!   is settled, in a sibling commit.
-//! - **The other four checks** (`TopologyMissingWiring`, `ConfigDrift`,
-//!   `GptpOutOfBudget`, `BinaryMismatch`) and the orchestrating
+//! - **Multi-bus `GptpOutOfBudget`** — needs the same connection-property
+//!   surface to map an observed PTP port to its owning bus or processor.
+//! - **The remaining three checks** (`TopologyMissingWiring`,
+//!   `ConfigDrift`, `BinaryMismatch`) and the orchestrating
 //!   `reconcile()` entry point that composes all five.
 //! - **SARIF 2.1.0 emission** and the **in-toto v1.0 attestation
 //!   envelope** — design §5; later v0.11.0 / v1.0 commits.
@@ -41,12 +50,13 @@
 //! order is a pure function of the input content, never of iteration or
 //! hashing order.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use spar_hir_def::instance::SystemInstance;
+use spar_network::tsn::get_sync_error_ps;
 
 use crate::identity;
-use crate::ingest::{FrameSource, IngestError, TopologySource};
+use crate::ingest::{FrameSource, IngestError, PtpTimeSource, TopologySource};
 use crate::reconcile::ReconcileFinding;
 
 /// An error raised while the reconciliation engine consumes its inputs.
@@ -157,6 +167,12 @@ pub struct DeclaredModel {
     /// Normalised LLDP chassis-ids declared via
     /// `Spar_Identity::LLDP_Chassis_Id`.
     declared_chassis_ids: BTreeSet<String>,
+    /// Declared `Spar_TSN::Sync_Error` budgets in picoseconds, keyed by
+    /// component instance path (FQN). Populated for any component — bus
+    /// or processor — that declares the property. The
+    /// [`check_gptp_out_of_budget`] check runs only when exactly one
+    /// entry is present.
+    declared_sync_budgets_ps: BTreeMap<String, u64>,
 }
 
 impl DeclaredModel {
@@ -185,6 +201,14 @@ impl DeclaredModel {
             .insert(normalise_chassis_id(chassis_id));
     }
 
+    /// Record a declared `Spar_TSN::Sync_Error` budget for the
+    /// component at `component_path` (FQN, e.g. `"Sys::net"`), in
+    /// picoseconds.
+    pub fn declare_sync_budget(&mut self, component_path: &str, budget_ps: u64) {
+        self.declared_sync_budgets_ps
+            .insert(component_path.to_string(), budget_ps);
+    }
+
     /// Build the declared model by walking every component instance of an
     /// instantiated AADL system and reading its `Spar_Identity::*`
     /// property surface.
@@ -202,6 +226,10 @@ impl DeclaredModel {
             if let Some(chassis_id) = identity::get_lldp_chassis_id(props) {
                 model.declare_chassis_id(&chassis_id);
             }
+            if let Some(budget_ps) = get_sync_error_ps(props) {
+                let path = instance.component_instance_path(idx);
+                model.declare_sync_budget(&path, budget_ps);
+            }
         }
         model
     }
@@ -218,6 +246,13 @@ impl DeclaredModel {
     pub fn knows_chassis_id(&self, chassis_id: &str) -> bool {
         self.declared_chassis_ids
             .contains(&normalise_chassis_id(chassis_id))
+    }
+
+    /// Look up a declared `Spar_TSN::Sync_Error` budget for the
+    /// component at `component_path`, in picoseconds.
+    #[must_use]
+    pub fn knows_sync_budget(&self, component_path: &str) -> Option<u64> {
+        self.declared_sync_budgets_ps.get(component_path).copied()
     }
 }
 
@@ -288,10 +323,67 @@ pub fn check_identity_unknown(
     Ok(findings)
 }
 
+/// `GptpOutOfBudget` — design §4.4.
+///
+/// **Pass:** the worst-case gPTP synchronization error observed at every
+/// port over the capture window does not exceed the declared
+/// `Spar_TSN::Sync_Error` (in picoseconds) for the bus or processor that
+/// owns the port.
+///
+/// **Fail:** at least one port observed ε > declared budget. Emits a
+/// single [`ReconcileFinding::GptpOutOfBudget`] for the owning component
+/// carrying the worst-case error observed across all of its over-budget
+/// ports — per the design's "worst-case observed error" wording.
+///
+/// This release supports the **single-budget** case only: if exactly one
+/// AADL component declares `Spar_TSN::Sync_Error`, every observed PTP
+/// port is checked against that one budget. Zero-budget or
+/// multi-budget cases return no findings (the multi-budget case is
+/// deferred — it needs the feature-level `LLDP_Port_Id` surface to map
+/// an observed port to its owning bus, the same connection-property
+/// surface deferred by `IdentityUnknown` and the other open checks).
+/// Choosing the most restrictive declared budget would be unsound: the
+/// finding's `bus_or_processor` field names the *owner*, and naming the
+/// strict-budget bus as the owner of an over-budget port that actually
+/// belongs to a lax bus would mis-attribute the failure.
+pub fn check_gptp_out_of_budget(
+    declared: &DeclaredModel,
+    ptp: &dyn PtpTimeSource,
+) -> Vec<ReconcileFinding> {
+    if declared.declared_sync_budgets_ps.len() != 1 {
+        return Vec::new();
+    }
+    // Safe: len == 1.
+    let (owner, &budget_ps) = declared.declared_sync_budgets_ps.iter().next().unwrap();
+
+    let mut worst_violation_ps: Option<u64> = None;
+    for port in ptp.ports() {
+        let worst_ns = port
+            .samples
+            .iter()
+            .map(|s| s.sync_error_ns)
+            .max()
+            .unwrap_or(0);
+        let worst_ps = worst_ns.saturating_mul(1_000);
+        if worst_ps > budget_ps {
+            worst_violation_ps = Some(worst_violation_ps.map_or(worst_ps, |m| m.max(worst_ps)));
+        }
+    }
+
+    match worst_violation_ps {
+        Some(observed_ps) => vec![ReconcileFinding::GptpOutOfBudget {
+            bus_or_processor: owner.clone(),
+            budget_ps,
+            observed_ps,
+        }],
+        None => Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ingest::{CapturedFrame, LldpNeighbor};
+    use crate::ingest::{CapturedFrame, LldpNeighbor, PtpPortObservation, PtpSample};
 
     /// In-memory [`FrameSource`] for tests — single-pass, no real I/O.
     struct VecFrames(Vec<CapturedFrame>);
@@ -329,6 +421,37 @@ mod tests {
             remote_port_id: "p1".to_string(),
             remote_port_id_type: "ifname".to_string(),
             remote_system_name: None,
+        }
+    }
+
+    /// In-memory [`PtpTimeSource`] for tests.
+    struct VecPtp {
+        ports: Vec<PtpPortObservation>,
+    }
+
+    impl PtpTimeSource for VecPtp {
+        fn grandmaster(&self) -> Option<&str> {
+            None
+        }
+        fn domain(&self) -> Option<u8> {
+            None
+        }
+        fn ports(&self) -> &[PtpPortObservation] {
+            &self.ports
+        }
+    }
+
+    fn ptp_port(name: &str, sync_errors_ns: &[u64]) -> PtpPortObservation {
+        PtpPortObservation {
+            name: name.to_string(),
+            samples: sync_errors_ns
+                .iter()
+                .enumerate()
+                .map(|(i, &e)| PtpSample {
+                    timestamp_ns: i as u64,
+                    sync_error_ns: e,
+                })
+                .collect(),
         }
     }
 
@@ -494,5 +617,128 @@ mod tests {
             err,
             ReconcileError::Ingest(IngestError::Truncated)
         ));
+    }
+
+    // ── GptpOutOfBudget ──────────────────────────────────────────────
+
+    #[test]
+    fn gptp_clean_when_all_ports_below_budget() {
+        // Budget = 1_000_000 ps = 1 us; observed worst = 500 ns = 500_000 ps.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[200, 500, 300])],
+        };
+
+        let findings = check_gptp_out_of_budget(&model, &ptp);
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn gptp_flags_port_over_budget() {
+        // Budget = 1000 ps; observed worst = 2000 ns × 1000 = 2_000_000 ps.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[1, 2000, 3])],
+        };
+
+        let findings = check_gptp_out_of_budget(&model, &ptp);
+        assert_eq!(
+            findings,
+            vec![ReconcileFinding::GptpOutOfBudget {
+                bus_or_processor: "Sys::net".to_string(),
+                budget_ps: 1_000,
+                observed_ps: 2_000_000,
+            }]
+        );
+    }
+
+    #[test]
+    fn gptp_no_finding_when_no_budget_declared() {
+        // Empty declared model — check is N/A, returns empty.
+        let model = DeclaredModel::new();
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[5_000_000_000])],
+        };
+        assert!(check_gptp_out_of_budget(&model, &ptp).is_empty());
+    }
+
+    #[test]
+    fn gptp_deferred_when_multiple_components_declare_budget() {
+        // Multi-budget — owner ambiguous without port→bus mapping; deferred.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net_a", 1_000);
+        model.declare_sync_budget("Sys::net_b", 100_000_000_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[1_000_000])],
+        };
+        assert!(check_gptp_out_of_budget(&model, &ptp).is_empty());
+    }
+
+    #[test]
+    fn gptp_uses_worst_sample_per_port() {
+        // Worst sample 1500 ns × 1000 = 1_500_000 ps > 1_000_000 budget.
+        // If the engine averaged or took the first sample it would pass.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[100, 200, 1500, 250])],
+        };
+        let findings = check_gptp_out_of_budget(&model, &ptp);
+        assert_eq!(findings.len(), 1);
+        match &findings[0] {
+            ReconcileFinding::GptpOutOfBudget { observed_ps, .. } => {
+                assert_eq!(*observed_ps, 1_500_000);
+            }
+            other => panic!("unexpected finding: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gptp_reports_max_across_all_violating_ports() {
+        // Two ports both exceed budget; finding's observed_ps is the
+        // greater of the two worst-cases — per design §4.4.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000_000);
+        let ptp = VecPtp {
+            ports: vec![
+                ptp_port("swp1", &[1200]),
+                ptp_port("swp2", &[5000]),
+                ptp_port("swp3", &[500]), // below budget — ignored
+            ],
+        };
+        let findings = check_gptp_out_of_budget(&model, &ptp);
+        assert_eq!(findings.len(), 1);
+        match &findings[0] {
+            ReconcileFinding::GptpOutOfBudget { observed_ps, .. } => {
+                assert_eq!(*observed_ps, 5_000_000);
+            }
+            other => panic!("unexpected finding: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gptp_observed_equal_to_budget_is_pass() {
+        // Boundary: per design §4.4, ε does not exceed budget — equality
+        // is pass, not fail.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[1000])], // 1000 ns × 1000 = 1_000_000 ps
+        };
+        assert!(check_gptp_out_of_budget(&model, &ptp).is_empty());
+    }
+
+    #[test]
+    fn gptp_port_with_no_samples_does_not_flag() {
+        // Ports with no observations contribute zero — must not synthesise
+        // a finding from absence of data.
+        let mut model = DeclaredModel::new();
+        model.declare_sync_budget("Sys::net", 1_000_000);
+        let ptp = VecPtp {
+            ports: vec![ptp_port("swp1", &[])],
+        };
+        assert!(check_gptp_out_of_budget(&model, &ptp).is_empty());
     }
 }

--- a/crates/spar-trace-topology/src/lib.rs
+++ b/crates/spar-trace-topology/src/lib.rs
@@ -47,7 +47,9 @@ pub mod ingest;
 pub mod reconcile;
 pub mod report;
 
-pub use engine::{DeclaredModel, ReconcileError, check_identity_unknown, parse_mac};
+pub use engine::{
+    DeclaredModel, ReconcileError, check_gptp_out_of_budget, check_identity_unknown, parse_mac,
+};
 pub use ingest::{
     CapturedFrame, FrameSource, GateOperation, GptpJsonPtpTimeSource, IngestError,
     LldpJsonTopologySource, LldpNeighbor, PcapngFrameSource, PortConfig, PtpPortObservation,

--- a/crates/spar-trace-topology/tests/gptp_out_of_budget.rs
+++ b/crates/spar-trace-topology/tests/gptp_out_of_budget.rs
@@ -1,0 +1,127 @@
+//! Integration test for the `GptpOutOfBudget` reconciliation check.
+//!
+//! Unit tests in `engine.rs` cover the pure check logic against a
+//! hand-built [`DeclaredModel`]. This test exercises the other half:
+//! [`DeclaredModel::from_instance`] reading `Spar_TSN::Sync_Error` off a
+//! real instantiated AADL model, with unit conversion (the property is
+//! `aadlinteger units Time_Units` — a value written as `1000 ns` must
+//! materialise as 1_000_000 picoseconds in the declared model).
+
+use spar_hir_def::{
+    HirDefDatabase, Name, file_item_tree, instance::SystemInstance, resolver::GlobalScope,
+};
+use spar_trace_topology::engine::{DeclaredModel, check_gptp_out_of_budget};
+use spar_trace_topology::ingest::{PtpPortObservation, PtpSample, PtpTimeSource};
+use spar_trace_topology::reconcile::ReconcileFinding;
+
+const GPTP_FIXTURE: &str = r#"
+package GptpFixture
+public
+
+  bus tsn_bus
+    properties
+      Spar_TSN::Sync_Error => 1000 ns;
+  end tsn_bus;
+  bus implementation tsn_bus.impl
+  end tsn_bus.impl;
+
+  system Sys
+  end Sys;
+  system implementation Sys.impl
+    subcomponents
+      net : bus tsn_bus.impl;
+  end Sys.impl;
+end GptpFixture;
+"#;
+
+fn instantiate(aadl_src: &str, pkg: &str, sys: &str, sys_impl: &str) -> SystemInstance {
+    let db = HirDefDatabase::default();
+    let file = spar_base_db::SourceFile::new(
+        &db,
+        "gptp_out_of_budget.aadl".to_string(),
+        aadl_src.to_string(),
+    );
+    let tree = file_item_tree(&db, file);
+    let scope = GlobalScope::from_trees(vec![tree]);
+    let inst = SystemInstance::instantiate(
+        &scope,
+        &Name::new(pkg),
+        &Name::new(sys),
+        &Name::new(sys_impl),
+    );
+    assert!(
+        inst.component_count() > 0,
+        "instantiation failed; diagnostics: {:?}",
+        inst.diagnostics
+    );
+    inst
+}
+
+struct VecPtp(Vec<PtpPortObservation>);
+
+impl PtpTimeSource for VecPtp {
+    fn grandmaster(&self) -> Option<&str> {
+        None
+    }
+    fn domain(&self) -> Option<u8> {
+        None
+    }
+    fn ports(&self) -> &[PtpPortObservation] {
+        &self.0
+    }
+}
+
+fn port(name: &str, sync_errors_ns: &[u64]) -> PtpPortObservation {
+    PtpPortObservation {
+        name: name.to_string(),
+        samples: sync_errors_ns
+            .iter()
+            .enumerate()
+            .map(|(i, &e)| PtpSample {
+                timestamp_ns: i as u64,
+                sync_error_ns: e,
+            })
+            .collect(),
+    }
+}
+
+/// FQN spar produces for the bus subcomponent — `<system-impl>/<subcomp>`.
+const BUS_PATH: &str = "Sys.impl/net";
+
+#[test]
+fn from_instance_reads_sync_error_with_unit_conversion() {
+    let inst = instantiate(GPTP_FIXTURE, "GptpFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+
+    // `Spar_TSN::Sync_Error => 1000 ns` must materialise as 1_000_000 ps.
+    assert_eq!(model.knows_sync_budget(BUS_PATH), Some(1_000_000));
+}
+
+#[test]
+fn observed_below_budget_reconciles_clean() {
+    let inst = instantiate(GPTP_FIXTURE, "GptpFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+    // Budget = 1_000_000 ps; worst observed = 500 ns × 1000 = 500_000 ps.
+    let ptp = VecPtp(vec![port("swp1", &[200, 500, 300])]);
+
+    let findings = check_gptp_out_of_budget(&model, &ptp);
+    assert!(findings.is_empty(), "{findings:?}");
+}
+
+#[test]
+fn observed_above_budget_raises_gptp_out_of_budget() {
+    let inst = instantiate(GPTP_FIXTURE, "GptpFixture", "Sys", "impl");
+    let model = DeclaredModel::from_instance(&inst);
+    // Worst observed = 1500 ns × 1000 = 1_500_000 ps > 1_000_000.
+    let ptp = VecPtp(vec![port("swp1", &[1500])]);
+
+    let findings = check_gptp_out_of_budget(&model, &ptp);
+    assert_eq!(
+        findings,
+        vec![ReconcileFinding::GptpOutOfBudget {
+            bus_or_processor: BUS_PATH.to_string(),
+            budget_ps: 1_000_000,
+            observed_ps: 1_500_000,
+        }]
+    );
+}


### PR DESCRIPTION
## Summary

Second of the five v1 deterministic checks — extends the v0.11.0
reconciliation engine (design `docs/designs/v0.10.0-trace-topology.md`
§4.4; contract `docs/contracts/spar-trace-topology-v1.md`).

- Extends `DeclaredModel` with `declared_sync_budgets_ps` — the
  declared `Spar_TSN::Sync_Error` budget per component (FQN keyed),
  populated from a `SystemInstance` via the existing
  `spar-network::tsn::get_sync_error_ps` accessor's unit conversion
  (`1000 ns` → `1_000_000` ps).
- New `check_gptp_out_of_budget` — flags the owning bus / processor
  when any observed gPTP port's worst-case sync error exceeds the
  budget. Emits a single finding per owner carrying the max observed
  across over-budget ports, matching design §4.4's "worst-case
  observed error" wording.
- **Single-budget-only scope**, documented in the module + this PR.
  Multi-budget needs the feature-level `LLDP_Port_Id` surface that
  remains deferred; emitting findings under a guessed-strict owner
  would mis-attribute, so the check is a no-op in that case.

Adds `spar-network` as a workspace dep of `spar-trace-topology`
(single source of truth for the `Spar_TSN::*` accessors — no cycle:
`spar-network` doesn't depend on `spar-trace-topology`).

## Falsifiable claims, each test-pinned

| Claim | Test |
|---|---|
| `Sync_Error => 1000 ns` materialises as `1_000_000` ps | `from_instance_reads_sync_error_with_unit_conversion` |
| Worst-case ns × 1000 > budget → one finding | `gptp_flags_port_over_budget`, `observed_above_budget_raises_gptp_out_of_budget` |
| Worst-case ≤ budget → zero findings | `gptp_clean_when_all_ports_below_budget`, `observed_below_budget_reconciles_clean` |
| Zero declared budgets → zero findings | `gptp_no_finding_when_no_budget_declared` |
| Multiple declared budgets → zero findings (deferred) | `gptp_deferred_when_multiple_components_declare_budget` |
| `observed_ps` = max over all violating ports | `gptp_reports_max_across_all_violating_ports` |
| Per-port worst-case = max of samples (not first / mean) | `gptp_uses_worst_sample_per_port` |
| `observed == budget` is pass (≤) | `gptp_observed_equal_to_budget_is_pass` |
| Empty-samples port → no finding | `gptp_port_with_no_samples_does_not_flag` |

Artifacts: `REQ-TRACE-TOPOLOGY-009` + `TEST-TRACE-TOPOLOGY-GPTP-OUT-OF-BUDGET`.

## Test plan

- [x] `cargo test -p spar-trace-topology --lib -- engine::tests::gptp_` — 8 unit tests
- [x] `cargo test -p spar-trace-topology --test gptp_out_of_budget` — 3 integration tests
- [x] `cargo clippy -p spar-trace-topology --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `rivet validate` — 0 broken cross-refs; totals byte-identical to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)