### PR TITLE
chore(release): bump to v0.26.0 (persistent state + inter-thread)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2856,10 +2856,9 @@ artifacts:
       `{thread}.rs` skeleton, which carries `DO NOT EDIT — regenerate`; adding real
       state means editing a file regen overwrites. The mechanism (instance reuse) is
       delivered here; a regen-safe user-authoring split is a separate successor.
-    status: proposed
+    status: verified
     tags: [codegen, wit, rust, wit-bindgen, data-plane, state]
-    fields:
-      release: v0.26.0
+    release: v0.26.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-DATAPLANE-001
@@ -2884,7 +2883,7 @@ artifacts:
     status: proposed
     tags: [codegen, wit, wit-bindgen, data-plane, kiln, integration, dogfood]
     fields:
-      release: v0.26.0
+      release: v0.27.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-DATAPLANE-001

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump for **v0.26.0 — persistent component state + inter-thread connections**.

The generated component `Guest` now reuses each thread's component instance across dispatches (state persists) and routes inter-thread connections through latest-value `thread_local!` buffers (REQ-CODEGEN-WIT-STATE-001, promoted to `verified`). Gated by a wasmtime runtime oracle proving, on one live instance, accumulator persistence (5,7→12) and inter-thread delivery (42) — both sabotage-verified non-vacuous.

- workspace + all spar-* crates `0.25.0` → `0.26.0`
- vscode-spar extension `0.25.0` → `0.26.0`
- `REQ-CODEGEN-WIT-STATE-001`: `proposed` → `verified`, top-level `release: v0.26.0`
- `REQ-CODEGEN-WIT-DATAPLANE-KILN-001` moved to `release: v0.27.0` (not in v0.26 scope)

Feature landed in #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)