### PR TITLE
feat(analysis): EMV2 overlay from instances — spar analyze reports real propagation chains (REQ-EMV2-PROPAGATION-002, L4/4, closes #294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "spar-annex",
  "spar-base-db",
  "spar-hir-def",
  "spar-network",

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2273,10 +2273,18 @@ artifacts:
       EMV2 model is projected onto each ComponentInstance at instantiation,
       stored as a SystemInstance emv2_models side-table with an emv2_for
       accessor) LANDED, verified by TEST-EMV2-INSTANCE-PROJECT; L4 (overlay
-      populate + analyze-path wiring + end-to-end > 0-chains oracle) remains.
-      Requirement flips proposed → implemented when L4 closes the end-to-end
-      oracle.
-    status: proposed
+      populate + analyze-path wiring + end-to-end > 0-chains oracle) LANDED,
+      verified by TEST-EMV2-OVERLAY-WIRING — Emv2Overlay::from_instance builds
+      the overlay from the projected instance EMV2 (replacing the empty
+      Emv2Overlay::new() at emv2_propagation.rs analyze), so `spar analyze` now
+      reports real propagation chains (a source→sink error path across a port
+      connection yields ≥1 chain; empty-overlay/negated cases yield 0). ALL 4
+      LAYERS LANDED — GitHub #294 CLOSED. (cmd_analyze needed no change: it
+      already instantiates via SystemInstance::instantiate, which runs the L3
+      projection.) Separate follow-up (out of scope): the fault tree +
+      EMV2→STPA bridge still hardcode error_type "ServiceFailure" and would
+      carry real error types once wired to this same foundation.
+    status: implemented
     tags: [emv2, analysis, safety, hir-def, capability]
     fields:
       release: v0.23.0

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -3532,6 +3532,39 @@ artifacts:
       - type: verifies
         target: REQ-EMV2-PROPAGATION-002
 
+  - id: TEST-EMV2-OVERLAY-WIRING
+    type: feature
+    title: EMV2 overlay built from instances — spar analyze reports real chains (closes #294)
+    description: >
+      Layer 4 (final) of REQ-EMV2-PROPAGATION-002 (GitHub #294): the
+      error-propagation pass builds its Emv2Overlay from the EMV2 models
+      projected onto instances (L1-L3) via new
+      Emv2Overlay::from_instance(&SystemInstance), replacing the empty
+      Emv2Overlay::new() the analyze path used before — which is why every real
+      model reported "0 chain(s)". END-TO-END, RED-BEFORE-GREEN oracle
+      (crates/spar-analysis/tests/emv2_chain.rs), parsing real AADL through the
+      whole pipeline (parse → item-tree → instantiate → overlay → traversal),
+      NON-VACUOUS: (a) two leaf systems Sender→Receiver connected by a
+      `dataxfer` port connection, Sender `out propagation {ServiceError}` +
+      Receiver `in propagation {ServiceError}` ⇒ the pass reports ≥1 chain
+      (origin snd, type ServiceError, one downstream rcv) AND analyze emits the
+      "error propagation chain:" diagnostic; (b) the SAME instance with an EMPTY
+      overlay (Emv2Overlay::new(), the pre-L4 state) yields 0 chains — the delta
+      L4 closes, proving (a) is not vacuous; (c) a negated `not out propagation`
+      is skipped and yields no chain. cmd_analyze needed no change (it already
+      instantiates via SystemInstance::instantiate, which runs the L3
+      projection). Verified workspace-wide (compile + clippy). Closes #294 and
+      flips REQ-EMV2-PROPAGATION-002 to implemented.
+    fields:
+      method: automated-test
+      steps:
+        - run: cargo test -p spar-analysis --test emv2_chain
+    status: passing
+    tags: [emv2, analysis, safety, v0.23.0, capability]
+    links:
+      - type: verifies
+        target: REQ-EMV2-PROPAGATION-002
+
   - id: TEST-WRPC-BINDING
     type: feature
     title: wrpc-binding honors per-connection Actual_Connection_Binding

--- a/crates/spar-analysis/Cargo.toml
+++ b/crates/spar-analysis/Cargo.toml
@@ -8,6 +8,9 @@ description = "Pluggable analysis framework for AADL models"
 
 [dependencies]
 spar-hir-def.workspace = true
+# For the EMV2 semantic model (Emv2Model) projected onto instances by
+# spar-hir-def L3; the propagation overlay is built from it (REQ-EMV2-PROPAGATION-002 L4).
+spar-annex.workspace = true
 # Explicit path dep (not workspace inheritance) so we can set
 # default-features = false — inherited deps can't override it. Keeps the MILP
 # solver (good_lp/HiGHS) opt-in; the `milp-solver` feature re-enables it for

--- a/crates/spar-analysis/src/emv2_propagation.rs
+++ b/crates/spar-analysis/src/emv2_propagation.rs
@@ -197,6 +197,49 @@ impl Emv2Overlay {
         });
     }
 
