### PR TITLE
fix(hir-def): preserve properties applied to connections and features (#237)

### DIFF
--- a/crates/spar-analysis/src/ai_ml/tests.rs
+++ b/crates/spar-analysis/src/ai_ml/tests.rs
@@ -89,6 +89,8 @@ fn single_component_instance(category: ComponentCategory, props: PropertyMap) ->
         mode_transition_instances: Arena::new(),
         diagnostics: Vec::new(),
         property_maps,
+        feature_property_maps: Default::default(),
+        connection_property_maps: Default::default(),
         semantic_connections: Vec::new(),
         system_operation_modes: Vec::new(),
     }

--- a/crates/spar-analysis/src/arinc653.rs
+++ b/crates/spar-analysis/src/arinc653.rs
@@ -546,6 +546,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/binding_check.rs
+++ b/crates/spar-analysis/src/binding_check.rs
@@ -302,6 +302,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/binding_rules.rs
+++ b/crates/spar-analysis/src/binding_rules.rs
@@ -275,6 +275,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/bus_bandwidth.rs
+++ b/crates/spar-analysis/src/bus_bandwidth.rs
@@ -575,6 +575,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }
@@ -1324,6 +1326,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: b.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: vec![som],
             }
@@ -1374,6 +1378,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: b.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: vec![som],
             }

--- a/crates/spar-analysis/src/classifier_match.rs
+++ b/crates/spar-analysis/src/classifier_match.rs
@@ -442,6 +442,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/completeness.rs
+++ b/crates/spar-analysis/src/completeness.rs
@@ -223,6 +223,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: self.diagnostics,
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/connection_rules.rs
+++ b/crates/spar-analysis/src/connection_rules.rs
@@ -276,6 +276,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/connectivity.rs
+++ b/crates/spar-analysis/src/connectivity.rs
@@ -521,6 +521,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/direction_rules.rs
+++ b/crates/spar-analysis/src/direction_rules.rs
@@ -410,6 +410,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/emv2_analysis.rs
+++ b/crates/spar-analysis/src/emv2_analysis.rs
@@ -374,6 +374,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/emv2_propagation.rs
+++ b/crates/spar-analysis/src/emv2_propagation.rs
@@ -536,6 +536,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: self.semantic_connections,
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/emv2_stpa_bridge.rs
+++ b/crates/spar-analysis/src/emv2_stpa_bridge.rs
@@ -529,6 +529,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/feature_group_check.rs
+++ b/crates/spar-analysis/src/feature_group_check.rs
@@ -483,6 +483,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/flow_check.rs
+++ b/crates/spar-analysis/src/flow_check.rs
@@ -306,6 +306,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/flow_rules.rs
+++ b/crates/spar-analysis/src/flow_rules.rs
@@ -507,6 +507,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/hierarchy.rs
+++ b/crates/spar-analysis/src/hierarchy.rs
@@ -228,6 +228,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/latency.rs
+++ b/crates/spar-analysis/src/latency.rs
@@ -614,6 +614,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/legality.rs
+++ b/crates/spar-analysis/src/legality.rs
@@ -544,6 +544,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/memory_budget.rs
+++ b/crates/spar-analysis/src/memory_budget.rs
@@ -248,6 +248,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/modal.rs
+++ b/crates/spar-analysis/src/modal.rs
@@ -157,6 +157,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: soms,
         }

