### PR TITLE
chore(traceability): promote REQ-NETWORK-007 to implemented

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1454,7 +1454,7 @@ artifacts:
       a TODO(v1.0.0) tag; statements are the load-bearing artifact.
       Track D commit 5 of the v0.8.0 design
       (docs/designs/track-d-tsn-wctt-research.md §4.3-4.4).
-    status: planned
+    status: implemented
     tags: [network, wctt, lean, proofs, v080]
 
   - id: REQ-TSN-001


### PR DESCRIPTION
Promotes **REQ-NETWORK-007** (Lean-formalized Network Calculus closed-form statements) `planned` → `implemented`.

**Evidence:** its verification `TEST-LEAN-MINPLUS` runs `cd proofs && lake build`. The CI **"Lean proof typecheck (lake build)"** job runs exactly that and **passes on main** (run 26709165789) — the formalization typechecks. Held back in #250 only because `lake` wasn't on the local PATH; CI is the authoritative oracle for the Lean toolchain, so the evidence is in hand.

`rivet validate` unchanged: `FAIL (190 errors, 160 warnings, 0 broken cross-refs)`. Status-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)