### PR TITLE
chore(release): bump to v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -610,7 +610,7 @@ artifacts:
     status: planned
     tags: [diff, merge, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   # ── MCP Server ───────────────────────────────────────────────────────
 
@@ -639,7 +639,7 @@ artifacts:
     status: planned
     tags: [query, instance, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   # ── Deployment Solver (v0.4.0+) ──────────────────────────────────────
 
@@ -703,7 +703,7 @@ artifacts:
     status: planned
     tags: [solver, verification, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-SOLVER-006
     type: requirement
@@ -741,7 +741,7 @@ artifacts:
     status: planned
     tags: [solver, safety, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-SOLVER-009
     type: requirement
@@ -754,7 +754,7 @@ artifacts:
     status: planned
     tags: [solver, security, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   # ── Competitive Gap Requirements (v0.4.0+) ─────────────────────────
 
@@ -990,7 +990,7 @@ artifacts:
     status: planned
     tags: [verification, competitive-gap, v040]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-BIDIRECTIONAL-001
     type: requirement
@@ -2430,7 +2430,7 @@ artifacts:
     status: proposed
     tags: [proofs, lean, scheduling, kiln, substrate]
     fields:
-      release: v0.20.0
+      release: v0.21.0
     links:
       - type: traces-to
         target: REQ-PROOF-SCHED-001
@@ -2455,7 +2455,7 @@ artifacts:
     status: proposed
     tags: [ingest, sysml2, grammar]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-PLUGFEST-002
     type: requirement
@@ -2551,7 +2551,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.20.0
+      release: v0.21.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-002
@@ -2570,7 +2570,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.20.0
+      release: v0.21.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-005
@@ -2590,7 +2590,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler, attestation]
     fields:
-      release: v0.20.0
+      release: v0.21.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-008
@@ -2670,7 +2670,7 @@ artifacts:
     status: proposed
     tags: [ingest, arxml, autosar, tier1]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-NC-TFA-001
     type: requirement
@@ -2757,7 +2757,7 @@ artifacts:
     status: proposed
     tags: [network-calculus, plp, cyclic, substrate, tier1]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-NC-PLP-CONVERGE-001
     type: requirement
@@ -2960,7 +2960,7 @@ artifacts:
     status: proposed
     tags: [network-calculus, cbs, qav, audit, tier1]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   # --- Tier 2: the product bet (synthesis → export), kill-gated ---
 
@@ -3024,7 +3024,7 @@ artifacts:
     status: proposed
     tags: [tsn, synthesis, milp, tier2]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-TSN-SYNTH-CQF-BASE-001
     type: requirement
@@ -3169,7 +3169,7 @@ artifacts:
     status: proposed
     tags: [proof, lean, network-calculus, soundness, tier3]
     fields:
-      release: v0.20.0
+      release: v0.21.0
 
   - id: REQ-PROOF-NC-CERT-001
     type: requirement

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.20.0** — the TSN synthesis track, end to end.

## Shipped (5 implemented requirements — a coherent ingest → synthesize → bridge → export story)
| Req | What |
|---|---|
| REQ-INGEST-DBC-FLOWS-001 | CAN/DBC message flows as AADL ports + bus-bound connections |
| REQ-TSN-SYNTH-QBV-BASE-001 | 802.1Qbv GCL synthesis baseline (exact TAS round-trip oracle) |
| REQ-TSN-SYNTH-CQF-BASE-001 | Standard CQF synthesis baseline (single cycle-time) |
| REQ-TSN-SYNTH-CQF-BRIDGE-001 | AADL `SystemInstance` → `CqfFlow` → `synthesize_cqf` bridge |
| REQ-TSN-EXPORT-YANG-001 | 802.1Qcw `ieee802-dot1q-sched` YANG/NETCONF config export |

## Version
Workspace `0.19.0 → 0.20.0` (Cargo.toml, Cargo.lock, vscode-spar/package.json).

## Scope cut (deliberate, logged)
The **16** requirements still tagged `release: v0.20.0` but not yet implemented are bumped to **v0.21.0** so the release scope honestly reflects what shipped — 6 `planned` architecture/solver backlog + 10 `proposed` (several gated: ARXML behind kill-gate + `autosar-data` dep, NC-PLP-002 on cyclic panco fixtures, MILP-001 on the TAS-composition soundness experiment). No requirement is dropped. Shipped reqs terminate at `implemented` per project convention (no release in this repo uses `verified`).

## Pre-tag verification
Clean-room self-verify (independent fresh-context review of the merged scope) → **GO**: every shipped req is V-closed by a passing verification artifact; prior tags v0.16–v0.19 each carry a genuine `success` CI run. Two gaps it surfaced were fixed first in #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)