### PR TITLE
chore(release): bump to v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -610,7 +610,7 @@ artifacts:
     status: planned
     tags: [diff, merge, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   # ── MCP Server ───────────────────────────────────────────────────────
 
@@ -639,7 +639,7 @@ artifacts:
     status: planned
     tags: [query, instance, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   # ── Deployment Solver (v0.4.0+) ──────────────────────────────────────
 
@@ -703,7 +703,7 @@ artifacts:
     status: planned
     tags: [solver, verification, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-SOLVER-006
     type: requirement
@@ -741,7 +741,7 @@ artifacts:
     status: planned
     tags: [solver, safety, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-SOLVER-009
     type: requirement
@@ -754,7 +754,7 @@ artifacts:
     status: planned
     tags: [solver, security, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   # ── Competitive Gap Requirements (v0.4.0+) ─────────────────────────
 
@@ -990,7 +990,7 @@ artifacts:
     status: planned
     tags: [verification, competitive-gap, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-BIDIRECTIONAL-001
     type: requirement
@@ -1043,7 +1043,7 @@ artifacts:
     status: planned
     tags: [interop, requirements, v040]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-INTEROP-003
     type: requirement
@@ -1586,7 +1586,7 @@ artifacts:
       synthesis (REQ-TSN-SYNTH-QBV-001), which must self-certify against
       the sound (and correctly-RANKING) bound. [SOLID — Zhao/Network
       Calculus for TSN; verified 2026-06-16 by independent falsification.]
-    status: approved
+    status: implemented
     tags: [network, tsn, wctt, network-calculus, soundness, tier1]
     fields:
       release: v0.21.0
@@ -2609,7 +2609,7 @@ artifacts:
     status: proposed
     tags: [proofs, lean, scheduling, kiln, substrate]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-PROOF-SCHED-001
@@ -2634,7 +2634,7 @@ artifacts:
     status: proposed
     tags: [ingest, sysml2, grammar]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-PLUGFEST-002
     type: requirement
@@ -2649,7 +2649,7 @@ artifacts:
     status: proposed
     tags: [interop, plugfest, osate]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -2693,7 +2693,7 @@ artifacts:
     status: proposed
     tags: [parser, plugfest, emv2]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -2709,7 +2709,7 @@ artifacts:
     status: proposed
     tags: [interop, plugfest, ocarina]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -2730,7 +2730,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-002
@@ -2749,7 +2749,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-005
@@ -2769,7 +2769,7 @@ artifacts:
     status: proposed
     tags: [trace-topology, reconciler, attestation]
     fields:
-      release: v0.21.0
+      release: v0.22.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-008
@@ -2849,7 +2849,7 @@ artifacts:
     status: proposed
     tags: [ingest, arxml, autosar, tier1]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-NC-TFA-001
     type: requirement
@@ -2936,7 +2936,7 @@ artifacts:
     status: proposed
     tags: [network-calculus, plp, cyclic, substrate, tier1]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-NC-PLP-CONVERGE-001
     type: requirement
@@ -3139,7 +3139,7 @@ artifacts:
     status: proposed
     tags: [network-calculus, cbs, qav, audit, tier1]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   # --- Tier 2: the product bet (synthesis → export), kill-gated ---
 
@@ -3258,7 +3258,7 @@ artifacts:
     status: proposed
     tags: [tsn, synthesis, milp, tier2]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-TSN-SYNTH-CQF-BASE-001
     type: requirement
@@ -3333,11 +3333,58 @@ artifacts:
       planning across a hyperperiod and multi-buffer ambiguity-window
       handling. Candidate methods: hyper-flow graph decomposition
       (arXiv:2309.06690 — 2,000 flows, <100 ms @1,000) or GASA injection
-      planning (arXiv:2506.22671 — GA+SA, +15% flows). [SOLID]
+      planning (arXiv:2506.22671 — GA+SA, +15% flows).
+      MODEL-PINNING VERDICT (2026-06-23, primary sources): the
+      HETEROGENEOUS-cycle case has NO sound closed-form per-flow delay
+      bound to self-certify against the way (h±1)·T_c works for
+      CQF-BASE. draft-ietf-detnet-tcqf-00 App.B only ASSERTS strict-
+      priority per-hop latency (C, 2C, 3C, 4C) with no end-to-end
+      composition rule and only a 25%-avg-utilization admission heuristic
+      (which is unsound as a per-cycle buffer-budget test). The two
+      candidate papers are HEURISTIC-with-simulation: arXiv:2506.22671's
+      WCD Eq.(3) is parameterized by a GA/SA-produced injection offset
+      and validated by simulation, not a standalone checkable bound. By
+      contrast, MULTI-BUFFER SINGLE-cycle (B∈[3,7]) keeps the existing
+      (h±1)·T_c bound unchanged — B only absorbs dead time / accommodates
+      long links (tcqf-00 §2.5.1/§2.6), so it is the honest, soundly
+      self-certifiable extension (carved to REQ-TSN-SYNTH-CQF-LONGLINK-001).
+      This requirement (heterogeneous synthesis) is therefore RESEARCH-
+      GRADE until an original, separately-proven interference/feasibility
+      bound exists; deferred to v0.22.0, not a clean self-certifying
+      baseline. [RESEARCH-GRADE]
     status: proposed
-    tags: [tsn, synthesis, cqf, tier2]
+    tags: [tsn, synthesis, cqf, tier2, research-grade]
     fields:
-      release: v0.21.0
+      release: v0.22.0
+
+  - id: REQ-TSN-SYNTH-CQF-LONGLINK-001
+    type: requirement
+    title: "Multi-buffer single-cycle CQF for long links (B-buffer dead-time accommodation)"
+    description: >
+      spar shall extend the single-cycle CQF synthesizer
+      (REQ-TSN-SYNTH-CQF-BASE-001) to use B ∈ [3,7] cyclic buffers so a
+      flow's link delay / dead time DT can exceed one cycle without
+      forcing a larger global cycle T or reducing utilization. This is
+      the SOUND, self-certifiable half of the Multi-CQF space identified
+      by the 2026-06-23 model-pinning study: per draft-ietf-detnet-tcqf-00
+      §2.5.1/§2.6, additional buffers absorb dead time and accommodate
+      "arbitrary latency links at arbitrary speeds without reduction of
+      utilization" — they do NOT change the end-to-end delay STRUCTURE,
+      which remains (h−1)·T_c + DT ≤ D ≤ (h+1)·T_c (§2.1). The feasibility
+      test stays the per-cycle csize buffer-budget non-overflow rule
+      (§5.1) that CQF-BASE already self-certifies against — so this is a
+      genuine capability add (long-link / WAN DetNet) that stays inside
+      the existing closed-form self-certification pattern, unlike the
+      research-grade heterogeneous-cycle case (REQ-TSN-SYNTH-CQF-001).
+      Scope: add a per-flow link-delay / DT input + buffer-count B to the
+      synthesizer, compute B = ceil(DT / T_c) bounded to [2,7], reject if
+      B exceeds the hardware buffer cap, and keep the delay/csize oracle.
+      Honest non-goal: this is table-stakes long-link support, not the
+      heterogeneous-cycle ambition and not the PLP≪TFA NC-tightness wedge.
+    status: proposed
+    tags: [tsn, synthesis, cqf, longlink, detnet]
+    fields:
+      release: v0.22.0
 
   - id: REQ-TSN-EXPORT-YANG-001
     type: requirement
@@ -3403,7 +3450,7 @@ artifacts:
     status: proposed
     tags: [proof, lean, network-calculus, soundness, tier3]
     fields:
-      release: v0.21.0
+      release: v0.22.0
 
   - id: REQ-PROOF-NC-CERT-001
     type: requirement
@@ -3421,4 +3468,4 @@ artifacts:
     status: proposed
     tags: [proof, certificate, network-calculus, soundness, tier3]
     fields:
-      release: v0.21.0
+      release: v0.22.0

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -2292,7 +2292,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- tas_sound"
-    status: planned
+    status: passing
     tags: [network, tsn, wctt, tas, soundness, oracle]
     links:
       - type: satisfies

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.21.0** — the TSN-soundness + traceability-correctness release.

## v0.21.0 scope = 3 implemented features (all merged green on main)
| Req | Feature | PR | Merge |
|-----|---------|----|-------|
| `REQ-TSN-SVC-MULTIWIN-001` | Sound EXACT TAS service-curve latency for multi-window GCLs (fixes a reachable *optimistic/unsound* WCTT bound) | #299 | `6c4c4c6` |
| `REQ-WRPC-BINDING-002` | Honor per-connection `Actual_Connection_Binding` in wrpc-binding (kills a cross-processor false-positive) | #300 | `70bd7c9` |
| `REQ-TSN-SYNTH-QBV-SPLIT-BASE-001` | Window-splitting 802.1Qbv GCL synthesis baseline (smallest feasible K, NC-level claim) | #302 | `2c82305` |

## Traceability reconciliation (clean-room campaign audit: RED → GREEN)
A fresh-context audit found `REQ-TSN-SVC-MULTIWIN-001` was still `approved` and `TEST-TSN-SVC-MULTIWIN` still `planned` despite #299 having merged green (the code + `tas_sound_*` / `split_*` tests landed; only the status flip was missed). This PR advances both → `implemented` / `passing`, so the roadmap records **3/3** (was 2/3) v0.21.0 features as landed.

## Deferred to v0.22.0 — 22 unbuilt v0.21.0 items (each gated or backlog, logged)
Every v0.21.0 requirement with status `planned`/`proposed` is bumped to v0.22.0 — a deliberate, surfaced scope move:
- **Gated:** `MILP-001` (gated on #141 panco TAS-composition soundness), `NC-PLP-002` (cyclic/high-util fixtures not yet generated), `INGEST-ARXML-001` (kill-gate + `autosar-data` dep).
- **Research-grade:** `REQ-TSN-SYNTH-CQF-001` (Multi-CQF / heterogeneous cycles) — see below.
- **Backlog:** pre-TSN items (`DIFF-003`, `QUERY-001`, `RESOLUTE-001`, `SOLVER-005/008/009`, `INTEROP-002`), proofs (`PROOF-NC-CERT-001`, `PROOF-NC-MINPLUS-001`, `PROOF-SCHED-002`), `TRACE-TOPOLOGY-010/011/012`, `PLUGFEST-002/004/005`, `SYSML2-DIFF-001`, `NC-CBS-AUDIT-001`.

## CQF-001 model-pinning verdict (primary sources)
A fresh-context research pass pinned that **heterogeneous-cycle Multi-CQF has no sound closed-form per-flow delay bound** to self-certify against (the way `(h±1)·T_c` works for CQF-BASE): `draft-ietf-detnet-tcqf-00` App.B only *asserts* strict-priority per-hop latency with no end-to-end composition + an unsound avg-utilization admission heuristic; `arXiv:2309.06690` / `arXiv:2506.22671` are heuristic-with-simulation, not standalone checkable bounds. So:
- `REQ-TSN-SYNTH-CQF-001` → v0.22.0, marked `[RESEARCH-GRADE]`.
- **NEW** `REQ-TSN-SYNTH-CQF-LONGLINK-001` (v0.22.0, proposed) — the *sound* half: multi-buffer single-cycle CQF for long links (B∈[3,7] absorbs dead time, keeps `(h±1)·T_c` + the per-cycle `csize` rule). The honest, self-certifiable extension of CQF-BASE.

## Version
- workspace `0.20.0` → `0.21.0` (`Cargo.toml`, `Cargo.lock` × 23 crates); vscode-spar extension `0.20.0` → `0.21.0`.

## Falsification
If any v0.21.0-tagged commit's required CI did not conclude `success`, or any of the 3 implemented requirements lacks a passing `TEST-*` with a `satisfies` link, this release is unsound and must not be tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)