--- a/crates/spar-analysis/src/modal_rules.rs
+++ b/crates/spar-analysis/src/modal_rules.rs
@@ -333,6 +333,8 @@ mod tests {
                 mode_transition_instances: self.mode_transition_instances,
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/mode_check.rs
+++ b/crates/spar-analysis/src/mode_check.rs
@@ -288,6 +288,8 @@ mod tests {
                 mode_transition_instances: self.mode_transition_instances,
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/mode_reachability.rs
+++ b/crates/spar-analysis/src/mode_reachability.rs
@@ -700,6 +700,8 @@ mod tests {
                 mode_transition_instances: self.mode_transition_instances,
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/mode_rules.rs
+++ b/crates/spar-analysis/src/mode_rules.rs
@@ -245,6 +245,8 @@ mod tests {
                 mode_transition_instances: self.mode_transition_instances,
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/property_rules.rs
+++ b/crates/spar-analysis/src/property_rules.rs
@@ -444,6 +444,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/regression_tests.rs
+++ b/crates/spar-analysis/src/regression_tests.rs
@@ -118,6 +118,8 @@ impl TestInstanceBuilder {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: self.property_maps,
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }

--- a/crates/spar-analysis/src/resource_budget.rs
+++ b/crates/spar-analysis/src/resource_budget.rs
@@ -370,6 +370,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/rta.rs
+++ b/crates/spar-analysis/src/rta.rs
@@ -736,6 +736,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/scheduling.rs
+++ b/crates/spar-analysis/src/scheduling.rs
@@ -624,6 +624,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/subcomponent_rules.rs
+++ b/crates/spar-analysis/src/subcomponent_rules.rs
@@ -238,6 +238,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: FxHashMap::default(),
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-analysis/src/tests.rs
+++ b/crates/spar-analysis/src/tests.rs
@@ -171,6 +171,8 @@ impl TestInstanceBuilder {
             mode_transition_instances: Arena::default(),
             diagnostics: self.diagnostics,
             property_maps: self.property_maps,
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }

--- a/crates/spar-analysis/src/weight_power.rs
+++ b/crates/spar-analysis/src/weight_power.rs
@@ -542,6 +542,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }
@@ -1240,6 +1242,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: b.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: vec![som],
             }
@@ -1317,6 +1321,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: b.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: vec![som],
             }

--- a/crates/spar-analysis/src/wrpc_binding.rs
+++ b/crates/spar-analysis/src/wrpc_binding.rs
@@ -271,6 +271,8 @@ mod tests {
                 mode_transition_instances: Arena::default(),
                 diagnostics: Vec::new(),
                 property_maps: self.property_maps,
+                feature_property_maps: Default::default(),
+                connection_property_maps: Default::default(),
                 semantic_connections: Vec::new(),
                 system_operation_modes: Vec::new(),
             }

--- a/crates/spar-cli/src/assertion/mod.rs
+++ b/crates/spar-cli/src/assertion/mod.rs
@@ -545,6 +545,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps,
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }
@@ -831,6 +833,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };

--- a/crates/spar-cli/src/diff.rs
+++ b/crates/spar-cli/src/diff.rs
@@ -932,6 +932,8 @@ mod tests {
                     mode_transition_instances: Arena::default(),
                     diagnostics: Vec::new(),
                     property_maps: self.property_maps,
+                    feature_property_maps: Default::default(),
+                    connection_property_maps: Default::default(),
                     semantic_connections: Vec::new(),
                     system_operation_modes: Vec::new(),
                 }

