### PR TITLE
feat(wasm): build spar-wasm for wasm32 + publish browser bundle (#259)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,60 @@ jobs:
           name: test-evidence
           path: spar-*-test-evidence.tar.gz
 
+  # ── Browser-ready spar-wasm bundle (jco transpile) ───────────────────
+  # Builds spar-wasm for wasm32-wasip2 and transpiles the component to a
+  # browser-loadable bundle (spar_wasm.js + spar_wasm.core*.wasm) that
+  # downstream consumers (rivet's dashboard/exports) embed without a local
+  # toolchain. The MILP solver (good_lp/HiGHS) is excluded from this build
+  # via spar-wasm's default-features = false (issue #259).
+  build-wasm:
+    name: Build spar-wasm browser bundle
+    needs: [check-versions]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip2
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-wasm32-wasip2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build spar-wasm (wasm32-wasip2)
+        run: cargo build --release --target wasm32-wasip2 -p spar-wasm
+
+      - name: Transpile to browser bundle (jco)
+        run: |
+          set -euo pipefail
+          mkdir -p dist/wasm
+          # Pinned jco version for a deterministic, supply-chain-stable bundle.
+          npx --yes @bytecodealliance/jco@1.4.0 transpile \
+            --instantiation async \
+            target/wasm32-wasip2/release/spar_wasm.wasm \
+            -o dist/wasm/
+          ls -la dist/wasm/
+
+      - name: Package browser bundle
+        env:
+          GH_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          VERSION="${GH_REF#refs/tags/}"
+          # spar_wasm.js + spar_wasm.core*.wasm + .d.ts + interfaces/
+          tar -C dist/wasm -czf "spar-wasm-browser-${VERSION}.tar.gz" .
+          ls -la "spar-wasm-browser-${VERSION}.tar.gz"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm-bundle
+          path: spar-wasm-browser-*.tar.gz
+
   # ── VS Code Extension (per-platform) ─────────────────────────────────
   build-vsix:
     name: Build VS Code Extension (${{ matrix.target }})
@@ -347,7 +401,7 @@ jobs:
   # the compliance-report archive, both folded into SHA256SUMS.txt.
   create-release:
     name: Create GitHub Release
-    needs: [build-binaries, build-compliance, build-test-evidence, build-vsix, build-sbom]
+    needs: [build-binaries, build-compliance, build-test-evidence, build-vsix, build-sbom, build-wasm]
     runs-on: ubuntu-latest
     # Restated at job-level: actions/attest-build-provenance + cosign
     # keyless OIDC need both `id-token: write` and `attestations: write`.

--- a/crates/spar-analysis/Cargo.toml
+++ b/crates/spar-analysis/Cargo.toml
@@ -8,10 +8,19 @@ description = "Pluggable analysis framework for AADL models"
 
 [dependencies]
 spar-hir-def.workspace = true
-spar-network.workspace = true
+# Explicit path dep (not workspace inheritance) so we can set
+# default-features = false — inherited deps can't override it. Keeps the MILP
+# solver (good_lp/HiGHS) opt-in; the `milp-solver` feature re-enables it for
+# normal builds, while spar-wasm builds without it (#259).
+spar-network = { path = "../spar-network", default-features = false }
 la-arena.workspace = true
 rustc-hash = "2"
 serde.workspace = true
+
+[features]
+default = ["milp-solver"]
+# Forwards to spar-network: enables the PMOO/LUDB WCTT tightening path.
+milp-solver = ["spar-network/milp-solver"]
 
 [dev-dependencies]
 spar-base-db.workspace = true

--- a/crates/spar-analysis/src/wctt.rs
+++ b/crates/spar-analysis/src/wctt.rs
@@ -792,6 +792,12 @@ impl WcttAnalysis {
             //
             // With `self.pmoo == false` (the default) this branch is a
             // no-op and the v0.9.2 output is byte-identical.
+            // PMOO/LUDB uses the HiGHS MILP solver, gated behind the
+            // `milp-solver` feature (off for wasm targets, #259). When the
+            // feature is disabled this whole branch compiles out and the
+            // analysis keeps the SFA bound — identical to `pmoo == false`.
+            #[cfg(feature = "milp-solver")]
+            {
             let sfa_delay_ps = total_delay_ps;
             if self.pmoo
                 && let Some((pmoo_delay_ps, pmoo_solve_us)) =
@@ -817,6 +823,7 @@ impl WcttAnalysis {
                 // min just in case f64 rounding flips that.
                 total_delay_ps = total_delay_ps.min(pmoo_delay_ps);
             }
+            } // end #[cfg(milp-solver)] PMOO branch
 
             // Step 6: budget check. If the source bus carried a
             // WCTT_Budget, compare. We use the *first* bound switch's
@@ -1175,6 +1182,10 @@ pub fn compute_network_hop_latency(
 ///
 /// On any failure (eligibility, LP infeasible, malformed inputs) we
 /// return `None` so the caller transparently keeps the SFA bound.
+///
+/// Compiled only with the `milp-solver` feature (the good_lp/HiGHS backend);
+/// the wasm build omits it (#259).
+#[cfg(feature = "milp-solver")]
 fn pmoo_or_sfa(
     tagged: &Stream,
     all_streams: &[Stream],
@@ -3208,6 +3219,7 @@ end Net;
     /// Helper: instantiate a fixture with multiple competing streams
     /// sharing a single FIFO switch. Used by both the PMOO-on and
     /// PMOO-off round-trip tests below.
+    #[cfg(feature = "milp-solver")]
     fn pmoo_fixture_aadl() -> &'static str {
         r#"
 package Net
@@ -3276,6 +3288,7 @@ end Net;
 "#
     }
 
+    #[cfg(feature = "milp-solver")]
     #[test]
     fn pmoo_flag_off_emits_no_pmoo_diagnostic() {
         // Default WcttAnalysis (pmoo = false) must produce
@@ -3296,6 +3309,7 @@ end Net;
         assert_eq!(bound_count, 4, "expected 4 streams: {:#?}", diags);
     }
 
+    #[cfg(feature = "milp-solver")]
     #[test]
     fn pmoo_flag_on_emits_pmoo_diagnostic_for_eligible_streams() {
         // With pmoo = true, the PMOO/LUDB path fires for every stream

--- a/crates/spar-analysis/src/wctt.rs
+++ b/crates/spar-analysis/src/wctt.rs
@@ -798,31 +798,31 @@ impl WcttAnalysis {
             // analysis keeps the SFA bound — identical to `pmoo == false`.
             #[cfg(feature = "milp-solver")]
             {
-            let sfa_delay_ps = total_delay_ps;
-            if self.pmoo
-                && let Some((pmoo_delay_ps, pmoo_solve_us)) =
-                    pmoo_or_sfa(stream, &streams, &switch_type, &service_for_bus)
-            {
-                let tightening_pct = if sfa_delay_ps > 0 {
-                    100.0 * (1.0 - (pmoo_delay_ps as f64 / sfa_delay_ps as f64))
-                } else {
-                    0.0
-                };
-                diags.push(AnalysisDiagnostic {
-                    severity: Severity::Info,
-                    message: format!(
-                        "WcttPmooBound: stream '{}' (method=ludb): PMOO delay {} ps vs SFA \
+                let sfa_delay_ps = total_delay_ps;
+                if self.pmoo
+                    && let Some((pmoo_delay_ps, pmoo_solve_us)) =
+                        pmoo_or_sfa(stream, &streams, &switch_type, &service_for_bus)
+                {
+                    let tightening_pct = if sfa_delay_ps > 0 {
+                        100.0 * (1.0 - (pmoo_delay_ps as f64 / sfa_delay_ps as f64))
+                    } else {
+                        0.0
+                    };
+                    diags.push(AnalysisDiagnostic {
+                        severity: Severity::Info,
+                        message: format!(
+                            "WcttPmooBound: stream '{}' (method=ludb): PMOO delay {} ps vs SFA \
                          {} ps (tightening {:.1}%, LP solve {} us)",
-                        stream_name, pmoo_delay_ps, sfa_delay_ps, tightening_pct, pmoo_solve_us,
-                    ),
-                    path: stream_path.clone(),
-                    analysis: self.name().to_string(),
-                });
-                // The PMOO bound is no looser than SFA on the LP's
-                // canonical topology (Bondorf et al.); guard with a
-                // min just in case f64 rounding flips that.
-                total_delay_ps = total_delay_ps.min(pmoo_delay_ps);
-            }
+                            stream_name, pmoo_delay_ps, sfa_delay_ps, tightening_pct, pmoo_solve_us,
+                        ),
+                        path: stream_path.clone(),
+                        analysis: self.name().to_string(),
+                    });
+                    // The PMOO bound is no looser than SFA on the LP's
+                    // canonical topology (Bondorf et al.); guard with a
+                    // min just in case f64 rounding flips that.
+                    total_delay_ps = total_delay_ps.min(pmoo_delay_ps);
+                }
             } // end #[cfg(milp-solver)] PMOO branch
 
             // Step 6: budget check. If the source bus carried a

--- a/crates/spar-network/Cargo.toml
+++ b/crates/spar-network/Cargo.toml
@@ -8,7 +8,15 @@ description = "Network Calculus primitives for AADL WCTT analysis (TSN/Ethernet,
 
 [dependencies]
 spar-hir-def.workspace = true
-good_lp.workspace = true
+# HiGHS-backed MILP solver for the PMOO/LUDB network-calculus bound. Optional
+# because `highs-sys` is a cmake/C++ build that cannot cross-compile to
+# wasm32 — the `milp-solver` feature gates it so spar-wasm can build (#259).
+good_lp = { workspace = true, optional = true }
+
+[features]
+default = ["milp-solver"]
+# Enables the `pmoo` module (PMOO/LUDB delay bound via good_lp + HiGHS).
+milp-solver = ["dep:good_lp"]
 
 [dev-dependencies]
 spar-base-db.workspace = true

--- a/crates/spar-network/src/lib.rs
+++ b/crates/spar-network/src/lib.rs
@@ -46,6 +46,10 @@
 
 pub mod curves;
 pub mod extract;
+/// PMOO/LUDB delay bound via a HiGHS-backed MILP (good_lp). Gated behind the
+/// default `milp-solver` feature so wasm targets (which can't build the cmake
+/// `highs-sys` dependency) can opt out (#259).
+#[cfg(feature = "milp-solver")]
 pub mod pmoo;
 pub mod tsn;
 pub mod types;
@@ -55,6 +59,7 @@ pub use curves::{
     ArrivalCurve, NcError, ServiceCurve, backlog_bound, delay_bound, output_bound, residual_service,
 };
 pub use extract::extract_network_graph;
+#[cfg(feature = "milp-solver")]
 pub use pmoo::{CompetingFlow, LpError, PmooBound, TaggedFlow, ludb_bound};
 pub use tsn::{
     CbsReservation, ClassOfService, CreditPool, GateSchedule, GateScheduleError, GateWindow,

--- a/crates/spar-wasm/Cargo.toml
+++ b/crates/spar-wasm/Cargo.toml
@@ -15,7 +15,10 @@ spar-syntax.workspace = true
 spar-base-db.workspace = true
 spar-hir-def.workspace = true
 spar-hir.workspace = true
-spar-analysis.workspace = true
+# Path dep with default-features = false so the MILP solver (good_lp/HiGHS,
+# a cmake build that can't target wasm32) is excluded. The wasm render path
+# uses only solver-free analyses; normal builds keep the solver (#259).
+spar-analysis = { path = "../spar-analysis", default-features = false }
 spar-render.workspace = true
 etch.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Fixes #259 — publishes the browser-ready `spar-wasm` bundle as release assets so rivet's AADL diagram rendering stops falling back to empty stub WASM (rivet#468).

## The real blocker (diagnosed first)
`spar-wasm` **could not build for `wasm32-wasip2`** at all: the HiGHS C++ MILP solver (`highs-sys`, cmake) was an *unconditional* dep via `spar-wasm → spar-analysis → spar-network → good_lp → highs`, and can't cross-compile to wasm.

## Fix
- **spar-network**: `good_lp` optional behind a default-on `milp-solver` feature that gates the `pmoo` module (PMOO/LUDB bound).
- **spar-analysis**: forwards `milp-solver` (default on); the `wctt.rs` PMOO branch, `pmoo_or_sfa`, and its tests are gated. Uses an explicit path dep on spar-network so `default-features = false` is settable (inherited workspace deps can't override it).
- **spar-wasm**: depends on spar-analysis with `default-features = false` → no good_lp/highs in the wasm tree. The render path registers only solver-free analyses, so nothing it exercises is lost.
- **release.yml**: new `build-wasm` job — build `wasm32-wasip2` + `jco transpile` (pinned 1.4.0) → `spar-wasm-browser-<version>.tar.gz` (`spar_wasm.js` + `spar_wasm.core*.wasm`). Named `*.tar.gz` so it flows through the existing flatten → SHA256SUMS → SLSA attest → cosign sign path with **no changes to those steps**.

## Verification (local, end-to-end)
- `cargo build --target wasm32-wasip2 -p spar-wasm --release` ✅ (was: highs-sys cmake error)
- `jco transpile` emits `spar_wasm.js` + `spar_wasm.core{,2,3}.wasm` ✅
- **Solver isolation** via `cargo tree -i highs-sys`: **present** for native spar-cli, **absent** for the wasm32-wasip2 spar-wasm tree ✅
- Native suites green: spar-network, spar-analysis (874), spar-wasm, spar — 0 failures. `rivet validate` unchanged vs origin/main (0 broken cross-refs).

**Design note:** the browser build omits PMOO/LUDB (MILP) network-calculus tightening — CLI-opt-in only and unused by the render path, so invisible to the rivet use case. Detailed on the issue. Raw `spar_wasm.wasm` component (optional in #259) deferred — can be added to the flatten/attest globs if rivet's server-side rendering needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)