### PR TITLE
fix(parser): accept underscore digit-separators in based literals (#339)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -565,6 +565,32 @@ artifacts:
     status: implemented
     tags: [parsing, as5506, v030]
 
+  - id: REQ-PARSER-002
+    type: requirement
+    title: Underscore digit separators inside based numeric literals
+    description: >
+      Closes #339. The lexer accepted `_` digit separators in decimal
+      literals (`131_072`) but rejected them inside based literals
+      (`16#0800_0000#`), splitting the token at the first `_` so the value
+      failed to parse. AADL v2.3 permits `_` as a digit separator in based
+      literals too. Fix: the based-literal scan loop in
+      `crates/spar-parser/src/lexer.rs` now also consumes `_`, so
+      `16#0800_0000#` lexes as one INTEGER_LIT and lowers to the same value
+      as `16#08000000#` (= 134217728). The value path already stripped `_`
+      before radix conversion, so no downstream change was needed.
+      PROVEN by executed oracles: a lexer unit test that the whole token is
+      a single INTEGER_LIT (confirmed red before the fix), a value test that
+      `parse_aadl_integer("16#0800_0000#") == parse_aadl_integer("16#08000000#")
+      == 134217728`, and an end-to-end lower test that the property value
+      survives lexing + lowering intact.
+    status: implemented
+    tags: [parsing, lexer, literals, as5506, bug]
+    fields:
+      release: v0.31.0
+    links:
+      - type: traces-to
+        target: REQ-PARSER-001
+
   # ── Property Verification ────────────────────────────────────────────
 
   - id: REQ-VERIFY-001

--- a/crates/spar-hir-def/src/item_tree/lower.rs
+++ b/crates/spar-hir-def/src/item_tree/lower.rs
@@ -2885,6 +2885,22 @@ mod lowering_diagnostic_tests {
     use spar_syntax::parse;
 
     #[test]
+    fn based_integer_underscore_separators_value(/* #339 */) {
+        // `_` digit separators inside a based literal must be ignored and yield
+        // the same value as the separator-free form (AADL v2.3). This guards the
+        // value semantics; the lexer change is what makes the whole token reach
+        // this path in the first place.
+        assert_eq!(parse_aadl_integer("16#0800_0000#"), Some(134_217_728));
+        assert_eq!(
+            parse_aadl_integer("16#0800_0000#"),
+            parse_aadl_integer("16#08000000#"),
+            "separated and unseparated base-16 literals must be equal"
+        );
+        assert_eq!(parse_aadl_integer("2#1010_1010#"), Some(170));
+        assert_eq!(parse_aadl_integer_or_real("16#0800_0000#"), 134_217_728);
+    }
+
+    #[test]
     fn annex_library_emits_diagnostic() {
         let src = r#"
 package Pkg

--- a/crates/spar-hir-def/src/lib.rs
+++ b/crates/spar-hir-def/src/lib.rs
@@ -612,6 +612,38 @@ end P;
     }
 
     #[test]
+    fn based_literal_underscore_separator_property_value() {
+        // End-to-end (#339): a base-16 property value with `_` digit separators
+        // must survive lexing + lowering as a single value. Before the fix the
+        // lexer split `16#0800_0000#` at the first `_`, corrupting the token.
+        let db = make_db();
+        let src = r#"package P
+public
+  device D
+    properties
+      Deployment::Priority => 16#0800_0000#;
+  end D;
+end P;
+"#;
+        let file = spar_base_db::SourceFile::new(&db, "based.aadl".to_string(), src.to_string());
+        let tree = file_item_tree(&db, file);
+
+        let ct = &tree.component_types[tree.component_types.iter().next().unwrap().0];
+        assert_eq!(
+            ct.property_associations.len(),
+            1,
+            "expected exactly 1 property association, got {}",
+            ct.property_associations.len()
+        );
+        let pa = &tree.property_associations[ct.property_associations[0]];
+        assert_eq!(pa.name.property_name.as_str(), "Priority");
+        assert_eq!(
+            pa.value, "16#0800_0000#",
+            "the whole based literal (with separators) must be captured as the value"
+        );
+    }
+
+    #[test]
     fn property_inheritance_type_to_impl() {
         let db = make_db();
         let src = r#"package P

--- a/crates/spar-parser/src/lexer.rs
+++ b/crates/spar-parser/src/lexer.rs
@@ -166,11 +166,15 @@ fn scan_number(c: &mut Cursor<'_>) -> SyntaxKind {
 
     // Check for based literal: digits followed by `#`.
     if !c.is_eof() && c.current() == b'#' {
-        // Based literal — consume `#`, then hex digits (possibly with a `.`),
-        // then closing `#`, then optional exponent.
+        // Based literal — consume `#`, then hex digits (possibly with a `.`
+        // and `_` digit separators), then closing `#`, then optional exponent.
+        // AADL v2.3 permits `_` as a digit separator inside based literals
+        // (e.g. `16#0800_0000#`), consistent with the decimal path below.
         c.bump(); // skip `#`
         let mut is_real = false;
-        while !c.is_eof() && (is_hex_digit(c.current()) || c.current() == b'.') {
+        while !c.is_eof()
+            && (is_hex_digit(c.current()) || c.current() == b'.' || c.current() == b'_')
+        {
             if c.current() == b'.' {
                 is_real = true;
             }
@@ -635,6 +639,21 @@ mod tests {
     fn integer_binary() {
         let tokens = lex_tokens("2#1010#");
         assert_eq!(tokens, vec![(INTEGER_LIT, "2#1010#")]);
+    }
+
+    #[test]
+    fn integer_based_with_underscores() {
+        // AADL v2.3 permits `_` digit separators inside based literals (#339).
+        // The whole `16#0800_0000#` must lex as ONE integer token — before the
+        // fix the lexer stopped at the first `_` and split it into three tokens.
+        let tokens = lex_tokens("16#0800_0000#");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "16#0800_0000#")]);
+    }
+
+    #[test]
+    fn integer_binary_with_underscores() {
+        let tokens = lex_tokens("2#1010_1010#");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "2#1010_1010#")]);
     }
 
     // -- Real literals --


### PR DESCRIPTION
## Summary

Closes #339. The AADL lexer accepted `_` digit separators in **decimal** literals (`131_072`) but rejected them inside **based** literals (`16#0800_0000#`): the based-literal scan loop stopped at the first `_`, so the closing `#` was never consumed and the token was split, producing a parse error. AADL v2.3 permits `_` as a digit separator in based literals too.

## Fix

One production-code change in `crates/spar-parser/src/lexer.rs`: the based-literal scan loop now also consumes `_`, so `16#0800_0000#` lexes as a single `INTEGER_LIT`. The value path already stripped `_` before radix conversion (`parse_aadl_integer` / `parse_aadl_integer_or_real` in `spar-hir-def`), so no downstream change was needed. This makes the based-literal path **consistent** with the existing decimal path (both are equally permissive about separator placement).

## Oracles (all executed; the lexer test was confirmed red before the fix)

- **Lexer unit test** — `16#0800_0000#` and `2#1010_1010#` each lex as one `INTEGER_LIT` (this is the exact bug; flips red when the fix is reverted).
- **Value test** — `parse_aadl_integer("16#0800_0000#") == parse_aadl_integer("16#08000000#") == 134217728`; `2#1010_1010#` == 170.
- **End-to-end lower test** — a `=> 16#0800_0000#;` property value survives lexing + lowering as a single intact value.

## Verification

- `cargo test -p spar-parser -p spar-hir-def` — green (469 + 63 lib tests); `spar-syntax` CST tests green (236 + 53).
- `cargo fmt --check` clean; `cargo clippy -p spar-parser -p spar-hir-def --all-targets -- -D warnings` clean.
- Independent clean-room verification confirmed the diff scope (4 files, one prod-code line), the numeric re-derivation, the red-flip, no over-claim in prose vs. executed oracles, and no panic on degenerate inputs (`16##`, `16#__#` → graceful `None`).

## Requirements

Adds `REQ-PARSER-002` (traces-to `REQ-PARSER-001`), release `v0.31.0`.

## Scope / honesty

Fix covers integer **and** real based literals (same lexer loop); oracles cover the integer forms from the issue. Separator-placement permissiveness intentionally matches the decimal path rather than adding stricter Ada-style placement rules (out of scope, and would be inconsistent). Related silent-hex bug #337 is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMav3c6j5akrjiPACMQfqH)_