### PR TITLE
chore(release): bump to v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2906,10 +2906,9 @@ artifacts:
       Deliberately NOT a v0.25/v0.26 gate: a cross-repo dependency on kiln + meld
       must not stall the spar release cadence; it follows once the substrate is
       proven, which it now is.
-    status: implemented
+    status: verified
     tags: [codegen, wit, wit-bindgen, data-plane, kiln, meld, integration, dogfood]
-    fields:
-      release: v0.27.0
+    release: v0.27.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-DATAPLANE-001

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump to **v0.27.0** — kiln runtime oracle.

The spar-generated component now runs on the [kiln](https://github.com/pulseengine/kiln)
interpreter via [meld](https://github.com/pulseengine/meld) fusion — a **second runtime**
beside wasmtime — closing the "spar generates → kiln fires" dogfood loop:

```
spar codegen → wasm32-wasip2 component → meld fuse → CORE module → kiln
```

**Falsification:** persistence `acc(5,7)→12` and inter-thread `42` are proven on one live
kiln instance; reverting the accumulator's Out port to emit its input drops persistence to
7 (the oracle catches it). kiln runs core modules, not components (kiln#269) — meld does the
lowering; filed kiln#427 for the residual library-API panic.

- workspace + all spar-* crates 0.26.0 → 0.27.0
- vscode-spar extension 0.26.0 → 0.27.0
- `REQ-CODEGEN-WIT-DATAPLANE-KILN-001` promoted `implemented → verified`, `release: v0.27.0`

Feature landed in #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)