--- a/crates/spar-hir-def/src/instance.rs
+++ b/crates/spar-hir-def/src/instance.rs
@@ -56,6 +56,14 @@ pub struct SystemInstance {
     pub diagnostics: Vec<InstanceDiagnostic>,
     /// Property maps for each component instance.
     pub property_maps: FxHashMap<ComponentInstanceIdx, PropertyMap>,
+    /// Property maps for feature instances — values attached via
+    /// `applies to <path>.<feature>` (AS5506D §11.3). Keyed by feature index
+    /// so each port keeps its own properties instead of colliding on the
+    /// owning component's map (issue #237).
+    pub feature_property_maps: FxHashMap<FeatureInstanceIdx, PropertyMap>,
+    /// Property maps for connection instances — values attached via
+    /// `applies to <path>.<connection>` (issue #237).
+    pub connection_property_maps: FxHashMap<ConnectionInstanceIdx, PropertyMap>,
     /// Semantic (end-to-end) connection instances traced through the hierarchy.
     pub semantic_connections: Vec<SemanticConnection>,
     /// System Operation Modes — the cartesian product of modes across all modal components.
@@ -207,6 +215,8 @@ impl SystemInstance {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: FxHashMap::default(),
+            connection_property_maps: FxHashMap::default(),
             pending_applies_to: Vec::new(),
             depth: 0,
             max_depth: 100,
@@ -248,6 +258,8 @@ impl SystemInstance {
             mode_transition_instances: builder.mode_transition_instances,
             diagnostics: builder.diagnostics,
             property_maps: builder.property_maps,
+            feature_property_maps: builder.feature_property_maps,
+            connection_property_maps: builder.connection_property_maps,
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };
@@ -300,6 +312,20 @@ impl SystemInstance {
     pub fn properties_for(&self, idx: ComponentInstanceIdx) -> &PropertyMap {
         static EMPTY: std::sync::LazyLock<PropertyMap> = std::sync::LazyLock::new(PropertyMap::new);
         self.property_maps.get(&idx).unwrap_or(&EMPTY)
+    }
+
+    /// Resolved properties attached to a feature instance via
+    /// `applies to <path>.<feature>` (issue #237). Empty if none.
+    pub fn properties_for_feature(&self, idx: FeatureInstanceIdx) -> &PropertyMap {
+        static EMPTY: std::sync::LazyLock<PropertyMap> = std::sync::LazyLock::new(PropertyMap::new);
+        self.feature_property_maps.get(&idx).unwrap_or(&EMPTY)
+    }
+
+    /// Resolved properties attached to a connection instance via
+    /// `applies to <path>.<connection>` (issue #237). Empty if none.
+    pub fn properties_for_connection(&self, idx: ConnectionInstanceIdx) -> &PropertyMap {
+        static EMPTY: std::sync::LazyLock<PropertyMap> = std::sync::LazyLock::new(PropertyMap::new);
+        self.connection_property_maps.get(&idx).unwrap_or(&EMPTY)
     }
 
     /// Build a `/`-separated instance path for a component (root first).
@@ -1360,10 +1386,14 @@ enum AppliesTarget {
     /// All segments named subcomponents; resolved to this component.
     Component(ComponentInstanceIdx),
     /// All-but-last segments named subcomponents; the last segment names a
-    /// feature on the returned component (AADL v2.3 AS5506D §11.3).
-    FeatureOwner(ComponentInstanceIdx),
-    /// No valid resolution: the path contains a segment that matches neither
-    /// a subcomponent nor (for the last segment) a feature.
+    /// feature on the resolved component (AADL v2.3 AS5506D §11.3). Carries the
+    /// specific feature instance so the property is stored per-feature (#237).
+    Feature(FeatureInstanceIdx),
+    /// All-but-last segments named subcomponents; the last segment names a
+    /// connection on the resolved component (#237).
+    Connection(ConnectionInstanceIdx),
+    /// No valid resolution: the path contains a segment that matches neither a
+    /// subcomponent nor (for the last segment) a feature or connection.
     Unresolvable,
 }
 
@@ -1378,6 +1408,8 @@ struct Builder<'a> {
     mode_transition_instances: Arena<ModeTransitionInstance>,
     diagnostics: Vec<InstanceDiagnostic>,
     property_maps: FxHashMap<ComponentInstanceIdx, PropertyMap>,
+    feature_property_maps: FxHashMap<FeatureInstanceIdx, PropertyMap>,
+    connection_property_maps: FxHashMap<ConnectionInstanceIdx, PropertyMap>,
     /// Property associations with a non-empty `applies to <path>` clause.
     ///
     /// These are collected during instantiation and eagerly attached to
@@ -2342,12 +2374,21 @@ impl<'a> Builder<'a> {
                 AppliesTarget::Component(target) => {
                     self.property_maps.entry(target).or_default().add(prop);
                 }
-                AppliesTarget::FeatureOwner(component) => {
-                    // The last segment named a feature on `component`.  Store
-                    // the property on the owning component — per AS5506D §11.3
-                    // the property association applies to the feature instance,
-                    // and the component is the natural retrieval point.
-                    self.property_maps.entry(component).or_default().add(prop);
+                AppliesTarget::Feature(feature) => {
+                    // Last segment named a feature (AS5506D §11.3). Store on the
+                    // feature instance so each port keeps its own values instead
+                    // of colliding by property name on the component map (#237).
+                    self.feature_property_maps
+                        .entry(feature)
+                        .or_default()
+                        .add(prop);
+                }
+                AppliesTarget::Connection(connection) => {
+                    // Last segment named a connection — store per-connection (#237).
+                    self.connection_property_maps
+                        .entry(connection)
+                        .or_default()
+                        .add(prop);
                 }
                 AppliesTarget::Unresolvable => {
                     // Unresolvable path: keep on owner (prior behavior) and
@@ -2370,9 +2411,11 @@ impl<'a> Builder<'a> {
     ///
     /// Returns:
     /// - [`AppliesTarget::Component`] when all segments name subcomponents.
-    /// - [`AppliesTarget::FeatureOwner`] when all-but-last segments name
+    /// - [`AppliesTarget::Feature`] when all-but-last segments name
     ///   subcomponents and the final segment names a feature on the resolved
     ///   component (AADL v2.3 AS5506D §11.3 feature-path support).
+    /// - [`AppliesTarget::Connection`] when the final segment names a connection
+    ///   on the resolved component (#237).
     /// - [`AppliesTarget::Unresolvable`] when any segment cannot be matched.
     fn resolve_applies_to_path(&self, owner: ComponentInstanceIdx, path: &str) -> AppliesTarget {
         let segments: Vec<&str> = path
@@ -2398,21 +2441,29 @@ impl<'a> Builder<'a> {
                 continue;
             }
 
-            // Not a child — check if this is the last segment and names a feature.
+            // Not a child — check if this is the last segment and names a
+            // feature or a connection on the current component.
             let is_last = i == segments.len() - 1;
             if is_last {
-                let is_feature = self.components[current].features.iter().any(|&fi| {
+                if let Some(&fi) = self.components[current].features.iter().find(|&&fi| {
                     self.features[fi]
                         .name
                         .as_str()
                         .eq_ignore_ascii_case(segment)
-                });
-                if is_feature {
-                    return AppliesTarget::FeatureOwner(current);
+                }) {
+                    return AppliesTarget::Feature(fi);
+                }
+                if let Some(&ci) = self.components[current].connections.iter().find(|&&ci| {
+                    self.connections[ci]
+                        .name
+                        .as_str()
+                        .eq_ignore_ascii_case(segment)
+                }) {
+                    return AppliesTarget::Connection(ci);
                 }
             }
 
-            // Neither subcomponent nor feature — unresolvable.
+            // Neither subcomponent, feature, nor connection — unresolvable.
             return AppliesTarget::Unresolvable;
         }
 
@@ -2503,6 +2554,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: FxHashMap::default(),
+            connection_property_maps: FxHashMap::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }
@@ -4263,6 +4316,83 @@ end derived_pkg;
             inst.all_components()
                 .map(|(_, c)| c.name.as_str().to_string())
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression for #237: a property declared with `applies to <connection>`
+    /// or `applies to <feature>` must be stored on the connection/feature
+    /// instance — not collapsed by property name onto the owning component.
+    #[test]
+    fn applies_to_connection_and_feature_store_per_instance() {
+        let src = r#"
+package p
+public
+    data D
+    end D;
+    thread T
+        features
+            tin: in data port D;
+            tout: out data port D;
+    end T;
+    thread implementation T.i
+    end T.i;
+    process Proc
+        features
+            pin: in data port D;
+    end Proc;
+    process implementation Proc.i
+        subcomponents
+            a: thread T.i;
+            b: thread T.i;
+        connections
+            conn1: port a.tout -> b.tin;
+        properties
+            stood::pos => "wire-shape" applies to conn1;
+            stood::pos => "port-shape" applies to pin;
+    end Proc.i;
+    system S
+    end S;
+    system implementation S.i
+        subcomponents
+            proc: process Proc.i;
+    end S.i;
+end p;
+"#;
+        let db = crate::HirDefDatabase::default();
+        let tree = crate::file_item_tree(
+            &db,
+            spar_base_db::SourceFile::new(&db, "p.aadl".to_string(), src.to_string()),
+        );
+        let scope = GlobalScope::from_trees(vec![tree]);
+        let inst = SystemInstance::instantiate(
+            &scope,
+            &Name::new("p"),
+            &Name::new("S"),
+            &Name::new("i"),
+        );
+
+        // Property on the connection lands on the connection instance.
+        let (conn_idx, _) = inst
+            .connections
+            .iter()
+            .find(|(_, c)| c.name.as_str() == "conn1")
+            .expect("conn1 should be instantiated");
+        assert_eq!(
+            inst.properties_for_connection(conn_idx).get("stood", "pos"),
+            Some("\"wire-shape\""),
+            "connection property must be stored per-connection, not on the component (#237)"
+        );
+
+        // Property on the feature lands on the feature instance.
+        let (feat_idx, _) = inst
+            .features
+            .iter()
+            .find(|(_, f)| f.name.as_str() == "pin")
+            .expect("pin feature should exist");
+        assert_eq!(
+            inst.properties_for_feature(feat_idx).get("stood", "pos"),
+            Some("\"port-shape\""),
+            "feature property must be stored per-feature, not on the component (#237)"
         );
     }
 }

--- a/crates/spar-hir-def/src/instance.rs
+++ b/crates/spar-hir-def/src/instance.rs
@@ -4322,7 +4322,12 @@ end derived_pkg;
     /// Regression for #237: a property declared with `applies to <connection>`
     /// or `applies to <feature>` must be stored on the connection/feature
     /// instance — not collapsed by property name onto the owning component.
+    ///
+    /// Ignored under Miri for the same reason as
+    /// `extends_chain_across_files_does_not_panic`: it parses AADL source,
+    /// pulling rowan (upstream rowan#192 UB) into the Miri run.
     #[test]
+    #[cfg_attr(miri, ignore = "parses via rowan — upstream rowan#192 UB under Miri")]
     fn applies_to_connection_and_feature_store_per_instance() {
         let src = r#"
 package p

--- a/crates/spar-hir-def/src/instance.rs
+++ b/crates/spar-hir-def/src/instance.rs
@@ -4364,12 +4364,8 @@ end p;
             spar_base_db::SourceFile::new(&db, "p.aadl".to_string(), src.to_string()),
         );
         let scope = GlobalScope::from_trees(vec![tree]);
-        let inst = SystemInstance::instantiate(
-            &scope,
-            &Name::new("p"),
-            &Name::new("S"),
-            &Name::new("i"),
-        );
+        let inst =
+            SystemInstance::instantiate(&scope, &Name::new("p"), &Name::new("S"), &Name::new("i"));
 
         // Property on the connection lands on the connection instance.
         let (conn_idx, _) = inst

--- a/crates/spar-hir-def/src/overlay.rs
+++ b/crates/spar-hir-def/src/overlay.rs
@@ -447,6 +447,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };
@@ -936,6 +938,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };
@@ -1101,6 +1105,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };

--- a/crates/spar-hir/src/lib.rs
+++ b/crates/spar-hir/src/lib.rs
@@ -399,6 +399,10 @@ pub struct InstanceFeature {
     /// Array index for array features: None for non-array, Some(1..N) for array elements.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array_index: Option<u64>,
+    /// Property values attached to this feature via `applies to <path>.<feature>`
+    /// (AS5506D §11.3). Keyed `PropSet::Name` or `Name` (issue #237).
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty", default)]
+    pub properties: std::collections::BTreeMap<String, String>,
 }
 
 /// A connection in the serializable instance tree.
@@ -409,6 +413,29 @@ pub struct InstanceConnection {
     pub is_bidirectional: bool,
     pub source: Option<String>,
     pub destination: Option<String>,
+    /// Property values attached to this connection via
+    /// `applies to <path>.<connection>` (issue #237).
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty", default)]
+    pub properties: std::collections::BTreeMap<String, String>,
+}
+
+/// Flatten a resolved property map into a `PropSet::Name`/`Name` → value-text
+/// map for JSON serialization. Shared by component, feature, and connection
+/// nodes (#129, #237).
+fn prop_map_to_btree(
+    pmap: &spar_hir_def::properties::PropertyMap,
+) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    for (_key, values) in pmap.iter() {
+        let Some(pv) = values.first() else { continue };
+        let name = pv.name.property_name.as_str();
+        let key = match pv.name.property_set.as_ref() {
+            Some(ps) if !ps.as_str().is_empty() => format!("{}::{}", ps.as_str(), name),
+            _ => name.to_string(),
+        };
+        out.insert(key, pv.value.clone());
+    }
+    out
 }
 
 impl Instance {
@@ -493,6 +520,7 @@ impl Instance {
                     kind: f.kind,
                     direction: f.direction,
                     array_index: f.array_index,
+                    properties: prop_map_to_btree(self.inner.properties_for_feature(fi)),
                 }
             })
             .collect();
@@ -504,7 +532,7 @@ impl Instance {
         //
         // We use the semantic connections that have been traced end-to-end,
         // grouped by the component that owns the originating across connection.
-        let connections = self
+        let mut connections: Vec<InstanceConnection> = self
             .inner
             .semantic_connections
             .iter()
@@ -534,15 +562,58 @@ impl Instance {
                         format!("{}.{}", path, feat_name)
                     }
                 };
+                // Properties come from the ORIGINATING raw connection (the named
+                // one the `applies to` clause targets), not the whole traced
+                // path — avoids mis-attributing a hop's property (#237).
+                let properties = sc
+                    .connection_path
+                    .first()
+                    .map(|&ci| prop_map_to_btree(self.inner.properties_for_connection(ci)))
+                    .unwrap_or_default();
                 InstanceConnection {
                     name: sc.name.as_str().to_string(),
                     kind: sc.kind,
                     is_bidirectional: false,
                     source: Some(src_name),
                     destination: Some(dst_name),
+                    properties,
                 }
             })
             .collect();
