### PR TITLE
chore(traceability): v0.14.0 link-and-promote — six codegen/MCP requirements to implemented

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -627,7 +627,7 @@ artifacts:
       Model Context Protocol server running as a spar CLI subcommand,
       exposing AADL analysis passes as MCP tools and instance model
       elements as MCP resources over stdio JSON-RPC transport.
-    status: planned
+    status: implemented
     tags: [mcp, integration, v040]
     fields:
       release: v0.14.0
@@ -804,7 +804,7 @@ artifacts:
       skeleton), ports.rs (typed channels), types.rs (data structs),
       config.rs (#[aadl(...)] scheduling attributes). System generates
       Cargo workspace. Both native and WASM component targets.
-    status: planned
+    status: implemented
     tags: [codegen, rust, v040]
     links:
       - type: traces-to
@@ -821,7 +821,7 @@ artifacts:
       rules_verus (SMT checking), rules_lean (proof checking),
       rules_kani (bounded model checking). Cargo.toml also generated
       for development iteration.
-    status: planned
+    status: implemented
     tags: [codegen, bazel, v040]
     links:
       - type: traces-to
@@ -837,7 +837,7 @@ artifacts:
       checked against AADL model at build time. Proc macro (Cargo) or
       build action (Bazel) reads model and fails compilation if constants
       diverge. Catches structural drift between design and code.
-    status: planned
+    status: implemented
     tags: [codegen, verification, v040]
     links:
       - type: traces-to
@@ -853,7 +853,7 @@ artifacts:
       directions match, all required ports connected, execution time
       within WCET bounds. Test results feed into rivet as verification
       evidence artifacts.
-    status: planned
+    status: implemented
     tags: [codegen, verification, testing, v040]
     links:
       - type: traces-to
@@ -885,7 +885,7 @@ artifacts:
       (links to requirements, architecture decisions), verification.yaml
       with verification-verdict records for each layer. SysML v2 forward
       compatible link types (satisfies, verifies match SysML v2 satisfy, verify).
-    status: planned
+    status: implemented
     tags: [codegen, rivet, traceability, v040]
     links:
       - type: traces-to

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -771,6 +771,21 @@ artifacts:
         target: REQ-CODEGEN-WIT
       - type: verifies
         target: REQ-CODEGEN-RUST
+      # v0.14.0 link-and-promote batch: the suite's golden tests validate
+      # each generator's output (rust_gen crate skeletons, workspace_gen
+      # BUILD.bazel, doc_gen + verification-yaml for rivet, test_gen
+      # harnesses, and build_gen's aadl-contract.toml + drift-failing
+      # build.rs from #263), so it satisfies those requirements directly.
+      - type: satisfies
+        target: REQ-CODEGEN-RUST
+      - type: satisfies
+        target: REQ-CODEGEN-BAZEL
+      - type: satisfies
+        target: REQ-CODEGEN-RIVET
+      - type: satisfies
+        target: REQ-CODEGEN-VERIFY-TEST
+      - type: satisfies
+        target: REQ-CODEGEN-VERIFY-BUILD
       - type: satisfies
         target: ARCH-CODEGEN-002
       - type: satisfies
@@ -2394,6 +2409,11 @@ artifacts:
     status: passing
     tags: [mcp, migration, track-e, v090, integration]
     links:
+      # v0.14.0 link-and-promote: the tool-surface tests exercise the MCP
+      # server's analysis tools + model resources end-to-end (in-process
+      # and stdio JSON-RPC), which is REQ-MCP-001's contract.
+      - type: satisfies
+        target: REQ-MCP-001
       - type: satisfies
         target: REQ-MCP-002
       - type: satisfies


### PR DESCRIPTION
Evidence-gated promotion batch (release plan #262, milestone v0.14.0): VAL-CODEGEN-002 (full spar-codegen suite — 48 lib + 22 golden green, incl. #263's build-contract golden test) now `satisfies` REQ-CODEGEN-RUST/-BAZEL/-RIVET/-VERIFY-TEST/-VERIFY-BUILD; TEST-MCP-TOOLS `satisfies` REQ-MCP-001. All six promoted `planned` → `implemented`.

`rivet validate`: 436 errors (**down 6**), 0 broken cross-refs. v0.14.0 burn-down now **8/9** — REQ-CODEGEN-WIT-TYPES (Data_Size → scalar WIT types) is the last item, in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)