### PR TITLE
chore(release): bump to v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2309,10 +2309,9 @@ artifacts:
       resolves UNAMBIGUOUSLY to a non-bus component, accept otherwise".
       Oracle: a connection bound to a non-bus component warns; one bound to
       a bus, or whose reference cannot be resolved, does not.
-    status: implemented
+    status: verified
+    release: v0.22.0
     tags: [wrpc, binding, analysis]
-    fields:
-      release: v0.22.0
 
   - id: REQ-CODEGEN-WIT-CONN-001
     type: requirement
@@ -3030,10 +3029,9 @@ artifacts:
       GATE: on the converging-bridge fixture the bridge's authoritative bound
       equals TFA (1048 µs) for the cross-burst flow, not the looser PLP.
       [SOLID — Bouillard arXiv:2010.09263]
-    status: implemented
+    status: verified
+    release: v0.22.0
     tags: [network-calculus, plp, bridge, substrate, tier1]
-    fields:
-      release: v0.22.0
 
   - id: REQ-NC-BRIDGE-001
     type: requirement
@@ -3239,10 +3237,9 @@ artifacts:
       synthesize_gcl* family it is library API; no synthesizer is yet wired
       into a CLI / AADL→Qbv consumer, so this REQ makes no end-to-end
       pipeline claim — consumer wiring is separate future work. [SOLID]
-    status: implemented
+    status: verified
+    release: v0.22.0
     tags: [tsn, synthesis, qbv, guard-band, tier2]
-    fields:
-      release: v0.22.0
 
   - id: REQ-TSN-SYNTH-QBV-001
     type: requirement
@@ -3455,6 +3452,20 @@ artifacts:
     type: requirement
     title: "Multi-buffer single-cycle CQF for long links (B-buffer dead-time accommodation)"
     description: >
+      ⚠ SPEC UNDER REVISION — DEFERRED to v0.23.0 (2026-06-27 fresh-context
+      model-pinning). The delay clause below is UNSOUND as written: it
+      conflates the within-cycle dead-time guard band DT (< T_c) with
+      multi-cycle link delay, so when the buffer clause B=ceil(DT/T_c)
+      activates (DT ≥ 3·T_c) the interval INVERTS (e.g. h=1, DT=3·T_c gives
+      D_min=3·T_c > D_max=2·T_c) and goes optimistic exactly in the
+      long-link regime. The SOUND model is per-hop CYCLE-QUANTIZATION:
+      kᵢ=ceil((dᵢ+DT)/T_c); D_max=T_c+Σkᵢ·T_c; D_min=Σ(kᵢ−1)·T_c+DT;
+      buffers key off JITTER Bᵢ=ceil((dᵢᵐᵃˣ−dᵢᵐⁱⁿ)/T_c)+2, B=clamp(maxᵢBᵢ,
+      3,B_cap); csize=T_c·rate unchanged. Degeneracy (all dᵢ<T_c ⇒ kᵢ=1)
+      reproduces the shipped (h+1)·T_c. Build to the corrected model in the
+      v0.23 feature loop (oracle design: degeneracy + 3-hop discrimination
+      + inversion-guard). Original (unsound) text retained below for the
+      rewrite diff:
       spar shall extend the single-cycle CQF synthesizer
       (REQ-TSN-SYNTH-CQF-BASE-001) to use B ∈ [3,7] cyclic buffers so a
       flow's link delay / dead time DT can exceed one cycle without
@@ -3476,9 +3487,8 @@ artifacts:
       Honest non-goal: this is table-stakes long-link support, not the
       heterogeneous-cycle ambition and not the PLP≪TFA NC-tightness wedge.
     status: proposed
+    release: v0.23.0
     tags: [tsn, synthesis, cqf, longlink, detnet]
-    fields:
-      release: v0.22.0
 
   - id: REQ-TSN-EXPORT-YANG-001
     type: requirement

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -1943,6 +1943,8 @@ artifacts:
       - type: satisfies
         target: REQ-NC-PLP-MIN-001
 
+      - type: verifies
+        target: REQ-NC-PLP-MIN-001
   - id: TEST-NC-PLP-STR
     type: feature
     title: TFA-strengthened PLP — tightening to EXACT (panco tfa=True oracle)
@@ -2437,6 +2439,8 @@ artifacts:
       - type: satisfies
         target: REQ-TSN-SYNTH-QBV-GUARDBAND-001
 
+      - type: verifies
+        target: REQ-TSN-SYNTH-QBV-GUARDBAND-001
   - id: TEST-TSN-EXPORT-YANG
     type: feature
     title: 802.1Qcw YANG/NETCONF export of a synthesized gate schedule
@@ -3437,6 +3441,8 @@ artifacts:
       - type: satisfies
         target: REQ-WRPC-BINDING-003
 
+      - type: verifies
+        target: REQ-WRPC-BINDING-003
   # ── CI / Verification gate ──────────────────────────────────────────────
 
   - id: TEST-VERIFY-GATE-RUNNER

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.22.0 — "Deployable TSN synthesis"

Cuts v0.22.0 with **three** shipped features (clean-room audited GO):

| Req | PR | What |
|-----|----|----|
| REQ-NC-PLP-MIN-001 | #307 | Authoritative per-flow NC bound = `min(PLP, TFA)` |
| REQ-WRPC-BINDING-003 | #308 | Verify `Actual_Connection_Binding` resolves to a bus |
| REQ-TSN-SYNTH-QBV-GUARDBAND-001 | #309 | Guard-band-aware 802.1Qbv GCL splitting (deployment-sound) |

## Release handling — adopts rivet 0.22's `release` flow

- The three features carry a **top-level `release: v0.22.0`** field and are advanced to **`verified`** (each now has a `verifies` link from its `TEST-*` feature). `rivet release status v0.22.0` → ✓ cuttable (every scoped artifact verified/accepted).
- Stale `fields.release` entries removed on the migrated artifacts.
- **Cross-version verified:** CI rivet **v0.4.3** (merge gate) and **v0.7.0** (verification gate) both PASS with unchanged warning counts (112 / 120) — the migration introduces zero new diagnostics.

## Scope correction (clean-room blocker)

`REQ-TSN-SYNTH-CQF-LONGLINK-001` moved to **v0.23.0** via `rivet release move` — its committed spec is **unsound** (the delay interval inverts on long links once the buffer clause activates). It's deferred for a sound **cycle-quantized** rewrite; a `SPEC-UNDER-REVISION` marker + the corrected model are recorded in the artifact.

## Bump

Workspace `0.21.0` → `0.22.0` (Cargo.toml, Cargo.lock, vscode-spar/package.json). `cargo build --workspace` green.

## Falsification

If the guard-band synthesizer's emitted GCL were not deployment-sound, a class would miss its deadline under the §8.6.8.4 overrun model — the K=1 anchor (`guard_band_k1_equals_sync_error_at_eps_g`) and the full-schedule self-cert would fail. They pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)