+
+        // AS5506 Ch.14 emits only "across" connections as semantic instances, so
+        // up/down connections (e.g. `input -> t1.input`) are normally absent. If
+        // such a raw connection carries `applies to` properties, surface it here
+        // so the property isn't silently dropped (#237). Keyed by name to avoid
+        // duplicating a connection already emitted as a semantic instance.
+        let emitted: std::collections::HashSet<&str> =
+            connections.iter().map(|c| c.name.as_str()).collect::<std::collections::HashSet<_>>();
+        let mut extra: Vec<InstanceConnection> = Vec::new();
+        for &ci in &comp.connections {
+            let props = prop_map_to_btree(self.inner.properties_for_connection(ci));
+            if props.is_empty() {
+                continue;
+            }
+            let conn = &self.inner.connections[ci];
+            if emitted.contains(conn.name.as_str()) || extra.iter().any(|e| e.name == conn.name.as_str()) {
+                continue;
+            }
+            let end_str = |e: &Option<spar_hir_def::instance::ConnectionEnd>| {
+                e.as_ref().map(|ce| match &ce.subcomponent {
+                    Some(sub) => format!("{}.{}", sub, ce.feature),
+                    None => ce.feature.as_str().to_string(),
+                })
+            };
+            extra.push(InstanceConnection {
+                name: conn.name.as_str().to_string(),
+                kind: conn.kind,
+                is_bidirectional: conn.is_bidirectional,
+                source: end_str(&conn.src),
+                destination: end_str(&conn.dst),
+                properties: props,
+            });
+        }
+        connections.extend(extra);
 
         let children = comp
             .children
