### PR TITLE
fix(codegen): emit valid, bindable WIT — kebab idents + defined types (#254)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "spar-base-db",
  "spar-hir-def",
  "toml",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -1799,6 +1800,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2028,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]

--- a/crates/spar-codegen/Cargo.toml
+++ b/crates/spar-codegen/Cargo.toml
@@ -19,6 +19,9 @@ spar-hir-def.workspace = true
 spar-base-db.workspace = true
 la-arena.workspace = true
 criterion.workspace = true
+# Parse generated WIT in tests so invalid output (bad identifiers, undefined
+# types) fails at the source rather than downstream in wit-bindgen (issue #254).
+wit-parser = "0.246"
 
 [[bench]]
 name = "codegen_benchmarks"

--- a/crates/spar-codegen/src/wit_gen.rs
+++ b/crates/spar-codegen/src/wit_gen.rs
@@ -4,16 +4,27 @@
 //! the process's ports as WIT imports/exports, following the WASI Component
 //! Model conventions.
 
+use std::collections::BTreeSet;
+
 use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
 use spar_hir_def::item_tree::{ComponentCategory, Direction, FeatureKind};
 
-use crate::{GeneratedFile, sanitize_ident};
+use crate::GeneratedFile;
+
+/// Default WIT representation for an AADL data type with no further detail.
+/// A byte buffer is always valid and bindable; `bytes` is NOT a WIT primitive.
+const DEFAULT_WIT_TYPE: &str = "list<u8>";
 
 /// Generate a WIT file for a process instance.
