### PR TITLE
chore(release): bump to v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2685,10 +2685,9 @@ artifacts:
       `*Impl` record structs + typed ports and module-wiring the per-thread files
       so the WHOLE crate (not just the binding lib.rs) compiles, and the
       wasm-component zero-`cabi_realloc` symbol check. Reported as GitHub #319.
-    status: implemented
+    status: verified
     tags: [codegen, wit, rust, wit-bindgen, interop]
-    fields:
-      release: v0.24.0
+    release: v0.24.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-TYPES
@@ -2726,10 +2725,9 @@ artifacts:
       imported WIT functions and persistent component state (Guest methods are
       free fns). Optional stronger evidence, not a completion gate: the crate also
       builds to `wasm32-wasip2` (toolchain present locally).
-    status: implemented
+    status: verified
     tags: [codegen, wit, rust, wit-bindgen, no-alloc]
-    fields:
-      release: v0.24.0
+    release: v0.24.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-RECORDS-001

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump for **v0.24.0 — "Structured WIT records + a compiling wit-bindgen component crate"** (ships PR #320, closes #319 items 1/3/4/6/7).

## Shipped (promoted to `verified`)
- **REQ-CODEGEN-WIT-RECORDS-001** — structured no_alloc WIT records + compiler-enforced WIT-world⟷Rust-Guest wiring + `Dispatch_Protocol`-derived lifecycle.
- **REQ-CODEGEN-WIT-RECORDS-002** — the whole generated per-process crate compiles (real Rust types from the same `DataShape` as the WIT records, relocated + module-wired per-thread components, delegating `Guest`), builds to `wasm32-wasip2`, with a sound WIT-level no-alloc oracle. Gated in CI by the new `codegen-oracle` job.

## Bump contents (mirrors the v0.23.0 bump)
- `Cargo.toml` workspace version 0.23.0 → 0.24.0; `Cargo.lock` propagated (spar-* crates only, no external dep changes); `vscode-spar/package.json` 0.23.0 → 0.24.0.
- `artifacts/requirements.yaml`: REQ-CODEGEN-WIT-RECORDS-001/002 → `status: verified`, `release: v0.24.0` (top-level).

## Scope / deferrals (unchanged, forward-looking)
- No-alloc guarantee holds only for all-scalar/record ports (opaque top-level port keeps the `list<u8>` fallback by design).
- Deferred: the codegen data plane (port population from imported WIT funcs + persistent state) and `REQ-CODEGEN-VERIFY-WORKSPACE-001` (`--verify test/build` emits inert artifacts). `REQ-EMV2-PROPAGATION-003` (binding-path traversal) remains proposed backlog, as it was for v0.23.0.

After merge, a signed annotated `v0.24.0` tag on the bump commit triggers the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)