### PR TITLE
feat(codegen): WIT scalar type fidelity from Data_Size (REQ-CODEGEN-WIT-TYPES)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2385,7 +2385,7 @@ artifacts:
       etc.) instead of the blanket `type x = list<u8>` alias introduced
       by the #254 validity fix. Requires threading scope/property access
       into generate_wit. Follow-up recorded in #254/#255.
-    status: proposed
+    status: implemented
     tags: [codegen, wit, interop]
     fields:
       release: v0.14.0

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -3123,3 +3123,26 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-CODEGEN-WIT
+
+  - id: TEST-CODEGEN-WIT-TYPES
+    type: feature
+    title: WIT scalar type fidelity from Data_Size
+    description: >
+      wit_gen's generated_wit_is_valid_and_bindable exercises the full
+      chain for REQ-CODEGEN-WIT-TYPES: instantiation resolves each
+      feature's data classifier to its declared Data_Size (bytes) via
+      Builder::resolve_data_size_bytes and stores it on FeatureInstance;
+      generate_wit maps scalar sizes to precise WIT types (1 -> u8,
+      2 -> u16, 4 -> u32, 8 -> u64; conflicting or undeclared sizes stay
+      list<u8>). Asserts `type clock64 = u64;` for an 8-byte data type,
+      `type flag8 = u8;` for a 1-byte one, list<u8> for an unsized one,
+      and wit-parser Resolve::push_str accepts the result.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-codegen --lib -- wit_gen
+    status: passing
+    tags: [codegen, wit, interop, v0140]
+    links:
+      - type: satisfies
+        target: REQ-CODEGEN-WIT-TYPES

--- a/crates/spar-analysis/src/arinc653.rs
+++ b/crates/spar-analysis/src/arinc653.rs
@@ -491,6 +491,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/classifier_match.rs
+++ b/crates/spar-analysis/src/classifier_match.rs
@@ -396,6 +396,7 @@ mod tests {
                 classifier,
                 access_kind,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/completeness.rs
+++ b/crates/spar-analysis/src/completeness.rs
@@ -199,6 +199,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/connection_rules.rs
+++ b/crates/spar-analysis/src/connection_rules.rs
@@ -230,6 +230,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/connectivity.rs
+++ b/crates/spar-analysis/src/connectivity.rs
@@ -460,6 +460,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/direction_rules.rs
+++ b/crates/spar-analysis/src/direction_rules.rs
@@ -363,6 +363,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/feature_group_check.rs
+++ b/crates/spar-analysis/src/feature_group_check.rs
@@ -437,6 +437,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/flow_check.rs
+++ b/crates/spar-analysis/src/flow_check.rs
@@ -252,6 +252,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/flow_rules.rs
+++ b/crates/spar-analysis/src/flow_rules.rs
@@ -439,6 +439,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/legality.rs
+++ b/crates/spar-analysis/src/legality.rs
@@ -498,6 +498,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/mode_check.rs
+++ b/crates/spar-analysis/src/mode_check.rs
@@ -235,6 +235,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/mode_reachability.rs
+++ b/crates/spar-analysis/src/mode_reachability.rs
@@ -618,6 +618,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
             idx

--- a/crates/spar-analysis/src/mode_rules.rs
+++ b/crates/spar-analysis/src/mode_rules.rs
@@ -192,6 +192,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: None,
+                data_size_bytes: None,
             });
             self.components[owner].features.push(idx);
         }

