### PR TITLE
chore(release): bump to v0.23.0 — sound long-link CQF + EMV2 annex ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2305,10 +2305,9 @@ artifacts:
       of scope): the fault tree + EMV2→STPA bridge still hardcode error_type
       "ServiceFailure" and would carry real error types once wired to this same
       foundation.
-    status: implemented
+    status: verified
+    release: v0.23.0
     tags: [emv2, analysis, safety, hir-def, capability]
-    fields:
-      release: v0.23.0
 
   - id: REQ-EMV2-PROPAGATION-003
     type: requirement
@@ -3585,7 +3584,7 @@ artifacts:
       a separate follow-up (the bound + synthesizer are library-complete).
       Non-goal: not the heterogeneous-cycle ambition (REQ-TSN-SYNTH-CQF-001)
       nor the PLP≪TFA NC-tightness wedge.
-    status: implemented
+    status: verified
     release: v0.23.0
     tags: [tsn, synthesis, cqf, longlink, detnet]
 

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.23.0 — "Sound long-link CQF + EMV2 annex ingestion"

Two features shipped since v0.22.0 (`git log v0.22.0..main`):

### REQ-TSN-SYNTH-CQF-LONGLINK-001 (#311) — sound cycle-quantized long-link CQF
Replaces the v0.22-deferred spec (delay interval inverted on long links) with a corrected `D_max = T_c + Σ kᵢ·T_c`, validated by an **independent discrete-event simulation oracle**: asserts `D_max ≥ observed` across 4 profiles × a full source-phase sweep, with a guard that *fails* if the multi-cycle (`kᵢ≥2`) regime is never exercised.
- **Calibration:** "sound" is **model-relative** — w.r.t. the draft-ietf-detnet-tcqf cycle model (catches sign/floor/off-by-one in the closed form), not a silicon claim.

### REQ-EMV2-PROPAGATION-002 (#313–#316) — EMV2 error-annex ingestion foundation
The `annex EMV2 {** … **}` subclause is now parsed → retained on the item-tree → projected onto instances → used to populate the propagation overlay. `spar analyze` now analyses per-component error **flows** on real models (**6** on the bundled OSATE `network_protocol_pkg`, was **0**).
- **Known limitation (inline):** cross-component **chains** on real binding-bound models are **not** yet reported — the traversal follows port `semantic_connections` only, while real models propagate along the `Actual_Connection_Binding` stack. The bundled repro still reports `0 chain(s), 6 local flow(s)`. Tracked in **#294 (reopened)** → successor **REQ-EMV2-PROPAGATION-003** (v0.24.0), whose oracle runs `spar analyze` on the *actual* `network_protocol_pkg.aadl`.

### Honesty note (this session)
PR #316 over-claimed "reports real chains / closes #294." Confirmed empirically the real model still yields 0 chains; corrected artifacts + reopened #294 in #317. REQ-EMV2-PROPAGATION-002 is `verified` on its **re-scoped** oracle (annex ingested + 6 real local flows + port-traversal mechanism), **not** on real-model chain closure. 002 verified-and-shipped while #294 reopened is deliberate (reopened symptom carved to 003).

## Release-handling
- Both features carry top-level `release: v0.23.0` + `verified` (each has a `verifies` link from a passing `TEST-*`). `rivet release status v0.23.0` → **cuttable**. Authoritative gate is CI rivet on this PR.
- Pre-existing debt (untouched, non-blocking): ~31 proposed/planned backlog artifacts still carry a legacy `fields.release: v0.23.0` invisible to the release-status flow; migrating off the legacy field is deferred hygiene.
- Bumps workspace 0.22.0 → 0.23.0 (Cargo.toml, Cargo.lock, vscode-spar/package.json).

## Falsification statement
- **CQF-LONGLINK:** if the analytical `D_max` were optimistic, the independent sim would observe a delay exceeding it on ≥1 of the swept phases/profiles → oracle red. It is green with slack.
- **EMV2:** the claim is scoped to *flows analysed*, not *chains reported*. Falsifier for the limitation being understated: run `spar analyze --root network_protocol_pkg::MySystem.basic …` — it prints `0 chain(s), 6 local flow(s)`, matching the stated scope exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)