### PR TITLE
chore(deps): bump rand to 0.9.3 to clear RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,9 +932,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -437,7 +437,7 @@ version = "6.0.0"
 criteria = "safe-to-run"
 
 [[exemptions.rand]]
-version = "0.9.2"
+version = "0.9.3"
 criteria = "safe-to-run"
 
 [[exemptions.rand_chacha]]


### PR DESCRIPTION
## What

Bumps `rand` 0.9.2 → 0.9.3 (Cargo.lock only) + matching cargo-vet exemption version, to clear **RUSTSEC-2026-0097**.

## Why

The full-tree **Security Audit (RustSec)** job on the `main` push for the v0.16.0 bump (#273, commit `ecb796f`) failed on `RUSTSEC-2026-0097` — an `unsound` informational warning on `rand 0.9.2` ("unsound with a custom logger using `rand::rng()`"). Zero actual vulnerabilities were found; the gate denies on `unsound` warnings.

`rand` is a **transitive dev-dependency only** (via `proptest 1.11.0`) — never in shipped binaries, and the unsound reseed-from-custom-logger path is not exercised by test code. Real risk is nil, but the gate (correctly) blocks.

The #273 PR check passed because `rustsec/audit-check` only diffs *newly-introduced* advisories on `pull_request` events, whereas the `push` event audits the *full* dependency tree.

## Scope

- `Cargo.lock`: `rand` 0.9.2 → 0.9.3 (semver-compatible patch; 40 other deps unchanged)
- `supply-chain/config.toml`: `exemptions.rand` version 0.9.2 → 0.9.3

No code or API change. This unblocks the `v0.16.0` tag (which will land on the post-merge green main commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)