### PR TITLE
chore(fuzz): gitignore the regeneratable fuzz Cargo.lock

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -2,3 +2,4 @@ target
 corpus
 artifacts
 coverage
+Cargo.lock


### PR DESCRIPTION
`fuzz/Cargo.lock` is an untracked cargo-fuzz dev artifact — the fuzz harness is never published, and CI's **Fuzz smoke** job builds it fine without a committed lock (so nothing depends on it being tracked). `fuzz/.gitignore` already excludes `target/corpus/artifacts/coverage`; this adds `Cargo.lock` so it stops resurfacing as recurring `git status` noise across worktrees.

Surfaced by a post-release **repo-hygiene** sweep (§8 status noise — fix the cause via `.gitignore`, don't silence it locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)