### PR TITLE
chore(release): bump to v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.19.0 — network-calculus tightening on converging TSN topologies

Scope is **exactly the implemented set** (release-planning hygiene — the 11
still-proposed/planned items were moved to v0.20.0 in #287):

- **REQ-NC-PLP-CONVERGE-001** — PLP on converging sink-trees via topological relabel (#285)
- **REQ-NC-PLP-003** — TFA-strengthened PLP tightening to EXACT (#287)

### Headline

REQ-NC-PLP-003 repairs the pure-PLP / TFA **incomparability**. On the
converging-bridge net where pure PLP's tagged flow *exceeds* TFA
(`1148.33 µs > 1048.09 µs` — both sound, neither dominates), the TFA-delay-
strengthened LP drives the bound to **EXACT `1035.2 µs` — back below TFA**.
Combined with CONVERGE-001, the many-talkers→one-listener TSN topology now
yields the `PLP ≤ TFA` dominance LUDB/PMOO cannot show on a tree.

### Verification

- Pre-tag clean-room verification (two fresh-context refutation agents): **work
  sound, no bugs** (constraint block byte-identical to panco, `d[j]` per-server
  TFA delay, LP always feasible, monotone by construction); **campaign machinery
  clean** (gate non-empty, tags signed, no orphan claims).
- Both scope items are `implemented` with closed V-traces (`TEST-NC-PLP-CONVERGE`,
  `TEST-NC-PLP-STR` passing), panco-pinned oracles under `EXACT ≤ str ≤ pure ≤ —`.

### Bump

Workspace `Cargo.toml` `0.18.0 → 0.19.0`, `Cargo.lock` (23 crates), `vscode-spar/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)