### PR TITLE
chore(release): bump to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1479,14 +1479,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Workspace bump 0.10.0 → 0.11.0 across all 22 spar crates (via
`[workspace.package].version`) plus the VS Code extension's
`package.json` — the two version surfaces the release workflow's
`check-versions` job compares against the tag.

## What v0.11.0 ships, since v0.10.0

### Trace-topology reconciliation engine (incremental rollout)

- `#239` — `IdentityUnknown` check (PR 3a; component-borne MAC + chassis-id)
- `#241` — `GptpOutOfBudget` check (PR 3b; single-budget case)

### Trace-topology fixture pipeline

- `#233` — Rust `gen-fixtures` tool (netns + TSN, RAII teardown)
- `#234` — NixOS guest + QEMU harness for fixture generation
- `#238` — corrected `nixos/nix` container digest (`fd7a5c67…`, multi-arch index)
- `#240` — `podman` runner label so workflows schedule on the only rootless-podman-capable runner in the fleet (runner9)

### Codegen

- `#232` — `--format wit` emits only WIT (strict-filter; no Rust/Bazel workspace leakage)
- `#242` — per-category file-count summary + hint when WIT was requested but the model has no `process` subcomponents *(in-flight at bump time; auto-merge armed — will land before tag)*

### Release flow

- `#244` — standardise on the synth reference: `actions/attest-build-provenance@v2` + sigstore `cosign sign-blob` (v2.4.1) over `SHA256SUMS.txt`, `build-env.txt`. **The v0.11.0 release is the first one to exercise the standardised cosign + SLSA chain end-to-end.**

## Verification after release lands

```
cosign verify-blob \
  --certificate-identity-regexp \
    'https://github.com/pulseengine/spar/.github/workflows/release.yml@.*' \
  --certificate-oidc-issuer \
    'https://token.actions.githubusercontent.com' \
  --bundle SHA256SUMS.txt.cosign.bundle SHA256SUMS.txt

gh attestation verify spar-v0.11.0-<triple>.tar.gz --repo pulseengine/spar
```

## Test plan

- [x] `cargo check --workspace` clean post-bump (all 22 crates moved to 0.11.0 in `Cargo.lock`)
- [x] `vscode-spar/package.json` version matches workspace
- [ ] `release.yml` `check-versions` job will validate `tag == Cargo.toml == package.json` when tagged
- [ ] On tag: cosign + SLSA chain exercised end-to-end against the standardised flow (this release is its smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)