### PR TITLE
feat(codegen): persistent component state + inter-thread connections (REQ-CODEGEN-WIT-STATE-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
         run: cargo test -p spar-codegen --test lifecycle_bindings -- --ignored
       - name: Run wasmtime runtime data-flow oracle (REQ-CODEGEN-WIT-DATAPLANE-001)
         run: cargo run --release --manifest-path codegen-exec-oracle/Cargo.toml --bin exec-oracle
+      - name: Run wasmtime state + inter-thread oracle (REQ-CODEGEN-WIT-STATE-001)
+        run: cargo run --release --manifest-path codegen-exec-oracle/Cargo.toml --bin state-oracle
 
   # ── Bench compile smoke (fast regression gate) ──────────────────────
   bench-smoke:

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2832,11 +2832,30 @@ artifacts:
       Both need the same mechanism: per-component persistent state in the
       single-threaded wasm component (a `thread_local!`/`static` holding the
       component instance and inter-thread buffers), initialized once and reused.
-      This requirement adds that: components persist across dispatches, and
-      inter-thread connections marshal through a shared buffer. Oracle extends the
-      wasmtime exec harness: a stateful accumulator component whose output on
-      dispatch N depends on dispatch N-1, plus a producer->consumer inter-thread
-      value observed at the consumer's boundary out port.
+      This requirement adds that:
+      (1) PERSISTENT STATE — the generated binding REUSES the component instance
+      across dispatches (a `thread_local! { RefCell<{Struct}Default> }`, borrowed per
+      `compute` instead of `{Struct}Default` constructed fresh) so any state the
+      component holds survives between dispatches; the skeleton struct gains
+      `#[derive(Default)]` for the one-time init. `borrow_mut` assumes single-
+      threaded, non-reentrant dispatch (a wasip2 component), stated in the binding.
+      (2) INTER-THREAD — a `ConnectionInstance` with BOTH ends `Some(...)` routes
+      through a `thread_local!` buffer with LATEST-VALUE / SAMPLING semantics: the
+      source thread's Out field writes the buffer after its `compute`, the
+      destination thread's In field reads the latest buffered value before its
+      `compute`. This is sampling (last-writer-wins), NOT AADL immediate (same-frame,
+      src-before-dst ordered) nor delayed (previous-frame latch) connection timing —
+      immediate-vs-delayed timing is explicitly OUT OF SCOPE.
+      Oracle extends the wasmtime exec harness on ONE live instance: (a) a stateful
+      accumulator called twice (feed 5 then 7, assert out == 12 — fresh-construct or
+      a call-local buffer yields 7, so the number discriminates persistence); (b) a
+      producer->consumer inter-thread value delivered across two SEPARATE dispatches
+      and observed at the consumer's boundary out port. Both sabotaged (revert the
+      thread_local to per-call Default / drop the buffer write) to prove non-vacuity.
+      STATED LIMITATION (skeleton authoring): user state lives in the generated
+      `{thread}.rs` skeleton, which carries `DO NOT EDIT — regenerate`; adding real
+      state means editing a file regen overwrites. The mechanism (instance reuse) is
+      delivered here; a regen-safe user-authoring split is a separate successor.
     status: proposed
     tags: [codegen, wit, rust, wit-bindgen, data-plane, state]
     fields:

--- a/codegen-exec-oracle/Cargo.lock
+++ b/codegen-exec-oracle/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.3",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "good_lp",
  "spar-hir-def",
@@ -1852,14 +1852,14 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "rowan",
 ]
 
 [[package]]
 name = "spar-syntax"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "rowan",
  "spar-parser",

--- a/codegen-exec-oracle/Cargo.toml
+++ b/codegen-exec-oracle/Cargo.toml
@@ -24,3 +24,7 @@ spar-base-db = { path = "../crates/spar-base-db" }
 [[bin]]
 name = "exec-oracle"
 path = "src/main.rs"
+
+[[bin]]
+name = "state-oracle"
+path = "src/state_main.rs"

