### PR TITLE
chore(release): bump to v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1480,14 +1480,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cut **v0.16.0**. The sole release-scoped requirement — **REQ-PLUGFEST-003** (core AADL parser gap closure) — is `implemented` and merged via #271, with CI green.

## Included in v0.16.0
- **#271** — four core-AADL parser constructs closed (array subscripts on containment paths, numeric-range property-type constraints, parenthesised classifier-ref lists, in-mode property associations). OSATE corpus ratchet **519→532** parsed (core **284→297**).

## Deferred (tracked)
- EMV2 annex-path `applies to ({EMV2}**…)` clauses → **REQ-PLUGFEST-005** (Tier-B EMV2 oracle track, v0.21.0).

Version bump only: `Cargo.toml`, `Cargo.lock`, `vscode-spar/package.json` (0.15.0 → 0.16.0). Tag `v0.16.0` pushed after merge to trigger binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)