### PR TITLE
chore(release): bump to v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2550,11 +2550,16 @@ artifacts:
       spar trace topology shall flag declared AADL connections whose
       endpoints never appear as observed adjacency in the runtime
       topology sources (LLDP/PCAPNG) — wiring declared but not observed.
-      Third of the five deterministic reconciler checks.
+      Third of the five deterministic reconciler checks. DEFERRED out of
+      v0.17.0 (2026-06-14): the v0.17.0 cut is the TSN-competitor Tier-1
+      spine (DBC ingest + FP-TFA), and this check is still a
+      defined-but-unemitted ReconcileFinding stub gated on the
+      connection-property surfacing prerequisite (spar-trace-topology
+      engine.rs §"Deliberately deferred"). Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.17.0
+      release: v0.19.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-002
@@ -2566,11 +2571,14 @@ artifacts:
       spar trace topology shall compare declared Spar_TSN/Spar_Network
       switch configuration (gate schedules, reservations,
       class-of-service) against observed Qcc YANG switch config and flag
-      drift. Fourth of the five deterministic reconciler checks.
+      drift. Fourth of the five deterministic reconciler checks. DEFERRED
+      out of v0.17.0 (2026-06-14): unemitted ReconcileFinding stub gated on
+      the connection-property surfacing prerequisite; v0.17.0 ships the
+      DBC+FP-TFA TSN spine. Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.17.0
+      release: v0.19.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-005
@@ -2583,11 +2591,14 @@ artifacts:
       (Spar_Identity hashes/versions) against observed attestation
       evidence and flag mismatches between the declared deployment and
       what is actually running. Fifth of the five deterministic
-      reconciler checks.
+      reconciler checks. DEFERRED out of v0.17.0 (2026-06-14): unemitted
+      ReconcileFinding stub gated on the connection-property surfacing
+      prerequisite (and observed-attestation ingest); v0.17.0 ships the
+      DBC+FP-TFA TSN spine. Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler, attestation]
     fields:
-      release: v0.17.0
+      release: v0.19.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-008

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.17.0** — the TSN-competitor Tier-1 spine.

## Scope (both `implemented`, V-trace closed)
- **REQ-INGEST-DBC-001** — CAN `.dbc` ingest → AADL via `spar-dbc` (#277)
- **REQ-NC-TFA-001** — FP-TFA / TFA++ network-calculus bounds (#276)

## Release-scope hygiene
`REQ-TRACE-TOPOLOGY-010/011/012` (3rd–5th trace-topology reconciler checks) were provisionally parked in v0.17.0 but remain defined-but-unemitted `ReconcileFinding` stubs gated on the connection-property surfacing prerequisite. **Deferred to v0.19.0** as a deliberate, logged scope decision, so v0.17.0's scope is exactly the two implemented spine requirements — matching the all-`implemented` release convention of v0.14–v0.16.

## Version bump
`0.16.0 → 0.17.0` across `Cargo.toml`, `Cargo.lock` (×23 workspace crates), `vscode-spar/package.json`. No other dependency churn.

## Falsification statement
If `spar dbc <file.dbc>` produced AADL that spar's own parser+instantiation pipeline rejected (nonzero diagnostics), or FP-TFA returned an SFA-optimistic burst (σ+ρ·T instead of σ+ρ·D), v0.17.0 would be unsound. Both are pinned by passing oracle tests (`TEST-INGEST-DBC`, `TEST-NC-TFA`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)