--- a/codegen-exec-oracle/src/state_main.rs
+++ b/codegen-exec-oracle/src/state_main.rs
@@ -1,0 +1,210 @@
+//! RUNTIME oracle for REQ-CODEGEN-WIT-STATE-001: persistent component state +
+//! inter-thread connections, proven at runtime under wasmtime (the load-bearing
+//! gate — the fast tests prove the wiring shape, this proves behavior).
+//!
+//! Two proofs on ONE live instance (state persists only within a live instance):
+//!   1. PERSISTENCE — an Accum component accumulates across dispatches. Feed 5 then
+//!      7 to `acc-in`; assert `acc-out == 12` on the second dispatch. Fresh-construct
+//!      or a call-local buffer would yield 7 — the number discriminates persistence.
+//!   2. INTER-THREAD — Producer echoes its boundary-in to its Out port; that value
+//!      crosses a thread_local buffer to Consumer's In port, which Consumer echoes to
+//!      its boundary-out. Feed 42 to `src-in`, dispatch `pr` then `cn` SEPARATELY,
+//!      assert `sink-out == 42` — the buffer surviving between the two dispatches is
+//!      what's under test.
+//!
+//! Both are sabotaged in the harness comments' spirit: revert the thread_local to a
+//! per-call Default and persistence drops to 7; drop the buffer write and inter-
+//! thread drops to 0.
+
+use anyhow::{Context, Result, bail};
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Engine, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+wasmtime::component::bindgen!({
+    world: "p-world",
+    path: "wit/state.wit",
+});
+
+use state_pkg::p::p_ports::Host as PortsHost;
+
+/// Store state: WASI + host-provided inputs + sentinel-initialized received slots.
+struct HostState {
+    table: ResourceTable,
+    wasi: WasiCtx,
+    acc_in_val: u32,
+    src_in_val: u32,
+    acc_out_recv: u32,
+    sink_out_recv: u32,
+}
+
+impl WasiView for HostState {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+impl PortsHost for HostState {
+    fn acc_in(&mut self) -> u32 {
+        self.acc_in_val
+    }
+    fn set_acc_out(&mut self, val: u32) {
+        self.acc_out_recv = val;
+    }
+    fn src_in(&mut self) -> u32 {
+        self.src_in_val
+    }
+    fn set_sink_out(&mut self, val: u32) {
+        self.sink_out_recv = val;
+    }
+}
+
+const STATE_AADL: &str = include_str!("../../test-data/codegen/state.aadl");
+
+fn main() -> Result<()> {
+    // 1. Generate the STATE crate.
+    let db = spar_hir_def::HirDefDatabase::default();
+    let sf = spar_base_db::SourceFile::new(&db, "state.aadl".to_string(), STATE_AADL.to_string());
+    let tree = spar_hir_def::file_item_tree(&db, sf);
+    let scope = spar_hir_def::resolver::GlobalScope::from_trees(vec![tree]);
+    let inst = spar_hir_def::instance::SystemInstance::instantiate(
+        &scope,
+        &spar_hir_def::name::Name::new("StatePkg"),
+        &spar_hir_def::name::Name::new("Top"),
+        &spar_hir_def::name::Name::new("Impl"),
+    );
+    let config = spar_codegen::CodegenConfig {
+        root_name: "st".into(),
+        output_dir: "out".into(),
+        format: spar_codegen::OutputFormat::Both,
+        verify: None,
+        rivet: false,
+        dry_run: true,
+    };
+    let out = spar_codegen::generate(&inst, &scope, &config).context("codegen failed")?;
+
+    // 2. Materialize + patch user component logic (stands in for hand-written code;
+    //    the code UNDER TEST is spar's generated state/inter-thread wiring).
+    let root = std::env::temp_dir().join("spar-state-exec-oracle");
+    let _ = std::fs::remove_dir_all(&root);
+    for f in &out.files {
+        let path = root.join(&f.path);
+        std::fs::create_dir_all(path.parent().unwrap())?;
+        let content = match f.path.as_str() {
+            "crates/p/src/a.rs" => patch_accumulator(&f.content)?,
+            "crates/p/src/pr.rs" => patch_echo(&f.content, "Pr", "po", "pi")?,
+            "crates/p/src/cn.rs" => patch_echo(&f.content, "Cn", "co", "ci")?,
+            _ => f.content.clone(),
+        };
+        std::fs::write(&path, content)?;
+    }
+
+    // 3. Build to a wasm32-wasip2 component.
+    let target_dir = std::env::temp_dir().join("spar-state-exec-target");
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .arg("--target")
+        .arg("wasm32-wasip2")
+        .current_dir(&root)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .status()
+        .context("failed to spawn cargo build")?;
+    if !status.success() {
+        bail!("STATE crate failed to build to wasm32-wasip2; inspect {root:?}");
+    }
+    let wasm = target_dir.join("wasm32-wasip2/debug/p.wasm");
+
+    // 4. Instantiate ONCE and run both proofs on the same live instance.
+    let engine = Engine::default();
+    let component = Component::from_file(&engine, &wasm)
+        .with_context(|| format!("wasmtime could not load {wasm:?}"))?;
+    let mut linker: Linker<HostState> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).context("add wasi to linker")?;
+    PWorld::add_to_linker::<_, wasmtime::component::HasSelf<_>>(&mut linker, |s: &mut HostState| s)
+        .context("add p-ports to linker")?;
+
+    let mut store = Store::new(
+        &engine,
+        HostState {
+            table: ResourceTable::new(),
+            wasi: WasiCtxBuilder::new().inherit_stdio().build(),
+            acc_in_val: 0,
+            src_in_val: 0,
+            acc_out_recv: 0,  // sentinel != 12
+            sink_out_recv: 0, // sentinel != 42
+        },
+    );
+    let world = PWorld::instantiate(&mut store, &component, &linker).context("instantiate")?;
+
+    // --- Proof 1: persistence. Two dispatches on the same instance, 5 then 7. ---
+    store.data_mut().acc_in_val = 5;
+    world.call_a_compute(&mut store).context("a-compute #1")?;
+    store.data_mut().acc_in_val = 7;
+    world.call_a_compute(&mut store).context("a-compute #2")?;
+    let acc = store.data().acc_out_recv;
+    if acc != 12 {
+        bail!(
+            "state did NOT persist: fed 5 then 7, expected acc-out=12, got {acc} \
+             (7 = fresh-construct or call-local; 0 = never written)"
+        );
+    }
+
+    // --- Proof 2: inter-thread. Producer -> buffer -> Consumer, separate dispatches. ---
+    store.data_mut().src_in_val = 42;
+    world.call_pr_compute(&mut store).context("pr-compute")?;
+    world.call_cn_compute(&mut store).context("cn-compute")?;
+    let sink = store.data().sink_out_recv;
+    if sink != 42 {
+        bail!(
+            "inter-thread did NOT deliver: fed src-in=42, expected sink-out=42, got {sink} \
+             (0 = buffer never carried the value)"
+        );
+    }
+
+    println!(
+        "STATE ORACLE PASSED: persistence acc(5,7)->12 across two dispatches, and \
+         inter-thread pr.po->buffer->cn.ci->sink-out delivered 42"
+    );
+    Ok(())
+}
+
+/// Replace exactly one occurrence of `needle` with `replacement`, or fail.
+fn patch_once(src: &str, needle: &str, replacement: &str, what: &str) -> Result<String> {
+    let n = src.matches(needle).count();
+    if n != 1 {
+        bail!("{what}: expected exactly 1 match, found {n}");
+    }
+    Ok(src.replace(needle, replacement))
+}
+
+/// Give the Accum component a persistent `acc` field and a compute that accumulates
+/// its In port into it and writes the running total to its Out port.
+fn patch_accumulator(src: &str) -> Result<String> {
+    let src = patch_once(
+        src,
+        "#[derive(Default)]\npub struct ADefault;",
+        "#[derive(Default)]\npub struct ADefault { acc: u32 }",
+        "accumulator state field",
+    )?;
+    patch_once(
+        &src,
+        "    fn compute(&mut self, _ports: &mut APorts) {\n        // TODO: compute logic\n    }",
+        "    fn compute(&mut self, ports: &mut APorts) {\n        self.acc = self.acc.wrapping_add(ports.ai);\n        ports.ao = self.acc;\n    }",
+        "accumulator compute",
+    )
+}
+
+/// Give a thread's compute an echo body copying its In port to its Out port.
+fn patch_echo(src: &str, pascal: &str, out_field: &str, in_field: &str) -> Result<String> {
+    let needle = format!(
+        "    fn compute(&mut self, _ports: &mut {pascal}Ports) {{\n        // TODO: compute logic\n    }}"
+    );
+    let repl = format!(
+        "    fn compute(&mut self, ports: &mut {pascal}Ports) {{\n        ports.{out_field} = ports.{in_field};\n    }}"
+    );
+    patch_once(src, &needle, &repl, &format!("{pascal} echo compute"))
+}

