### PR TITLE
chore(release): bump to v0.29.0 (#321 foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.29.0 — **honest foundation toward #321** (landed in #334). **#321 is NOT closed** — the real generator is `REQ-PROOF-SCHED-CODEGEN-001` (proposed).

- Removed the `lake exe codegen` fiction: a string-emitting stub whose documented regen command would have **silently deleted 7 shipped functions**.
- Corrected a false verification claim (claim-verification): `scheduling_verified.rs` no longer claims "generated / DO NOT EDIT" — it's hand-written to mirror the Lean, bound by the **named property tests** that run in CI.
- Extracted the combinational RTA defs into a mathlib-free **`RTACore.lean`** — the named single source a future reflection-based generator will consume.

Bump:
- workspace + all `spar-*` crates 0.28.0 → 0.29.0
- vscode-spar extension 0.28.0 → 0.29.0
- `REQ-PROOF-SCHED-SPEC-SOURCE-001` verified, release v0.29.0
- `REQ-PROOF-SCHED-CODEGEN-001` proposed (closes #321, backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)