@@ -551,20 +622,7 @@ impl Instance {
             .collect();
 
         // Resolved property values for this instance (fixes #129).
-        let properties = {
-            let mut out = std::collections::BTreeMap::new();
-            let pmap = self.inner.properties_for(idx);
-            for (_key, values) in pmap.iter() {
-                let Some(pv) = values.first() else { continue };
-                let name = pv.name.property_name.as_str();
-                let key = match pv.name.property_set.as_ref() {
-                    Some(ps) if !ps.as_str().is_empty() => format!("{}::{}", ps.as_str(), name),
-                    _ => name.to_string(),
-                };
-                out.insert(key, pv.value.clone());
-            }
-            out
-        };
+        let properties = prop_map_to_btree(self.inner.properties_for(idx));
 
         InstanceNode {
             name: comp.name.as_str().to_string(),
@@ -2155,6 +2213,7 @@ mod serde_round_trip_tests {
             kind: FeatureKind::EventDataPort,
             direction: Some(Direction::In),
             array_index: None,
+            properties: Default::default(),
         };
         round_trip(&feat);
 
@@ -2164,6 +2223,7 @@ mod serde_round_trip_tests {
             kind: FeatureKind::DataPort,
             direction: Some(Direction::Out),
             array_index: Some(3),
+            properties: Default::default(),
         };
         round_trip(&feat_arr);
     }
@@ -2178,6 +2238,7 @@ mod serde_round_trip_tests {
             is_bidirectional: false,
             source: Some("sensor.data_out".to_string()),
             destination: Some("controller.data_in".to_string()),
+            properties: Default::default(),
         };
         round_trip(&conn);
 
@@ -2188,6 +2249,7 @@ mod serde_round_trip_tests {
             is_bidirectional: true,
             source: None,
             destination: None,
+            properties: Default::default(),
         };
         round_trip(&conn2);
     }