--- a/codegen-exec-oracle/wit/state.wit
+++ b/codegen-exec-oracle/wit/state.wit
@@ -1,0 +1,18 @@
+// Generated from AADL process: StatePkg::p
+package state-pkg:p;
+
+interface p-ports {
+    type word32 = u32;
+
+    acc-in: func() -> word32;
+    set-acc-out: func(val: word32);
+    src-in: func() -> word32;
+    set-sink-out: func(val: word32);
+}
+
+world p-world {
+    import p-ports;
+    export a-compute: func();
+    export pr-compute: func();
+    export cn-compute: func();
+}

--- a/crates/spar-codegen/src/rust_gen.rs
+++ b/crates/spar-codegen/src/rust_gen.rs
@@ -138,6 +138,62 @@ pub fn resolve_port_routes(
     routes
 }
 
+/// One resolved INTER-THREAD route: a source thread's Out port wired directly to a
+/// destination thread's In port within the same process (REQ-CODEGEN-WIT-STATE-001).
+/// Both connection ends are `Some(subcomponent)` — neither is a process boundary
+/// port — so this value never leaves the component; it is carried between the two
+/// threads' dispatches by a `thread_local!` buffer with latest-value (sampling)
+/// semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterThreadRoute {
+    pub src_thread: String,
+    pub src_feature: String,
+    pub dst_thread: String,
+    pub dst_feature: String,
+}
+
+impl InterThreadRoute {
+    /// Stable, unique Rust identifier for this route's `thread_local!` buffer.
+    /// UPPER_SNAKE (a `static` name) so it satisfies `non_upper_case_globals`.
+    pub fn buffer_ident(&self) -> String {
+        format!(
+            "ITB_{}_{}__{}_{}",
+            sanitize_ident(&self.src_thread).to_uppercase(),
+            sanitize_ident(&self.src_feature).to_uppercase(),
+            sanitize_ident(&self.dst_thread).to_uppercase(),
+            sanitize_ident(&self.dst_feature).to_uppercase(),
+        )
+    }
+}
+
+/// Resolve every inter-thread connection in a PROCESS (REQ-CODEGEN-WIT-STATE-001):
+/// a `ConnectionInstance` whose `src` and `dst` are BOTH `Some(subcomponent)` — the
+/// case [`resolve_port_routes`] deliberately skips. Returned in connection order.
+pub fn resolve_interthread_routes(
+    inst: &SystemInstance,
+    proc_idx: ComponentInstanceIdx,
+) -> Vec<InterThreadRoute> {
+    let proc = inst.component(proc_idx);
+    let mut routes = Vec::new();
+    for &conn_idx in &proc.connections {
+        let conn = &inst.connections[conn_idx];
+        let (Some(src), Some(dst)) = (conn.src.as_ref(), conn.dst.as_ref()) else {
+            continue;
+        };
+        if let (Some(src_thread), Some(dst_thread)) =
+            (src.subcomponent.as_ref(), dst.subcomponent.as_ref())
+        {
+            routes.push(InterThreadRoute {
+                src_thread: src_thread.as_str().to_string(),
+                src_feature: src.feature.as_str().to_string(),
+                dst_thread: dst_thread.as_str().to_string(),
+                dst_feature: dst.feature.as_str().to_string(),
+            });
+        }
+    }
+    routes
+}
+
 /// Generate a Rust component skeleton for a thread instance.
 ///
 /// `scope` resolves each port's data classifier to a concrete Rust type (scalar,