+///
+/// Identifiers are emitted in WIT kebab-case (see [`wit_ident`]) — NOT the
+/// Rust `snake_case` used elsewhere in codegen — and every named data type a
+/// port references is emitted as a `type` alias so the interface resolves
+/// under `wasm-tools` / `wit-bindgen` (see issue #254).
 pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> GeneratedFile {
     let comp = inst.component(proc_idx);
-    let name = sanitize_ident(comp.name.as_str());
-    let pkg_name = sanitize_ident(comp.package.as_str());
+    let name = wit_ident(comp.name.as_str());
+    let pkg_name = wit_ident(comp.package.as_str());
 
     let mut wit = String::new();
     wit.push_str(&format!(
@@ -29,17 +40,39 @@ pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> Ge
         .filter(|&&child_idx| inst.component(child_idx).category == ComponentCategory::Thread)
         .collect();
 
+    // First pass: collect every named data type referenced by a port so we can
+    // emit `type` definitions. WIT rejects references to undefined types, so an
+    // interface that names `mattermessage` without defining it will not bind.
+    let mut referenced_types: BTreeSet<String> = BTreeSet::new();
+    for &fi in &comp.features {
+        let feat = &inst.features[fi];
+        if let Some(c) = feat.classifier.as_ref() {
+            referenced_types.insert(wit_ident(&c.to_string()));
+        }
+    }
+
     // Generate an interface for the process's own ports
     wit.push_str(&format!("interface {name}-ports {{\n"));
 
+    // Emit a type alias for each referenced data type. Without per-type
+    // `Data_Size` resolution (the generator has no scope handle here) every
+    // AADL data type maps to a byte buffer — always valid and bindable.
+    // Refining scalar sizes (8 bytes -> u64, etc.) is tracked as a follow-up.
+    for ty in &referenced_types {
+        wit.push_str(&format!("    type {ty} = {DEFAULT_WIT_TYPE};\n"));
+    }
+    if !referenced_types.is_empty() {
+        wit.push('\n');
+    }
+
     for &fi in &comp.features {
         let feat = &inst.features[fi];
-        let feat_name = sanitize_ident(feat.name.as_str());
+        let feat_name = wit_ident(feat.name.as_str());
         let type_name = feat
             .classifier
             .as_ref()
-            .map(|c| sanitize_ident(&c.to_string()))
-            .unwrap_or_else(|| "bytes".to_string());
+            .map(|c| wit_ident(&c.to_string()))
+            .unwrap_or_else(|| DEFAULT_WIT_TYPE.to_string());
 
         match feat.kind {
             FeatureKind::DataPort => {
@@ -93,7 +126,7 @@ pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> Ge
 
     for &&child_idx in &child_threads {
         let child = inst.component(child_idx);
-        let child_name = sanitize_ident(child.name.as_str());
+        let child_name = wit_ident(child.name.as_str());
         wit.push_str(&format!("    export {child_name}: func();\n"));
     }
 
@@ -103,6 +136,59 @@ pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> Ge
         path: format!("wit/{name}.wit"),
         content: wit,
     }
+}
+
+/// WIT reserved words that must be `%`-escaped when used as identifiers.
+/// (A representative set covering the WIT keywords an AADL-derived name could
+/// realistically collide with.)
+const WIT_KEYWORDS: &[&str] = &[
+    "use", "type", "func", "record", "enum", "flags", "variant", "resource", "interface", "world",
+    "import", "export", "package", "include", "as", "from", "static", "constructor", "list",
+    "option", "result", "tuple", "future", "stream", "bool", "u8", "u16", "u32", "u64", "s8",
+    "s16", "s32", "s64", "f32", "f64", "char", "string",
+];
+
+/// Sanitize an arbitrary AADL identifier into a valid WIT identifier.
+///
+/// WIT identifiers are kebab-case (`word ('-' word)*`, each `word` matching
+/// `[a-z][a-z0-9]*`), NOT the Rust `snake_case` produced by
+/// [`crate::sanitize_ident`]. Underscores and other separators become hyphens,
+/// words that would start with a digit are letter-prefixed, and collisions with
+/// WIT keywords are `%`-escaped. See issue #254.
+fn wit_ident(name: &str) -> String {
+    // Split into lowercase alphanumeric words on any run of separators
+    // (`_`, `.`, `-`, whitespace, etc.).
+    let mut words: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            cur.push(ch.to_ascii_lowercase());
+        } else if !cur.is_empty() {
+            words.push(std::mem::take(&mut cur));
+        }
+    }
+    if !cur.is_empty() {
+        words.push(cur);
+    }
+
+    // Each WIT word must start with a letter; prefix a leading-digit word.
+    for w in &mut words {
+        if w.starts_with(|c: char| c.is_ascii_digit()) {
+            w.insert(0, 'n');
+        }
+    }
+
+    if words.is_empty() {
+        return "unnamed".to_string();
+    }
+
+    let joined = words.join("-");
+
+    // `%`-escape WIT keywords (only meaningful for single-word identifiers).
+    if WIT_KEYWORDS.contains(&joined.as_str()) {
+        return format!("%{joined}");
+    }
+    joined
 }
 
 #[cfg(test)]
@@ -116,10 +202,15 @@ mod tests {
         let aadl = r#"
 package TestPkg
 public
+    data Sample
+    end Sample;
+
     process Controller
         features
             sensor_in: in data port;
             cmd_out: out data port;
+            message_in: in event data port Sample;
+            announce_out: out event data port Sample;
     end Controller;
 
     process implementation Controller.Impl
@@ -170,5 +261,66 @@ end TestPkg;
             assert!(file.content.contains("package"));
             assert!(file.content.contains("world"));
         }
+    }
+
+    /// Regression guard for #254: the generated WIT must parse + resolve under
+    /// `wit-parser` — no invalid identifiers (underscores), no references to
+    /// undefined types. Without this, `spar codegen --format wit` could emit
+    /// files that only fail later in `wasm-tools` / `wit-bindgen`.
+    #[test]
+    fn generated_wit_is_valid_and_bindable() {
+        let inst = build_test_instance();
+        let idx = inst
+            .all_components()
+            .find(|(_, c)| c.category == ComponentCategory::Process)
+            .map(|(idx, _)| idx)
+            .expect("test model has a process");
+        let file = generate_wit(&inst, idx);
+
+        // No stray underscores in the emitted WIT (kebab-case only). The header
+        // comment echoes the AADL names, so check the body after it.
+        let body: String = file
+            .content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !body.contains('_'),
+            "WIT body must be kebab-case (no underscores):\n{body}"
+        );
+
+        // The classifier-typed ports must have produced a `type` definition so
+        // the interface resolves rather than referencing an undefined type.
+        assert!(
+            body.contains("type sample = list<u8>;"),
+            "expected a type alias for the `Sample` data type:\n{body}"
+        );
+
+        // Authoritative check: feed the WIT to wit-parser. push_str errors on
+        // invalid identifiers OR references to undefined types.
+        let mut resolve = wit_parser::Resolve::new();
+        resolve
+            .push_str("generated.wit", &file.content)
+            .unwrap_or_else(|e| panic!("generated WIT failed to parse/resolve: {e}\n---\n{}", file.content));
+    }
+
+    #[test]
+    fn wit_ident_kebab_cases() {
+        // The exact identifiers from issue #254.
+        assert_eq!(wit_ident("Wohl_Matter"), "wohl-matter");
+        assert_eq!(wit_ident("message_in"), "message-in");
+        assert_eq!(wit_ident("announce_out"), "announce-out");
+        // Dotted + mixed separators collapse to single hyphens.
+        assert_eq!(wit_ident("Ctrl.Impl"), "ctrl-impl");
+        assert_eq!(wit_ident("My-Thread"), "my-thread");
+        // Leading-digit words get a letter prefix (WIT words start with a letter).
+        assert_eq!(wit_ident("3d_pos"), "n3d-pos");
+        // WIT keywords are %-escaped.
+        assert_eq!(wit_ident("type"), "%type");
+        assert_eq!(wit_ident("list"), "%list");
+        // Degenerate input.
+        assert_eq!(wit_ident("___"), "unnamed");
+        assert_eq!(wit_ident(""), "unnamed");
     }
 }