--- a/crates/spar-analysis/src/regression_tests.rs
+++ b/crates/spar-analysis/src/regression_tests.rs
@@ -84,6 +84,7 @@ impl TestInstanceBuilder {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
         self.components[owner].features.push(idx);
         idx

--- a/crates/spar-analysis/src/tests.rs
+++ b/crates/spar-analysis/src/tests.rs
@@ -77,6 +77,7 @@ impl TestInstanceBuilder {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
         self.components[owner].features.push(idx);
         idx

--- a/crates/spar-cli/src/assertion/mod.rs
+++ b/crates/spar-cli/src/assertion/mod.rs
@@ -487,6 +487,7 @@ mod tests {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
 
         // Add features to thread2: an in data port
@@ -498,6 +499,7 @@ mod tests {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
 
         // Unconnected out port on thread2
@@ -509,6 +511,7 @@ mod tests {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
 
         // Connect thread1.sensor_out -> thread2.cmd_in

--- a/crates/spar-cli/src/diff.rs
+++ b/crates/spar-cli/src/diff.rs
@@ -861,6 +861,7 @@ mod tests {
                     classifier: None,
                     access_kind: None,
                     array_index: None,
+                    data_size_bytes: None,
                 });
                 self.components[owner].features.push(idx);
                 idx

--- a/crates/spar-codegen/src/wit_gen.rs
+++ b/crates/spar-codegen/src/wit_gen.rs
@@ -4,7 +4,7 @@
 //! the process's ports as WIT imports/exports, following the WASI Component
 //! Model conventions.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
 use spar_hir_def::item_tree::{ComponentCategory, Direction, FeatureKind};
@@ -43,23 +43,42 @@ pub fn generate_wit(inst: &SystemInstance, proc_idx: ComponentInstanceIdx) -> Ge
     // First pass: collect every named data type referenced by a port so we can
     // emit `type` definitions. WIT rejects references to undefined types, so an
     // interface that names `mattermessage` without defining it will not bind.
-    let mut referenced_types: BTreeSet<String> = BTreeSet::new();
+    // The instance model carries each feature's resolved Data_Size (bytes), so
+    // scalar-sized data types map to precise WIT scalars instead of a byte
+    // buffer (REQ-CODEGEN-WIT-TYPES): 1 -> u8, 2 -> u16, 4 -> u32, 8 -> u64;
+    // anything else (or undeclared) stays list<u8>. If two features reference
+    // the same type name with conflicting sizes, fall back to list<u8> rather
+    // than guess.
+    let mut referenced_types: BTreeMap<String, Option<u64>> = BTreeMap::new();
     for &fi in &comp.features {
         let feat = &inst.features[fi];
         if let Some(c) = feat.classifier.as_ref() {
-            referenced_types.insert(wit_ident(&c.to_string()));
+            let ty = wit_ident(&c.to_string());
+            match referenced_types.entry(ty) {
+                std::collections::btree_map::Entry::Vacant(e) => {
+                    e.insert(feat.data_size_bytes);
+                }
+                std::collections::btree_map::Entry::Occupied(mut e) => {
+                    if *e.get() != feat.data_size_bytes {
+                        e.insert(None); // conflicting sizes: stay list<u8>
+                    }
+                }
+            }
         }
     }
 
     // Generate an interface for the process's own ports
     wit.push_str(&format!("interface {name}-ports {{\n"));
 
-    // Emit a type alias for each referenced data type. Without per-type
-    // `Data_Size` resolution (the generator has no scope handle here) every
-    // AADL data type maps to a byte buffer — always valid and bindable.
-    // Refining scalar sizes (8 bytes -> u64, etc.) is tracked as a follow-up.
-    for ty in &referenced_types {
-        wit.push_str(&format!("    type {ty} = {DEFAULT_WIT_TYPE};\n"));
+    for (ty, size) in &referenced_types {
+        let wit_ty = match size {
+            Some(1) => "u8",
+            Some(2) => "u16",
+            Some(4) => "u32",
+            Some(8) => "u64",
+            _ => DEFAULT_WIT_TYPE,
+        };
+        wit.push_str(&format!("    type {ty} = {wit_ty};\n"));
     }
     if !referenced_types.is_empty() {
         wit.push('\n');
@@ -238,12 +257,24 @@ public
     data Sample
     end Sample;
 
+    data Clock64
+        properties
+            Data_Size => 8 Bytes;
+    end Clock64;
+
+    data Flag8
+        properties
+            Data_Size => 1 Bytes;
+    end Flag8;
+
     process Controller
         features
             sensor_in: in data port;
             cmd_out: out data port;
             message_in: in event data port Sample;
             announce_out: out event data port Sample;
+            clock_in: in event data port Clock64;
+            flag_in: in event data port Flag8;
     end Controller;
 
     process implementation Controller.Impl
@@ -328,6 +359,18 @@ end TestPkg;
         assert!(
             body.contains("type sample = list<u8>;"),
             "expected a type alias for the `Sample` data type:\n{body}"
+        );
+
+        // Scalar Data_Size maps to precise WIT scalars (REQ-CODEGEN-WIT-TYPES):
+        // Clock64 declares 8 Bytes -> u64, Flag8 declares 1 Bytes -> u8;
+        // Sample declares nothing -> stays list<u8> (asserted above).
+        assert!(
+            body.contains("type clock64 = u64;"),
+            "8-byte Data_Size must map to u64:\n{body}"
+        );
+        assert!(
+            body.contains("type flag8 = u8;"),
+            "1-byte Data_Size must map to u8:\n{body}"
         );
 
         // Authoritative check: feed the WIT to wit-parser. push_str errors on

--- a/crates/spar-hir-def/src/instance.rs
+++ b/crates/spar-hir-def/src/instance.rs
@@ -105,6 +105,11 @@ pub struct FeatureInstance {
     pub access_kind: Option<AccessKind>,
     /// Array index for array features: None for non-array, Some(1..N) for array elements.
     pub array_index: Option<u64>,
+    /// Resolved `Data_Size` (in bytes) of the feature's data classifier, when
+    /// the classifier resolves to a `data` component type that declares one.
+    /// Lets consumers (e.g. WIT codegen scalar mapping, REQ-CODEGEN-WIT-TYPES)
+    /// use the size without re-resolving against the global scope.
+    pub data_size_bytes: Option<u64>,
 }
 
 /// A connection instance.
@@ -1977,6 +1982,46 @@ impl<'a> Builder<'a> {
     /// Populate features, flows, modes, and mode transitions from a resolved component type.
     ///
     /// Walks the extends chain to include inherited features from parent types.
+    /// Resolve a feature's data classifier to its declared `Data_Size`, in
+    /// bytes (REQ-CODEGEN-WIT-TYPES). Returns `None` when the classifier
+    /// does not resolve to a `data` component type, declares no `Data_Size`,
+    /// or the value does not parse as a size.
+    fn resolve_data_size_bytes(
+        &self,
+        from_package: &Name,
+        classifier: &ClassifierRef,
+    ) -> Option<u64> {
+        let resolved = self.scope.resolve_classifier(from_package, classifier);
+        let loc = match &resolved {
+            ResolvedClassifier::ComponentType { loc, .. } => *loc,
+            _ => return None,
+        };
+        let ct = self.scope.get_component_type(loc)?;
+        if ct.category != ComponentCategory::Data {
+            return None;
+        }
+        let tree = self.scope.tree(loc.tree)?;
+        for &pa_idx in &ct.property_associations {
+            let pa = &tree.property_associations[pa_idx];
+            if pa
+                .name
+                .property_name
+                .as_str()
+                .eq_ignore_ascii_case("Data_Size")
+                || pa
+                    .name
+                    .property_name
+                    .as_str()
+                    .eq_ignore_ascii_case("Source_Data_Size")
+            {
+                // parse_size_value returns BITS ("8 Bytes" -> 64).
+                let bits = crate::property_value::parse_size_value(&pa.value)?;
+                return Some(bits / 8);
+            }
+        }
+        None
+    }
+
     fn populate_from_type(
         &mut self,
         idx: ComponentInstanceIdx,
@@ -2035,6 +2080,9 @@ impl<'a> Builder<'a> {
         for (name, kind, direction, classifier, access_kind, array_dims) in feat_data {
             let feat_count = array_element_count(&array_dims, &mut self.diagnostics, &name);
             let feat_is_array = !array_dims.is_empty();
+            let data_size_bytes = classifier
+                .as_ref()
+                .and_then(|c| self.resolve_data_size_bytes(type_package, c));
 
             for fi_i in 0..feat_count {
                 let feat_array_index = if feat_is_array { Some(fi_i + 1) } else { None };
@@ -2051,6 +2099,7 @@ impl<'a> Builder<'a> {
                     classifier: classifier.clone(),
                     access_kind,
                     array_index: feat_array_index,
+                    data_size_bytes,
                 });
                 feat_indices.push(fi);
             }
@@ -2745,6 +2794,7 @@ mod tests {
                 classifier: None,
                 access_kind: None,
                 array_index: Some(i),
+                data_size_bytes: None,
             });
             feat_indices.push(fi);
         }
@@ -2939,6 +2989,7 @@ mod tests {
                     classifier: None,
                     access_kind: None,
                     array_index: Some(fi),
+                    data_size_bytes: None,
                 });
                 feat_indices.push(feat);
             }

--- a/crates/spar-render/src/lib.rs
+++ b/crates/spar-render/src/lib.rs
@@ -790,6 +790,7 @@ mod tests {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         };
         let p = feature_to_port(&f);
         assert_eq!(p.port_type, PortType::Data);
@@ -804,6 +805,7 @@ mod tests {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         };
         let p2 = feature_to_port(&f2);
         assert_eq!(p2.port_type, PortType::Event);

--- a/crates/spar-solver/src/tests.rs
+++ b/crates/spar-solver/src/tests.rs
@@ -89,6 +89,7 @@ impl TestBuilder {
             classifier: None,
             access_kind: None,
             array_index: None,
+            data_size_bytes: None,
         });
         self.components[owner].features.push(idx);
         idx


### PR DESCRIPTION
Last v0.14.0 scope item (release plan #262) — the fidelity follow-up promised on #254: AADL data types with scalar `Data_Size` now map to precise WIT scalars instead of the blanket `list<u8>`.

- **spar-hir-def**: `FeatureInstance.data_size_bytes`, resolved at instantiation (classifier → `data` component type → `Data_Size`/`Source_Data_Size`, bits→bytes) — resolved where the Builder has scope, so consumers don't re-resolve.
- **wit_gen**: 1→`u8`, 2→`u16`, 4→`u32`, 8→`u64`; undeclared/non-scalar stays `list<u8>`; conflicting sizes for one type name fall back to `list<u8>` rather than guess.
- **Tests**: end-to-end (`Clock64 8 Bytes` → `type clock64 = u64;`, `Flag8 1 Bytes` → `u8`, unsized → `list<u8>`) + wit-parser `Resolve` round-trip green. Workspace suites green.

Traceability: `TEST-CODEGEN-WIT-TYPES` satisfies `REQ-CODEGEN-WIT-TYPES` → `implemented`. With this + #265 + #266, **v0.14.0 scope is 9/9** — bump PR follows.

For the wohl Matter seam: `MonotonicTime 8 Bytes` now binds as `u64` as requested in #254's fidelity note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)