### PR TITLE
fix(analysis): resolve multi-level dotted binding reference paths

### DIFF
--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2612,6 +2612,32 @@ artifacts:
       - type: satisfies
         target: REQ-BINDING-002
 
+  - id: TEST-BINDING-DOTTED-PATH-ANALYSIS
+    type: feature
+    title: Binding analyses resolve multi-level dotted reference paths
+    description: >
+      Regression for the ee_system.poc user report: the binding_rules
+      and binding_check analyses resolved Actual_Processor_Binding /
+      Actual_Memory_Binding reference targets by bare name, so a
+      multi-level subcomponent reference like `reference
+      (cvc.soc.helix_linux)` was wrongly reported as "does not exist in
+      the instance model" (and skipped category validation). Both
+      analyses now resolve through SystemInstance::resolve_dotted_path,
+      honouring REQ-BINDING-002 at the analysis layer. Tests in
+      crates/spar-analysis/src/binding_rules.rs:
+      nested_dotted_processor_binding_resolves (no false not-found) and
+      nested_dotted_binding_to_nonprocessor_still_flags_category
+      (category checking preserved through dotted resolution).
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-analysis --lib -- binding_rules::tests
+    status: passing
+    tags: [binding, analysis, v0111]
+    links:
+      - type: satisfies
+        target: REQ-BINDING-002
+
   - id: TEST-CLASSIFIER-MATCH-DELEGATION
     type: feature
     title: Delegation connections accept matching directions, peer connections require opposing

--- a/crates/spar-analysis/src/binding_check.rs
+++ b/crates/spar-analysis/src/binding_check.rs
@@ -184,33 +184,34 @@ fn validate_binding_target(
         None => return, // Can't parse the reference
     };
 
