### PR TITLE
chore(release): bump to v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1480,14 +1480,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -788,7 +788,7 @@ artifacts:
       features. Data ports → WIT stream<T>, event ports → WIT future,
       subprogram access → WIT functions. wit-bindgen runs as Bazel build
       action (not proc macro) producing plain Rust bindings.
-    status: planned
+    status: implemented
     tags: [codegen, wit, v040]
     links:
       - type: traces-to

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -3063,3 +3063,27 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-PLUGFEST-001
+
+  - id: TEST-CODEGEN-WIT-VALID
+    type: feature
+    title: Generated WIT parses and resolves (wit-parser round-trip)
+    description: >
+      crates/spar-codegen/src/wit_gen.rs tests
+      (generated_wit_is_valid_and_bindable + wit_ident_kebab_cases) feed
+      generated WIT through wit-parser's Resolve::push_str, which rejects
+      invalid identifiers AND references to undefined types — the two
+      failure classes of issue #254 (underscored idents from the Rust
+      sanitizer; ports referencing types never defined). Also asserts the
+      kebab-case mapping for the exact identifiers from the issue and
+      that every referenced data type gets a `type x = list<u8>` alias.
+      End-to-end confirmed with wasm-tools 1.243.0 `component wit`
+      (the reporter's repro command) on the fixed output.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-codegen --lib -- wit_gen
+    status: passing
+    tags: [codegen, wit, interop, v0130]
+    links:
+      - type: satisfies
+        target: REQ-CODEGEN-WIT

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump 0.12.0 → 0.13.0 (workspace + VS Code extension; Cargo.lock restamped). Cuttable per the release plan (#262, milestone v0.13.0) — every scoped item is merged:

| | |
|---|---|
| #254 invalid WIT → valid, bindable (kebab idents + defined types) | #255 ✅ |
| #236 cross-file extends-chain instantiation panic | #256 ✅ |
| #237 properties on connections/features preserved | #257 ✅ |
| #235 case-insensitive AADL keyword highlighting | #258 ✅ |
| #259 wasm32 build + browser bundle release asset | #260 ✅ |

Traceability: new TEST-CODEGEN-WIT-VALID (wit-parser round-trip guard from #255) satisfies REQ-CODEGEN-WIT → promoted to implemented; the v0.13.0 rivet scope reads 1/1 done. `rivet validate`: 0 broken cross-refs.

On merge: signed annotated tag `v0.13.0` fires release.yml — first release shipping the **spar-wasm-browser** bundle alongside the cosign+SLSA chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)