@@ -2208,6 +2270,7 @@ mod serde_round_trip_tests {
                 kind: FeatureKind::DataPort,
                 direction: Some(Direction::InOut),
                 array_index: None,
+                properties: Default::default(),
             }],
             connections: vec![InstanceConnection {
                 name: "bus_link".to_string(),
@@ -2215,6 +2278,7 @@ mod serde_round_trip_tests {
                 is_bidirectional: false,
                 source: Some("cpu1.data_out".to_string()),
                 destination: Some("cpu2.data_in".to_string()),
+                properties: Default::default(),
             }],
             properties: std::collections::BTreeMap::new(),
             children: vec![
@@ -2230,6 +2294,7 @@ mod serde_round_trip_tests {
                         kind: FeatureKind::DataPort,
                         direction: Some(Direction::Out),
                         array_index: None,
+                        properties: Default::default(),
                     }],
                     connections: vec![],
                     properties: std::collections::BTreeMap::new(),
@@ -2248,6 +2313,7 @@ mod serde_round_trip_tests {
                         kind: FeatureKind::DataPort,
                         direction: Some(Direction::In),
                         array_index: Some(2),
+                        properties: Default::default(),
                     }],
                     connections: vec![],
                     properties: std::collections::BTreeMap::new(),
@@ -2277,6 +2343,7 @@ mod serde_round_trip_tests {
                 kind: FeatureKind::EventPort,
                 direction: Some(Direction::In),
                 array_index: None,
+                properties: Default::default(),
             }],
             connections: vec![],
             properties: std::collections::BTreeMap::new(),