+    /// Build the overlay from the EMV2 models projected onto each component
+    /// instance at instantiation time (REQ-EMV2-PROPAGATION-002 L4, GitHub
+    /// #294). This is what makes `spar analyze` report real propagation chains:
+    /// previously the analyze path used an EMPTY overlay ([`Self::new`]), so
+    /// every model reported "0 chain(s)". Layers 1-3 parse the `annex EMV2`
+    /// subclause into a typed model, retain it on the item-tree, and project it
+    /// onto `SystemInstance::emv2_models`; here we translate that into the
+    /// per-component out/in propagations + flows the traversal consumes.
+    ///
+    /// A `not` (negated) propagation asserts the component does NOT emit/receive
+    /// the type, so it is SKIPPED — projecting it would fabricate a chain that
+    /// the model explicitly denies.
+    #[must_use]
+    pub fn from_instance(instance: &spar_hir_def::instance::SystemInstance) -> Self {
+        use spar_annex::emv2::{ErrorFlowKind, PropagationDirection as AnnexDir};
+
+        let mut overlay = Self::new();
+        for (&component, models) in &instance.emv2_models {
+            for model in models {
+                for p in &model.propagations {
+                    if p.negated {
+                        continue;
+                    }
+                    let types: Vec<&str> = p.error_types.iter().map(String::as_str).collect();
+                    match p.direction {
+                        AnnexDir::Out => overlay.add_out_propagation(component, &p.feature, &types),
+                        AnnexDir::In => overlay.add_in_propagation(component, &p.feature, &types),
+                    }
+                }
+                for f in &model.flows {
+                    let kind = match f.kind {
+                        ErrorFlowKind::Source => "source",
+                        ErrorFlowKind::Sink => "sink",
+                        ErrorFlowKind::Path => "path",
+                    };
+                    let types: Vec<&str> = f.error_types.iter().map(String::as_str).collect();
+                    overlay.add_flow(component, &f.name, kind, &types);
+                }
+            }
+        }
+        overlay
+    }
+
     /// Check whether a component has any `in propagation` that matches
     /// `error_type` (case-insensitive, per AADL EMV2 v2 §4.3).
     pub fn has_in_propagation_for(
@@ -394,7 +437,10 @@ impl Analysis for Emv2PropagationAnalysis {
     }
 
     fn analyze(&self, instance: &SystemInstance) -> Vec<AnalysisDiagnostic> {
-        let overlay = Emv2Overlay::new();
+        // Build the overlay from the EMV2 models projected onto instances
+        // (L1-L3); previously this was an EMPTY overlay, so every real model
+        // reported "0 chain(s)". REQ-EMV2-PROPAGATION-002 L4, GitHub #294.
+        let overlay = Emv2Overlay::from_instance(instance);
         let report = compute_error_propagation(instance, &overlay);
         let root_path = component_path(instance, instance.root);
 

--- a/crates/spar-analysis/tests/emv2_chain.rs
+++ b/crates/spar-analysis/tests/emv2_chain.rs
@@ -1,0 +1,193 @@
+//! End-to-end oracle for EMV2 propagation-chain reporting
+//! (REQ-EMV2-PROPAGATION-002 layer 4, GitHub #294).
+//!
+//! RED-BEFORE-GREEN: before L4 the analyze path fed `compute_error_propagation`
+//! an EMPTY `Emv2Overlay` (`Emv2Overlay::new()`), so EVERY real model reported
+//! "0 chain(s)". L4 builds the overlay from the EMV2 models parsed (L1),
+//! retained on the item-tree (L2), and projected onto instances (L3), so a
+//! source→sink error path across a connection now yields a chain.
+//!
+//! Non-circular: the model is parsed from real AADL through the whole pipeline
+//! (parse → item-tree → instantiate → overlay → traversal); nothing is
+//! hand-built. The chain forms because Sender's `out propagation {ServiceError}`
+//! matches Receiver's `in propagation {ServiceError}` across the `dataxfer`
+//! port connection (the traversal matches on error type across
+//! semantic connections).
+
+use spar_analysis::emv2_propagation::{
+    Emv2Overlay, Emv2PropagationAnalysis, compute_error_propagation,
+};
+use spar_analysis::{Analysis, AnalysisDiagnostic};
+use spar_hir_def::{
+    HirDefDatabase, Name, file_item_tree, instance::SystemInstance, resolver::GlobalScope,
+};
+
+fn instantiate(src: &str, pkg: &str, sys: &str, sys_impl: &str) -> SystemInstance {
+    let db = HirDefDatabase::default();
+    let file = spar_base_db::SourceFile::new(&db, "emv2_chain.aadl".to_string(), src.to_string());
+    let tree = file_item_tree(&db, file);
+    let scope = GlobalScope::from_trees(vec![tree]);
+    let inst = SystemInstance::instantiate(
+        &scope,
+        &Name::new(pkg),
+        &Name::new(sys),
+        &Name::new(sys_impl),
+    );
+    assert!(
+        inst.component_count() > 0,
+        "instantiation failed; diagnostics: {:?}",
+        inst.diagnostics
+    );
+    inst
+}
+
+/// Two leaf systems directly connected by a port connection: Sender emits
+/// `ServiceError` out its `output` port, Receiver receives it on `input`.
+const CHAIN_AADL: &str = r#"package emv2_chain_pkg
+public
+  system Sender
+    features
+      output : out data port;
+    annex EMV2 {**
+error propagations
+  output: out propagation {ServiceError};
+end propagations;
+    **};
+  end Sender;
+
+  system Receiver
+    features
+      input : in data port;
+    annex EMV2 {**
+error propagations
+  input: in propagation {ServiceError};
+end propagations;
+    **};
+  end Receiver;
+
+  system Top
+  end Top;
+
+  system implementation Top.impl
+    subcomponents
+      snd : system Sender;
+      rcv : system Receiver;
+    connections
+      dataxfer : port snd.output -> rcv.input;
+  end Top.impl;
+end emv2_chain_pkg;
+"#;
+
+#[test]
+fn emv2_propagation_reports_a_chain_across_a_port_connection() {
+    let inst = instantiate(CHAIN_AADL, "emv2_chain_pkg", "Top", "impl");
+
+    // Structural: the overlay built from the projected instance EMV2 yields a
+    // source→sink chain. Empty on main before L4 (the #294 bug) ⇒ 0 chains.
+    let overlay = Emv2Overlay::from_instance(&inst);
+    let report = compute_error_propagation(&inst, &overlay);
+    assert!(
+        !report.chains.is_empty(),
+        "expected >=1 EMV2 propagation chain, got 0 — the overlay is empty (#294)"
+    );
+    let chain = &report.chains[0];
+    assert_eq!(chain.error_type.to_lowercase(), "serviceerror");
+    assert_eq!(
+        chain.downstream.len(),
+        1,
+        "exactly one downstream recipient (rcv)"
+    );
+
+    // Authoritative: the analyze pass emits the per-chain diagnostic that was
+    // never produced for any real model before L4.
+    let diags: Vec<AnalysisDiagnostic> = Emv2PropagationAnalysis.analyze(&inst);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("error propagation chain:")),
+        "analyze must report the propagation chain; messages: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_overlay_yields_no_chain_the_pre_l4_state() {
+    // The pre-L4 behaviour, made permanent as the RED half of red-before-green:
+    // an EMPTY overlay (`Emv2Overlay::new()`, exactly what `analyze` used before
+    // #294 was fixed) yields 0 chains on the SAME instance that
+    // `from_instance` turns into a chain. This is the delta L4 closes — proof
+    // the passing chain test is not vacuous.
+    let inst = instantiate(CHAIN_AADL, "emv2_chain_pkg", "Top", "impl");
+    let report = compute_error_propagation(&inst, &Emv2Overlay::new());
+    assert!(
+        report.chains.is_empty(),
+        "empty overlay must yield 0 chains — the #294 bug state"
+    );
+}
+
+/// A component declaring error source/sink/path flows — exercises the flow
+/// projection in `from_instance` (all three `ErrorFlowKind` arms), which the
+/// propagation-only fixtures above don't touch. Flows surface in the report's
+/// `local_flows` (they are not traversed into chains, per the pass design).
+const FLOWS_AADL: &str = r#"package emv2_flows_pkg
+public
+  system Node
+    features
+      p_in : in data port;
+      p_out : out data port;
+    annex EMV2 {**
+error propagations
+  p_out: out propagation {ServiceError};
+  p_in: in propagation {ServiceError};
+flows
+  f_src: error source p_out {ServiceError};
+  f_snk: error sink p_in {ServiceError};
+  f_pth: error path p_in {ServiceError} -> p_out;
+end propagations;
+    **};
+  end Node;
+
+  system Top
+  end Top;
+
+  system implementation Top.impl
+    subcomponents
+      n : system Node;
+  end Top.impl;
+end emv2_flows_pkg;
+"#;
+
+#[test]
+fn emv2_flows_are_projected_into_local_flows() {
+    let inst = instantiate(FLOWS_AADL, "emv2_flows_pkg", "Top", "impl");
+    let overlay = Emv2Overlay::from_instance(&inst);
+    let report = compute_error_propagation(&inst, &overlay);
+    // The Node's source + sink + path flows are all projected.
+    assert_eq!(
+        report.local_flows.len(),
+        3,
+        "source + sink + path flows must be projected into local_flows: {:?}",
+        report.local_flows
+    );
+    let kinds: std::collections::BTreeSet<&str> =
+        report.local_flows.iter().map(|f| f.kind.as_str()).collect();
+    assert_eq!(
+        kinds,
+        ["path", "sink", "source"].into_iter().collect(),
+        "all three flow kinds must round-trip through from_instance"
+    );
+}
+
+#[test]
+fn emv2_negated_out_propagation_yields_no_chain() {
+    // A `not out propagation` asserts the component does NOT emit the type;
+    // projecting it must NOT fabricate a chain (from_instance skips negated).
+    let src = CHAIN_AADL.replace("output: out propagation", "output: not out propagation");
+    let inst = instantiate(&src, "emv2_chain_pkg", "Top", "impl");
+    let overlay = Emv2Overlay::from_instance(&inst);
+    let report = compute_error_propagation(&inst, &overlay);
+    assert!(
+        report.chains.is_empty(),
+        "a negated out-propagation must not create a chain"
+    );
+}


### PR DESCRIPTION
## What — the final layer that closes #294

`spar analyze` reported **"0 chain(s), 0 local flow(s)" for every real model** because the error-propagation pass fed `compute_error_propagation` an **empty** `Emv2Overlay` (`Emv2Overlay::new()`). This is **Layer 4 of 4** of the EMV2 annex→instance foundation — it wires in the data threaded through L1–L3:

- New `Emv2Overlay::from_instance(&SystemInstance)` translates the projected per-instance EMV2 models (L3 `emv2_for`) into the overlay's out/in propagations + flows. A `not` (negated) propagation is **skipped** — projecting it would fabricate a chain the model explicitly denies.
- `Emv2PropagationAnalysis::analyze` now builds `from_instance(instance)` instead of the empty overlay.
- **`cmd_analyze` needed no change** — it already instantiates via `SystemInstance::instantiate`, which runs the L3 projection, so the models are already on the instance the pass sees. (This corrected the original assumption that the CLI needed annex-parsing rewiring; L1–L3 already thread it through.)

## Red-before-green oracle (`tests/emv2_chain.rs`)

Parses real AADL through the whole pipeline (parse → item-tree → instantiate → overlay → traversal), non-vacuous:
- **green** — two leaf systems Sender→Receiver joined by a `dataxfer` port connection; Sender `out propagation {ServiceError}` + Receiver `in propagation {ServiceError}` ⇒ the pass reports **≥1 chain** (origin `snd`, type `ServiceError`, one downstream `rcv`) *and* `analyze` emits the `"error propagation chain:"` diagnostic.
- **red (permanent)** — the *same* instance with an empty overlay yields **0 chains** (the pre-L4 bug state), proving the green test isn't vacuous.
- **negated** — a `not out propagation` yields no chain.

## Verification

- `cargo test --workspace --all-targets --no-run` + `cargo clippy --workspace` → 0 errors / 0 warnings; spar-analysis emv2 tests + the 3-test end-to-end oracle pass; fmt clean; **mutation on `from_instance` 0-missed**.

## Foundation complete

L1 (parse→model) → L2 (retain in item-tree) → L3 (project onto instances) → **L4 (build overlay + wire analyze)**. `REQ-EMV2-PROPAGATION-002` → `implemented`, verified by `TEST-EMV2-OVERLAY-WIRING`. **Closes #294.**

Separate follow-up (out of scope): the EMV2 fault tree + STPA bridge still hardcode `"ServiceFailure"` and would carry real error types once wired to this same foundation.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)