-    // Try to find the target in the instance model
-    for (_idx, comp) in instance.all_components() {
-        if comp.name.as_str().eq_ignore_ascii_case(target_name) {
-            if !allowed_categories.contains(&comp.category) {
-                diags.push(AnalysisDiagnostic {
-                    severity: Severity::Error,
-                    message: format!(
-                        "{} references '{}' which is a {} component, \
-                         expected one of: {}",
-                        binding_name,
-                        target_name,
-                        comp.category,
-                        allowed_categories
-                            .iter()
-                            .map(|c| c.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
-                    path: path.to_vec(),
-                    analysis: "binding_check".to_string(),
-                });
-            }
-            return;
+    // Resolve the target by dotted instance path (handles multi-level
+    // subcomponent references like `cvc.soc.helix_linux`) as well as by
+    // bare name. A bare-name-only match silently skips category
+    // validation for any nested-path binding. See REQ-BINDING-002.
+    if let Some(idx) = instance.resolve_dotted_path(target_name) {
+        let comp = instance.component(idx);
+        if !allowed_categories.contains(&comp.category) {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Error,
+                message: format!(
+                    "{} references '{}' which is a {} component, \
+                     expected one of: {}",
+                    binding_name,
+                    target_name,
+                    comp.category,
+                    allowed_categories
+                        .iter()
+                        .map(|c| c.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                path: path.to_vec(),
+                analysis: "binding_check".to_string(),
+            });
         }
     }
     // Target not found in instance model — not an error, might be
-    // in a different part of the model or use a different naming scheme
+    // in a different part of the model or use a different naming scheme.
 }
 
 #[cfg(test)]

--- a/crates/spar-analysis/src/binding_rules.rs
+++ b/crates/spar-analysis/src/binding_rules.rs
@@ -146,13 +146,15 @@ fn check_binding_target(
         None => return,
     };
 
-    // BIND-TARGET-EXISTS: Try to find the target
-    let mut found = false;
-    for (_idx, comp) in instance.all_components() {
-        if comp.name.as_str().eq_ignore_ascii_case(target_name) {
-            found = true;
-
+    // BIND-TARGET-EXISTS: resolve the reference by dotted instance path
+    // (`reference (cvc.soc.helix_linux)`) as well as by bare name. A
+    // bare-name-only match wrongly reports multi-level subcomponent
+    // references as "does not exist" — they name a component by its
+    // containment path, not a top-level identifier. See REQ-BINDING-002.
+    match instance.resolve_dotted_path(target_name) {
+        Some(idx) => {
             // BIND-TARGET-CATEGORY: Check that the category is appropriate
+            let comp = instance.component(idx);
             if !allowed_categories.contains(&comp.category) {
                 diags.push(AnalysisDiagnostic {
                     severity: Severity::Error,
@@ -171,20 +173,18 @@ fn check_binding_target(
                     analysis: "binding_rules".to_string(),
                 });
             }
-            break;
         }
-    }
-
-    if !found {
-        diags.push(AnalysisDiagnostic {
-            severity: Severity::Error,
-            message: format!(
-                "{} references '{}' which does not exist in the instance model",
-                binding_name, target_name
-            ),
-            path: path.to_vec(),
-            analysis: "binding_rules".to_string(),
-        });
+        None => {
+            diags.push(AnalysisDiagnostic {
+                severity: Severity::Error,
+                message: format!(
+                    "{} references '{}' which does not exist in the instance model",
+                    binding_name, target_name
+                ),
+                path: path.to_vec(),
+                analysis: "binding_rules".to_string(),
+            });
+        }
     }
 }
 
@@ -694,5 +694,81 @@ mod tests {
         assert_eq!(extract_reference_target("reference(mem)"), Some("mem"));
         assert_eq!(extract_reference_target("invalid"), None);
         assert_eq!(extract_reference_target(""), None);
+    }
+
+    // ── BIND-TARGET-EXISTS: multi-level dotted reference paths ──────
+
+    #[test]
+    fn nested_dotted_processor_binding_resolves() {
+        // Regression (ee_system.poc user report): `reference
+        // (cvc.soc.helix_linux)` names a processor by its multi-level
+        // containment path, not a top-level identifier. A bare-name match
+        // wrongly reported it as "does not exist". It must resolve via the
+        // dotted instance path.
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let cvc = b.add_component("cvc", ComponentCategory::System, Some(root));
+        let soc = b.add_component("soc", ComponentCategory::System, Some(cvc));
+        let helix = b.add_component("helix_linux", ComponentCategory::Processor, Some(soc));
+        let proc = b.add_component("proc", ComponentCategory::Process, Some(root));
+        let thread = b.add_component("worker", ComponentCategory::Thread, Some(proc));
+        b.set_children(root, vec![cvc, proc]);
+        b.set_children(cvc, vec![soc]);
+        b.set_children(soc, vec![helix]);
+        b.set_children(proc, vec![thread]);
+        b.set_property(
+            thread,
+            "Deployment_Properties",
+            "Actual_Processor_Binding",
+            "reference (cvc.soc.helix_linux)",
+        );
+
+        let inst = b.build(root);
+        let diags = BindingRuleAnalysis.analyze(&inst);
+        let not_found: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("does not exist in the instance model"))
+            .collect();
+        assert!(
+            not_found.is_empty(),
+            "nested dotted binding path should resolve, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn nested_dotted_binding_to_nonprocessor_still_flags_category() {
+        // Dotted-path resolution must not lose category checking: binding a
+        // thread to a nested *memory* component is still a category error.
+        let mut b = TestBuilder::new();
+        let root = b.add_component("root", ComponentCategory::System, None);
+        let cvc = b.add_component("cvc", ComponentCategory::System, Some(root));
+        let mem = b.add_component("dram", ComponentCategory::Memory, Some(cvc));
+        let proc = b.add_component("proc", ComponentCategory::Process, Some(root));
+        let thread = b.add_component("worker", ComponentCategory::Thread, Some(proc));
+        b.set_children(root, vec![cvc, proc]);
+        b.set_children(cvc, vec![mem]);
+        b.set_children(proc, vec![thread]);
+        b.set_property(
+            thread,
+            "Deployment_Properties",
+            "Actual_Processor_Binding",
+            "reference (cvc.dram)",
+        );
+
+        let inst = b.build(root);
+        let diags = BindingRuleAnalysis.analyze(&inst);
+        let cat_err: Vec<_> = diags
+            .iter()
+            .filter(|d| {
+                d.severity == Severity::Error
+                    && d.message
+                        .contains("Actual_Processor_Binding target 'cvc.dram'")
+            })
+            .collect();
+        assert_eq!(
+            cat_err.len(),
+            1,
+            "binding a thread to a nested memory component should flag category: {diags:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

User report (`ee_system.poc`): `spar analyze` produced **14 spurious** `Actual_Processor_Binding references 'cvc.soc.helix_linux' which does not exist in the instance model` errors for valid bindings.

**Root cause:** `binding_rules::check_binding_target` and `binding_check::validate_binding_target` matched the reference target by **bare name** (`comp.name == target`). A multi-level subcomponent reference names a component by its *containment path*, not a top-level identifier — `extract_reference_target` returns the full dotted string `cvc.soc.helix_linux`, and no component is *named* that (it's `helix_linux` at path `.../cvc/soc/helix_linux`), so the match always failed.

**Fix:** route both analyses through `SystemInstance::resolve_dotted_path`, which converts dots to `/` and suffix-matches against the full instance path (and still resolves bare names). This applies `REQ-BINDING-002` ("nested dotted reference paths") at the analysis layer — it had been implemented only in the RTA binding resolution. `binding_check` keeps its lenient not-found behaviour but now does category validation for nested-path targets (previously skipped silently).

This is a clean-room-verified finding: I confirmed the bug against the code (not just the forwarded report) — `resolve_dotted_path` already existed and handles the case; the two analyses simply weren't using it.

## Note on the rest of the `ee_system.poc` report

The other categories in that run are **not** spar bugs:
- `thread unbound (15)` — the model genuinely lacks `Actual_Processor_Binding` on those PM threads (a model fix, not a spar fix).
- connectivity / scheduling / emv2 / arinc653 warnings — informational (unconnected features, missing Period/WCET, no EMV2 models declared).

Only the dotted-path false-negatives were a spar defect; this PR fixes exactly that.

## Test plan

- [x] `cargo test -p spar-analysis --lib` — 874 pass incl. 2 new regressions:
  - `nested_dotted_processor_binding_resolves` — `reference (cvc.soc.helix_linux)` resolves, no false not-found
  - `nested_dotted_binding_to_nonprocessor_still_flags_category` — category check preserved through dotted resolution
- [x] `cargo clippy -p spar-analysis` — clean
- [x] `cargo fmt --check` — clean
- [x] `rivet validate` — 0 broken cross-refs; byte-identical to baseline

Artifacts: `TEST-BINDING-DOTTED-PATH-ANALYSIS` → satisfies `REQ-BINDING-002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)