### PR TITLE
chore(release): bump to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1479,14 +1479,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump 0.11.0 → 0.12.0 (workspace + VS Code extension). Cargo.lock regenerated, 22 workspace crates restamped.

## What v0.12.0 collects
- **fix(analysis)** multi-level dotted binding reference path resolution (#248) — `Actual_Processor_Binding => (reference (cpu.core0))` now resolves through `SystemInstance::resolve_dotted_path` instead of bare-name matching. Ships the `ee_system.poc` binding-path-resolution fix reported by a user.
- **feat(parser)** property-set `applies to (...)` now accepts the `feature`/`port`/`flow`/`mode`/`access`/`parameter`/`connections` owner categories (#247).
- **feat(interop)** AADL plug-fest Tier-A (#246/#247): the OSATE `examples` corpus vendored verbatim (~548 `.aadl`, SEI Notice.txt grant), a parse ratchet that fails only on genuine regressions, and a two-baseline split (`spar-gaps.txt` parser gaps vs `unadjudicated.txt` bugtrack fixtures pending the Tier-B OSATE oracle).

## Verification
- `cargo check -p spar` clean at 0.12.0.
- `rivet validate` byte-identical to baseline (190 errors / 160 warnings / **0 broken cross-refs**) — a pure version bump touches no artifact YAML, so the unchanged count is the invariant.
- Tag `v0.12.0` (signed annotated) fires the release workflow on merge, re-exercising the cosign sign-blob + SLSA attest-build-provenance chain standardized in #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)