--- a/crates/spar-hir/src/lib.rs
+++ b/crates/spar-hir/src/lib.rs
@@ -586,8 +586,10 @@ impl Instance {
         // such a raw connection carries `applies to` properties, surface it here
         // so the property isn't silently dropped (#237). Keyed by name to avoid
         // duplicating a connection already emitted as a semantic instance.
-        let emitted: std::collections::HashSet<&str> =
-            connections.iter().map(|c| c.name.as_str()).collect::<std::collections::HashSet<_>>();
+        let emitted: std::collections::HashSet<&str> = connections
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect::<std::collections::HashSet<_>>();
         let mut extra: Vec<InstanceConnection> = Vec::new();
         for &ci in &comp.connections {
             let props = prop_map_to_btree(self.inner.properties_for_connection(ci));
@@ -595,7 +597,9 @@ impl Instance {
                 continue;
             }
             let conn = &self.inner.connections[ci];
-            if emitted.contains(conn.name.as_str()) || extra.iter().any(|e| e.name == conn.name.as_str()) {
+            if emitted.contains(conn.name.as_str())
+                || extra.iter().any(|e| e.name == conn.name.as_str())
+            {
                 continue;
             }
             let end_str = |e: &Option<spar_hir_def::instance::ConnectionEnd>| {

--- a/crates/spar-mermaid/src/lib.rs
+++ b/crates/spar-mermaid/src/lib.rs
@@ -715,6 +715,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }
@@ -874,6 +876,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }

--- a/crates/spar-render/src/lib.rs
+++ b/crates/spar-render/src/lib.rs
@@ -1059,6 +1059,8 @@ mod tests {
             mode_transition_instances: Arena::<ModeTransitionInstance>::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };

--- a/crates/spar-solver/src/enumerate.rs
+++ b/crates/spar-solver/src/enumerate.rs
@@ -680,6 +680,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };

--- a/crates/spar-solver/src/tests.rs
+++ b/crates/spar-solver/src/tests.rs
@@ -127,6 +127,8 @@ impl TestBuilder {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: self.property_maps,
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }

--- a/crates/spar-wasm/src/graph.rs
+++ b/crates/spar-wasm/src/graph.rs
@@ -245,6 +245,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         }
@@ -362,6 +364,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };
@@ -465,6 +469,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };
@@ -543,6 +549,8 @@ mod tests {
             mode_transition_instances: Arena::default(),
             diagnostics: Vec::new(),
             property_maps: FxHashMap::default(),
+            feature_property_maps: Default::default(),
+            connection_property_maps: Default::default(),
             semantic_connections: Vec::new(),
             system_operation_modes: Vec::new(),
         };


### PR DESCRIPTION
Fixes #237 — properties via `applies to <connection>`/`applies to <feature>` were lost (connection→Unresolvable→dumped on component; feature→collapsed last-wins on component). Adds per-feature/per-connection property side-maps + AppliesTarget Feature/Connection + spar-hir serialization of feature/connection properties (originating raw connection; up/down connections surfaced). Verified on the issue's dataflow.aadl (c1–c4 keep distinct link_position; ports keep port_position). Regression test added; full suites green. Stacked on #256 (same file); retarget base to main once #256 merges. Bulk of diff = mechanical fixture updates to ~50 SystemInstance test literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)