@@ -240,9 +296,14 @@ pub fn generate_rust_component(
     }
     code.push_str("}\n\n");
 
-    // Skeleton implementation
+    // Skeleton implementation. `#[derive(Default)]` lets the process binding hold
+    // ONE instance in a `thread_local!` (constructed once via `Default`) and reuse
+    // it across dispatches so component state persists (REQ-CODEGEN-WIT-STATE-001);
+    // a user adding state fields keeps them `Default`-constructible.
     code.push_str("/// Default implementation skeleton.\n");
-    code.push_str(&format!("pub struct {struct_name}Default;\n\n"));
+    code.push_str(&format!(
+        "#[derive(Default)]\npub struct {struct_name}Default;\n\n"
+    ));
     code.push_str(&format!(
         "impl {struct_name}Component for {struct_name}Default {{\n"
     ));
@@ -371,18 +432,54 @@ pub fn generate_process_bindings(
     let mut bridge_records: Vec<(String, Vec<DataField>)> = Vec::new();
     let mut bridge_seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
+    // Inter-thread connections (both ends `Some`) are carried between the two
+    // threads' dispatches by a thread_local buffer with latest-value (sampling)
+    // semantics (REQ-CODEGEN-WIT-STATE-001).
+    let itc_routes = resolve_interthread_routes(inst, proc_idx);
+
+    // PERSISTENT STATE: the binding holds ONE instance of each thread's component in
+    // a thread_local RefCell, borrowed per dispatch, instead of constructing
+    // `{Struct}Default` fresh — so component state survives across dispatches. Plus
+    // one thread_local buffer per inter-thread route. A wasip2 component is
+    // single-threaded and non-reentrant, so `borrow_mut` here cannot alias.
+    code.push_str(
+        "// Persistent per-thread component state + inter-thread buffers. Reused\n\
+         // across dispatches; single-threaded, non-reentrant wasip2 component so the\n\
+         // RefCell borrows cannot alias. REQ-CODEGEN-WIT-STATE-001.\n",
+    );
+    for &&child_idx in &child_threads {
+        let child = inst.component(child_idx);
+        let m = sanitize_ident(child.name.as_str());
+        let s = to_pascal_case(child.name.as_str());
+        code.push_str(&format!(
+            "thread_local! {{ static {up}_STATE: std::cell::RefCell<crate::{m}::{s}Default> = \
+             std::cell::RefCell::new(Default::default()); }}\n",
+            up = m.to_uppercase(),
+        ));
+    }
+    for route in &itc_routes {
+        let ty = interthread_buffer_type(inst, scope, proc_idx, route);
+        code.push_str(&format!(
+            "thread_local! {{ static {b}: std::cell::RefCell<{ty}> = \
+             std::cell::RefCell::new(Default::default()); }}\n",
+            b = route.buffer_ident(),
+        ));
+    }
+    code.push('\n');
+
     code.push_str("/// Component entry point, exported to the WIT world.\n");
     code.push_str("struct Component;\n\n");
     code.push_str("impl Guest for Component {\n");
-    for (ti, &&child_idx) in child_threads.iter().enumerate() {
+    for &&child_idx in &child_threads {
         let child = inst.component(child_idx);
+        let thread_name = child.name.as_str().to_string();
         let thread_kebab = crate::wit_gen::wit_ident(child.name.as_str());
         let child_mod = sanitize_ident(child.name.as_str());
         let child_struct = to_pascal_case(child.name.as_str());
+        let state_ident = format!("{}_STATE", child_mod.to_uppercase());
         let dispatch = crate::dispatch_protocol(inst, child_idx);
 
-        // Data-plane marshalling lines apply to `compute` only (port I/O happens
-        // at dispatch). Resolve them once per thread.
+        // Boundary marshalling (process ports), compute only.
         let (reads, writes) = marshalling_for_thread(
             inst,
             scope,
@@ -391,38 +488,63 @@ pub fn generate_process_bindings(
             &mut bridge_records,
             &mut bridge_seen,
         );
+        // Inter-thread reads (this thread is a destination) / writes (a source),
+        // through the shared buffers. `.clone()` covers scalar (Copy) and record.
+        let itc_reads: Vec<String> = itc_routes
+            .iter()
+            .filter(|r| r.dst_thread == thread_name)
+            .map(|r| {
+                format!(
+                    "        ports.{f} = {b}.with(|__b| __b.borrow().clone());",
+                    f = sanitize_ident(&r.dst_feature),
+                    b = r.buffer_ident(),
+                )
+            })
+            .collect();
+        let itc_writes: Vec<String> = itc_routes
+            .iter()
+            .filter(|r| r.src_thread == thread_name)
+            .map(|r| {
+                format!(
+                    "        {b}.with(|__b| *__b.borrow_mut() = ports.{f}.clone());",
+                    f = sanitize_ident(&r.src_feature),
+                    b = r.buffer_ident(),
+                )
+            })
+            .collect();
 
-        for (mi, method) in crate::lifecycle_for(&dispatch).methods().iter().enumerate() {
+        for method in crate::lifecycle_for(&dispatch).methods() {
             // wit-bindgen mangles the kebab WIT export `{thread}-{method}` to the
-            // snake Rust method `{thread}_{method}`. Deriving both names from the
-            // same `wit_ident` keeps them consistent; the compiler is the final
-            // arbiter (see doc comment).
+            // snake Rust method `{thread}_{method}`.
             let rust_method = format!("{thread_kebab}-{method}").replace('-', "_");
+            let is_compute = *method == "compute";
             code.push_str(&format!("    fn {rust_method}() {{\n"));
             code.push_str(&format!(
                 "        use crate::{child_mod}::{child_struct}Component;\n"
             ));
+            // Borrow the persistent instance; all port I/O happens inside the borrow.
+            code.push_str(&format!("        {state_ident}.with(|__st| {{\n"));
+            code.push_str("            let mut component = __st.borrow_mut();\n");
             code.push_str(&format!(
-                "        let mut component = crate::{child_mod}::{child_struct}Default;\n"
+                "            let mut ports = crate::{child_mod}::{child_struct}Ports::default();\n"
             ));
-            code.push_str(&format!(
-                "        let mut ports = crate::{child_mod}::{child_struct}Ports::default();\n"
-            ));
-            if *method == "compute" {
-                for line in &reads {
+            if is_compute {
+                for line in reads.iter().chain(itc_reads.iter()) {
+                    code.push_str("    ");
                     code.push_str(line);
                     code.push('\n');
                 }
             }
-            code.push_str(&format!("        component.{method}(&mut ports);\n"));
-            if *method == "compute" {
-                for line in &writes {
+            code.push_str(&format!("            component.{method}(&mut ports);\n"));
+            if is_compute {
+                for line in writes.iter().chain(itc_writes.iter()) {
+                    code.push_str("    ");
                     code.push_str(line);
                     code.push('\n');
                 }
             }
+            code.push_str("        });\n");
             code.push_str("    }\n");
-            let _ = (ti, mi);
         }
     }
     code.push_str("}\n\n");
@@ -524,6 +646,30 @@ fn marshalling_for_thread(
         }
     }
     (reads, writes)
+}
+
+/// The Rust type of an inter-thread buffer — the source thread port's resolved Rust
+/// type (scalar/record/Vec<u8>), matching both endpoints of the connection.
+fn interthread_buffer_type(
+    inst: &SystemInstance,
+    scope: &GlobalScope,
+    proc_idx: ComponentInstanceIdx,
+    route: &InterThreadRoute,
+) -> String {
+    let proc = inst.component(proc_idx);
+    for &child_idx in &proc.children {
+        let child = inst.component(child_idx);
+        if child.name.as_str() != route.src_thread {
+            continue;
+        }
+        for &fi in &child.features {
+            let feat = &inst.features[fi];
+            if feat.name.as_str() == route.src_feature {
+                return feature_to_rust_type(feat.kind, &feat.classifier, scope, &child.package);
+            }
+        }
+    }
+    "Vec<u8>".to_string()
 }
 
 /// Collect a record shape (nested-first, de-duplicated) into the bridge worklist,

--- a/crates/spar-codegen/src/rust_gen.rs
+++ b/crates/spar-codegen/src/rust_gen.rs
@@ -357,11 +357,13 @@ fn lifecycle_doc(method: &str, dispatch: &str) -> String {
 /// In ports are read from the imported `{proc}-ports` funcs BEFORE `compute`, Out
 /// ports are written AFTER — routed through [`resolve_port_routes`]. Scalars marshal
 /// directly (WIT `u32` == Rust `u32`); records go through a generated `From`/`Into`
-/// bridge (wit-bindgen's struct <-> `crate::types`). `initialize`/`finalize` keep
-/// the plain construct-and-call body. LIMITATION (stated, deferred to
-/// REQ-CODEGEN-WIT-STATE-001): the component is constructed fresh per dispatch, so
-/// a stateful user component does NOT retain state between dispatches, and
-/// inter-thread connections are not yet plumbed.
+/// bridge (wit-bindgen's struct <-> `crate::types`).
+///
+/// Each thread's component instance is held in a `thread_local!` and REUSED across
+/// dispatches (borrowed in every lifecycle method), so component state persists;
+/// inter-thread connections are carried by `thread_local!` buffers with latest-value
+/// semantics (REQ-CODEGEN-WIT-STATE-001). Remaining limitation: user state lives in
+/// the generated `{thread}.rs` skeleton, which regen overwrites.
 pub fn generate_process_bindings(
     inst: &SystemInstance,
     scope: &GlobalScope,
@@ -393,9 +395,11 @@ pub fn generate_process_bindings(
     code.push_str(
         "//! Data plane: each thread's `compute` reads its In ports from the imported\n\
          //! `{proc}-ports` functions, runs the component, and writes its Out ports back\n\
-         //! (REQ-CODEGEN-WIT-DATAPLANE-001). LIMITATION: the component is constructed\n\
-         //! fresh per dispatch, so state does NOT persist across dispatches, and\n\
-         //! inter-thread connections are not yet plumbed (REQ-CODEGEN-WIT-STATE-001).\n\n",
+         //! (REQ-CODEGEN-WIT-DATAPLANE-001). Each thread's component instance is held in\n\
+         //! a `thread_local!` and reused across dispatches so state persists;\n\
+         //! inter-thread connections are carried by `thread_local!` buffers with\n\
+         //! latest-value semantics (REQ-CODEGEN-WIT-STATE-001). Note: user state lives\n\
+         //! in the `{thread}.rs` skeleton, which regen overwrites.\n\n",
     );
 
     // The `wit_bindgen::generate!` + `export!` glue calls its own unsafe `*_cabi`

--- a/crates/spar-codegen/tests/lifecycle_bindings.rs
+++ b/crates/spar-codegen/tests/lifecycle_bindings.rs
@@ -13,7 +13,10 @@
 //!    disk for the target dir). Run with:
 //!    `cargo test -p spar-codegen --test lifecycle_bindings -- --ignored`
 
-use spar_codegen::rust_gen::{PortRoute, RouteDir, generate_process_bindings, resolve_port_routes};
+use spar_codegen::rust_gen::{
+    InterThreadRoute, PortRoute, RouteDir, generate_process_bindings, resolve_interthread_routes,
+    resolve_port_routes,
+};
 use spar_codegen::wit_gen::generate_wit;
 use spar_codegen::{CodegenConfig, OutputFormat, generate};
 use spar_hir_def::instance::{ComponentInstanceIdx, SystemInstance};
@@ -317,6 +320,42 @@ fn routing_resolver_is_exact_including_blind_spots() {
     );
 }
 
+/// The state/inter-thread fixture (REQ-CODEGEN-WIT-STATE-001): an Accum thread
+/// (boundary in->out, for persistent state) plus a Producer->Consumer inter-thread
+/// pair (`pr.po -> cn.ci`) whose value is observable at Consumer's boundary out.
+const STATE_AADL: &str = include_str!("../../../test-data/codegen/state.aadl");
+
+/// INTER-THREAD RESOLVER oracle (REQ-CODEGEN-WIT-STATE-001): `resolve_interthread_routes`
+/// returns exactly the both-ends-`Some` connection `pr.po -> cn.ci`, and NOT the
+/// boundary connections (which `resolve_port_routes` owns). Complements
+/// `routing_resolver_is_exact_including_blind_spots`, which asserts these same
+/// inter-thread connections are absent from the boundary routes.
+#[test]
+fn interthread_resolver_is_exact() {
+    let (_scope, inst) = build(STATE_AADL, "StatePkg", "Top", "Impl");
+    let idx = process_idx(&inst);
+    let routes = resolve_interthread_routes(&inst, idx);
+    assert_eq!(
+        routes,
+        vec![InterThreadRoute {
+            src_thread: "pr".into(),
+            src_feature: "po".into(),
+            dst_thread: "cn".into(),
+            dst_feature: "ci".into(),
+        }],
+        "only the both-ends-Some connection pr.po -> cn.ci is an inter-thread route"
+    );
+    // The boundary connections (acc_in->a.ai, a.ao->acc_out, src_in->pr.pi,
+    // cn.co->sink_out) must NOT appear as inter-thread routes.
+    assert_eq!(
+        routes.len(),
+        1,
+        "boundary connections are not inter-thread: {routes:?}"
+    );
+    // And the buffer ident is stable/unique.
+    assert_eq!(routes[0].buffer_ident(), "ITB_PR_PO__CN_CI");
+}
+
 /// MARSHALLING string oracle (REQ-CODEGEN-WIT-DATAPLANE-001): the generated Guest
 /// `compute` reads In ports from the imported funcs before compute and writes Out
 /// ports after — scalars directly, records via a `From`/`Into` bridge. This is the
@@ -394,6 +433,111 @@ fn dataplane_wit_matches_exec_oracle_fixture() {
         "generated DATAPLANE WIT drifted from the committed exec-oracle fixture; \
          the wasmtime host `bindgen!` would bind a stale ABI. Regenerate \
          codegen-exec-oracle/wit/dp.wit."
+    );
+}
+
+/// STATE fixture generates the persistent-state + inter-thread wiring
+/// (REQ-CODEGEN-WIT-STATE-001): a per-thread `thread_local!` component instance
+/// (reused across dispatches) and a `thread_local!` inter-thread buffer. Fast shape
+/// check; the exec oracle proves state persists and the buffer carries the value.
+#[test]
+fn state_bindings_emit_threadlocal_and_interthread_buffer() {
+    let (scope, inst) = build(STATE_AADL, "StatePkg", "Top", "Impl");
+    let idx = process_idx(&inst);
+    let src = generate_process_bindings(&inst, &scope, idx).content;
+
+    // Persistent instance: each thread's component held in a thread_local RefCell,
+    // borrowed per dispatch (not constructed fresh).
+    assert!(
+        src.contains(
+            "static A_STATE: std::cell::RefCell<crate::a::ADefault> = \
+             std::cell::RefCell::new(Default::default());"
+        ),
+        "Accum must hold a persistent thread_local instance:\n{src}"
+    );
+    assert!(
+        src.contains("A_STATE.with(|__st| {")
+            && src.contains("let mut component = __st.borrow_mut();"),
+        "compute must borrow the persistent instance, not construct fresh:\n{src}"
+    );
+    assert!(
+        !src.contains("let mut component = crate::a::ADefault;"),
+        "must NOT fresh-construct the component:\n{src}"
+    );
+    // Inter-thread buffer: pr.po -> cn.ci carried by a thread_local buffer.
+    assert!(
+        src.contains("static ITB_PR_PO__CN_CI: std::cell::RefCell<u32>"),
+        "inter-thread buffer must be declared:\n{src}"
+    );
+    assert!(
+        src.contains("ITB_PR_PO__CN_CI.with(|__b| *__b.borrow_mut() = ports.po.clone());"),
+        "producer must write its Out port to the buffer:\n{src}"
+    );
+    assert!(
+        src.contains("ports.ci = ITB_PR_PO__CN_CI.with(|__b| __b.borrow().clone());"),
+        "consumer must read its In port from the buffer:\n{src}"
+    );
+}
+
+/// GOLDEN LOCK for the STATE exec oracle: `generate_wit` for the STATE process must
+/// reproduce the committed `codegen-exec-oracle/wit/state.wit` byte-for-byte (the
+/// `bindgen!` host binds against it). Same guard as the DATAPLANE golden lock.
+#[test]
+fn state_wit_matches_exec_oracle_fixture() {
+    let (scope, inst) = build(STATE_AADL, "StatePkg", "Top", "Impl");
+    let idx = process_idx(&inst);
+    let generated = generate_wit(&inst, &scope, idx)
+        .expect("wit generation should succeed")
+        .content;
+    let committed = include_str!("../../../codegen-exec-oracle/wit/state.wit");
+    assert_eq!(
+        generated, committed,
+        "generated STATE WIT drifted from the committed exec-oracle fixture; \
+         regenerate codegen-exec-oracle/wit/state.wit."
+    );
+}
+
+/// COMPILE oracle for STATE (REQ-CODEGEN-WIT-STATE-001): the thread_local instance
+/// reuse + inter-thread buffer wiring type-checks against real wit-bindgen output.
+///
+/// `#[ignore]` (shells out to cargo). Run with `-- --ignored`.
+#[test]
+#[ignore = "shells out to cargo check (network/disk); run with --ignored"]
+fn emitted_state_crate_cargo_checks() {
+    use std::process::Command;
+
+    let (scope, inst) = build(STATE_AADL, "StatePkg", "Top", "Impl");
+    let config = CodegenConfig {
+        root_name: "st".into(),
+        output_dir: "out".into(),
+        format: OutputFormat::Both,
+        verify: None,
+        rivet: false,
+        dry_run: true,
+    };
+    let out = generate(&inst, &scope, &config).expect("codegen should succeed");
+
+    let root = std::env::temp_dir().join("spar-state-oracle");
+    let _ = std::fs::remove_dir_all(&root);
+    for f in &out.files {
+        let path = root.join(&f.path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, &f.content).unwrap();
+    }
+
+    let target_dir = std::env::temp_dir().join("spar-state-target");
+    let status = Command::new("cargo")
+        .arg("check")
+        .current_dir(&root)
+        .env("CARGO_INCREMENTAL", "0")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .status()
+        .expect("failed to spawn cargo check");
+    assert!(
+        status.success(),
+        "generated STATE crate failed to `cargo check` (thread_local/inter-thread \
+         wiring broken); inspect {}",
+        root.display()
     );
 }
 

--- a/test-data/codegen/state.aadl
+++ b/test-data/codegen/state.aadl
@@ -1,0 +1,67 @@
+package StatePkg
+public
+    data Word32
+        properties
+            Data_Size => 4 Bytes;
+    end Word32;
+
+    -- Accumulator: boundary in -> (stateful) -> boundary out. Exercises
+    -- persistent component state across dispatches.
+    thread Accum
+        features
+            ai: in data port Word32;
+            ao: out data port Word32;
+    end Accum;
+
+    thread implementation Accum.Impl
+    end Accum.Impl;
+
+    -- Producer -> Consumer inter-thread pair. Producer boundary-in -> its out
+    -- port -> (inter-thread buffer) -> Consumer in port -> boundary-out.
+    thread Producer
+        features
+            pi: in data port Word32;
+            po: out data port Word32;
+    end Producer;
+
+    thread implementation Producer.Impl
+    end Producer.Impl;
+
+    thread Consumer
+        features
+            ci: in data port Word32;
+            co: out data port Word32;
+    end Consumer;
+
+    thread implementation Consumer.Impl
+    end Consumer.Impl;
+
+    process Sp
+        features
+            acc_in: in data port Word32;
+            acc_out: out data port Word32;
+            src_in: in data port Word32;
+            sink_out: out data port Word32;
+    end Sp;
+
+    process implementation Sp.Impl
+        subcomponents
+            a: thread Accum.Impl;
+            pr: thread Producer.Impl;
+            cn: thread Consumer.Impl;
+        connections
+            k1: port acc_in -> a.ai;
+            k2: port a.ao -> acc_out;
+            k3: port src_in -> pr.pi;
+            k4: port pr.po -> cn.ci;
+            k5: port cn.co -> sink_out;
+    end Sp.Impl;
+
+    system Top
+    end Top;
+
+    system implementation Top.Impl
+        subcomponents
+            p: process Sp.Impl;
+    end Top.Impl;
+end StatePkg;


### PR DESCRIPTION
## What

Removes the two v0.25 data-plane limitations. The generated component `Guest` now:

- **Persistent state** — holds ONE instance of each thread's component in a `thread_local! { RefCell<{Struct}Default> }`, borrowed per `compute`, instead of constructing `{Struct}Default` fresh each dispatch. Component state now survives across dispatches. The skeleton struct gains `#[derive(Default)]` for the one-time init. A wasip2 component is single-threaded and non-reentrant, so `borrow_mut` cannot alias.
- **Inter-thread connections** — a `ConnectionInstance` with BOTH ends `Some(...)` (thread A out → thread B in, previously skipped) now routes through a `thread_local!` buffer with **latest-value / sampling** semantics: the source's Out field writes the buffer after `compute`, the destination's In field reads the latest value before `compute`. (`resolve_interthread_routes` + `InterThreadRoute`.) This is sampling, **not** AADL immediate/delayed connection timing — out of scope, stated in the requirement.

## Oracles

- **Resolver / shape (fast):** `interthread_resolver_is_exact`, `state_bindings_emit_threadlocal_and_interthread_buffer`.
- **Golden lock + `cargo check`** of the emitted STATE crate (green under `-D warnings`).
- **wasmtime `state-oracle`** (out-of-workspace, the load-bearing gate) — on ONE live instance:
  - persistence: an accumulator fed 5 then 7 returns **12** (fresh-construct or a call-local buffer would give 7 — the number discriminates);
  - inter-thread: `pr.po → buffer → cn.ci → sink-out` delivers **42** across two separate dispatches.
  ```
  STATE ORACLE PASSED: persistence acc(5,7)->12 across two dispatches, and
  inter-thread pr.po->buffer->cn.ci->sink-out delivered 42
  ```

## Falsification (both sabotage-verified non-vacuous)

- Reverting the `thread_local` to a per-call `Default` drops persistence to **7**.
- Dropping the buffer write drops inter-thread delivery to **0**.

Both wired into the `codegen-oracle` CI job. The v0.25 DATAPLANE exec oracle still passes (its generated code now carries the state/inter-thread wiring).

## Stated limitation

User state lives in the generated `{thread}.rs` skeleton, which carries `DO NOT EDIT — regenerate`; adding real state means editing a file regen overwrites. The *mechanism* (instance reuse) ships here; a regen-safe authoring split is a separate successor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)