### PR TITLE
chore(release): bump to v0.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ verification.yaml
 
 # Stale dev artifacts — re-add explicitly if needed.
 /dashboard-render*.png
+
+# LP solver problem dumps written into the repo root by HiGHS/good_lp
+# during network-calculus (PLP/TFA) test runs — regenerable scratch.
+*.lp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -123,8 +123,6 @@ artifacts:
       and down patterns to produce end-to-end connection instances.
     status: partial
     tags: [instance, as5506-ch14]
-    fields:
-      release: v0.18.0
 
   - id: REQ-INST-004
     type: requirement
@@ -230,8 +228,6 @@ artifacts:
       subcomponent rules. Target 50+ rules.
     status: partial
     tags: [analysis, legality]
-    fields:
-      release: v0.18.0
 
   - id: REQ-ANALYSIS-008
     type: requirement
@@ -471,8 +467,6 @@ artifacts:
     links:
       - type: satisfies
         target: REQ-INST-004
-    fields:
-      release: v0.18.0
 
   - id: COVERAGE-CH13
     type: requirement
@@ -984,8 +978,6 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-SOLVER-009
-    fields:
-      release: v0.18.0
 
   - id: REQ-RESOLUTE-001
     type: requirement
@@ -2438,7 +2430,7 @@ artifacts:
     status: proposed
     tags: [proofs, lean, scheduling, kiln, substrate]
     fields:
-      release: v0.18.0
+      release: v0.20.0
     links:
       - type: traces-to
         target: REQ-PROOF-SCHED-001
@@ -2647,7 +2639,7 @@ artifacts:
     status: proposed
     tags: [ingest, dbc, can, flows, tier1]
     fields:
-      release: v0.18.0
+      release: v0.19.0
 
   - id: REQ-INGEST-ARXML-001
     type: requirement
@@ -2665,7 +2657,7 @@ artifacts:
     status: proposed
     tags: [ingest, arxml, autosar, tier1]
     fields:
-      release: v0.18.0
+      release: v0.19.0
 
   - id: REQ-NC-TFA-001
     type: requirement

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.18.0 — the network-calculus foundation

The runnable spine that makes spar a tsnkit / TTTech Slate / RTaW-Pegase competitor end-to-end: **AADL model → network-wide NC analysis → per-stream delay bounds**. Three coherent, merged-to-main requirements:

| Req | What | PR |
|---|---|---|
| REQ-NC-VALIDATION-001 | NC-bound cross-validation against the panco reference (Bouillard) | #279 |
| REQ-NC-PLP-001 | PLP (polynomial-LP) network-calculus bounds, arXiv:2010.09263 | #280 |
| REQ-NC-BRIDGE-001 | AADL instance → network-wide TFA/PLP solver bridge (`--pmoo` arm) | #283 |

All three are `implemented` with **passing feature tests and a closed V-trace** (TEST-NC-VALIDATION / TEST-NC-PLP / TEST-NC-BRIDGE `satisfies`; DEC-TSN-OSS-001 the strategic decision) — matching the all-implemented release convention of v0.14–v0.17. All three commits are on `main` with green CI.

**Falsification statement:** on a shared multi-hop FIFO TSN line, PLP yields a strictly *tighter* per-flow delay bound than TFA (measured ~2.7× on a 3-hop line: 39 µs vs 105.5 µs), and never looser on a feed-forward sink-tree — the analysis-dominance wedge a real competitor needs. If PLP ever exceeded TFA on a feed-forward topology, the cross-validation gate (sandwich EXACT ≤ PLP ≤ TFA) would fail.

## Release-scope hygiene (deliberate, logged)

v0.18.0 was overloaded with 7 unrelated carry-overs. Moved so the scope is *exactly* the three NC spine requirements:

- **REQ-INGEST-ARXML-001, REQ-INGEST-DBC-FLOWS-001 → v0.19.0** (ingest track, alongside the already-slated REQ-NC-PLP-002 converging-PLP work)
- **REQ-PROOF-SCHED-002 → v0.20.0** (proofs track, with REQ-PROOF-NC-MINPLUS-001)
- **REQ-SECURITY-001 → backlog** (no security theme on the roadmap yet — unscheduled rather than a fake commitment)
- **REQ-INST-003, REQ-ANALYSIS-007, COVERAGE-CH12 → backlog** (perpetual AS5506-coverage trackers, partial-by-design — were re-blocking every release's readiness query)

## Version bump

Workspace `0.17.0 → 0.18.0` (Cargo.toml, Cargo.lock ×23 crates, vscode-spar/package.json). Plus `*.lp` gitignore — HiGHS/good_lp solver dumps the NC test runs write into the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)