### PR TITLE
chore: gitignore cargo-mutants output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ verification.yaml
 # LP solver problem dumps written into the repo root by HiGHS/good_lp
 # during network-calculus (PLP/TFA) test runs — regenerable scratch.
 *.lp
+
+# cargo-mutants output — regenerable mutation-testing scratch.
+/mutants.out/
+/mutants.out.old/


### PR DESCRIPTION
`mutants.out/` and `mutants.out.old/` are regenerable cargo-mutants scratch that showed up as untracked working-tree clutter. Ignore them alongside the existing `*.lp` HiGHS dumps. Working tree is clean after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)