### PR TITLE
chore(release): bump to v0.28.0 (#331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2015,10 +2015,9 @@ artifacts:
       tool-qualification credit by itself — the machine-checked bound is a
       safety-case input, not a certification claim. Tracks issue #331;
       companion input-side issue synth#778.
-    status: implemented
+    status: verified
     tags: [rta, arinc653, supply, timing, proofs, v0280]
-    fields:
-      release: v0.28.0
+    release: v0.28.0
     links:
       - type: traces-to
         target: REQ-RTA-001

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.28.0 — **ARINC-653 partition-supply-derived inner RTA** (`REQ-RTA-ARINC-SUPPLY-001`, closes #331, landed in #332).

Inner threads bound under a virtual processor `Γ=(Π,Θ)` now receive a per-task worst-case response-time bound analyzed against the **partition supply**, not wall-clock — reusing the Lean-verified jittered+blocking recurrence unchanged. Supply-derived jitter `J=2(Π−Θ)`, cooperative non-preemptive blocking, and a demand-vs-supply fallback that hard-errors on unschedulable/ill-formed sets. Golden `Γ=(1000µs,300µs)` → 1520/1570/1570 µs (w-form). Lean floor (`ArincSupply.lean`, 0 `sorry`, CI-verified): blocking folds into jitter so convergence transfers; `lsbf` monotone + conditional fallback soundness under an explicit `SupplyGuarantee` hypothesis (PROVEN vs ASSUMED stated precisely).

- workspace + all `spar-*` crates 0.27.0 → 0.28.0
- vscode-spar extension 0.27.0 → 0.28.0
- `REQ-RTA-ARINC-SUPPLY-001` status: implemented → **verified**, release: v0.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)