--- a/crates/spar-codegen/src/wit_gen.rs
+++ b/crates/spar-codegen/src/wit_gen.rs
@@ -142,10 +142,43 @@ pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> Ge
 /// (A representative set covering the WIT keywords an AADL-derived name could
 /// realistically collide with.)
 const WIT_KEYWORDS: &[&str] = &[
-    "use", "type", "func", "record", "enum", "flags", "variant", "resource", "interface", "world",
-    "import", "export", "package", "include", "as", "from", "static", "constructor", "list",
-    "option", "result", "tuple", "future", "stream", "bool", "u8", "u16", "u32", "u64", "s8",
-    "s16", "s32", "s64", "f32", "f64", "char", "string",
+    "use",
+    "type",
+    "func",
+    "record",
+    "enum",
+    "flags",
+    "variant",
+    "resource",
+    "interface",
+    "world",
+    "import",
+    "export",
+    "package",
+    "include",
+    "as",
+    "from",
+    "static",
+    "constructor",
+    "list",
+    "option",
+    "result",
+    "tuple",
+    "future",
+    "stream",
+    "bool",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "s8",
+    "s16",
+    "s32",
+    "s64",
+    "f32",
+    "f64",
+    "char",
+    "string",
 ];
 
 /// Sanitize an arbitrary AADL identifier into a valid WIT identifier.
@@ -302,7 +335,12 @@ end TestPkg;
         let mut resolve = wit_parser::Resolve::new();
         resolve
             .push_str("generated.wit", &file.content)
-            .unwrap_or_else(|e| panic!("generated WIT failed to parse/resolve: {e}\n---\n{}", file.content));
+            .unwrap_or_else(|e| {
+                panic!(
+                    "generated WIT failed to parse/resolve: {e}\n---\n{}",
+                    file.content
+                )
+            });
     }
 
     #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -676,6 +676,10 @@ criteria = "safe-to-run"
 version = "0.245.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.wasmparser]]
+version = "0.246.2"
+criteria = "safe-to-run"
+
 [[exemptions.web-sys]]
 version = "0.3.95"
 criteria = "safe-to-run"
@@ -743,6 +747,10 @@ criteria = "safe-to-run"
 [[exemptions.wit-parser]]
 version = "0.245.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.wit-parser]]
+version = "0.246.2"
+criteria = "safe-to-run"
 
 [[exemptions.yansi]]
 version = "1.0.1"


### PR DESCRIPTION
Fixes #254 — `spar codegen --format wit` emitted WIT that `wasm-tools` / `wit-bindgen` reject, so the generated interface couldn't be bound (broke the spar-generates-WIT workflow on the wohl Matter seam).

## Root causes
1. **Invalid identifiers.** The WIT generator reused `sanitize_ident`, which produces Rust **`snake_case`** — but WIT is **kebab-case**. Package `wohl_matter:matter` was the first hard error; funcs like `on-message_in` mix a hyphen prefix with an underscore (doubly invalid).
2. **Undefined types.** Ports referenced types (`mattermessage`, `monotonictime`, …) that were never defined, and emitted `bytes`, which isn't a WIT primitive.

## Fix
- New `wit_ident()`: kebab-case WIT identifiers — separators → hyphens, leading-digit words letter-prefixed (WIT words must start with a letter), WIT keywords `%`-escaped. Used for package / interface / world / func / type / export names.
- Emit `type <name> = list<u8>;` for every data type a port references so the interface **resolves**; untyped ports use `list<u8>` (valid primitive) instead of non-primitive `bytes`.
- Regression guard: a test parses the generated WIT with **`wit-parser`** (`Resolve::push_str` errors on bad idents *or* undefined types), plus `wit_ident` unit tests covering the exact #254 identifiers.

## Before → after (same model)
```wit
// before (rejected)            // after (valid)
package wohl_matter:matter;     package wohl-matter:bridge;
on-message_in: func() ...       type mattermessage = list<u8>;
... mattermessage (undefined)   on-message-in: func() -> option<mattermessage>;
```

## Verification
- `cargo test -p spar-codegen` — 46 lib + 21 golden, **0 failures**; new `generated_wit_is_valid_and_bindable` + `wit_ident_kebab_cases` pass.
- End-to-end: **`wasm-tools 1.243.0 component wit`** (exact tool/version from #254) now round-trips the generated file — the `invalid character in identifier '_'` error is gone.

## Follow-up (noted, out of scope)
Per-type scalar-size fidelity (8-byte `Data_Size` → `u64`, etc., rather than `list<u8>` for everything) needs `scope` access threaded into the generator; tracked for a later change. This PR makes the output **valid and bindable**, which is the blocking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)