### PR TITLE
fix(parser): reject C-style radix literals (0x/0b/0o) instead of silently parsing to 0 (#337)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -591,6 +591,47 @@ artifacts:
       - type: traces-to
         target: REQ-PARSER-001
 
+  - id: REQ-PARSER-003
+    type: requirement
+    title: Reject C-style radix-prefixed integer literals with a diagnostic
+    description: >
+      Closes #337. A `0x…`-style (C-style hex) integer literal in a property
+      association silently parsed to `0`: the lexer split `0x40003000` into
+      INTEGER_LIT `0` + IDENT `x40003000`, and the parser then treated the
+      trailing identifier as a *unit*, yielding `Integer(0, unit="x40003000")`
+      with no diagnostic — a silent wrong value for any downstream consumer.
+      C-style radix prefixes are NOT valid AADL v2.3 numeric literals (AADL
+      uses based notation `base#digits#`, e.g. `16#40003000#`); accepting them
+      would introduce a spar-specific dialect divergence, so — per the issue's
+      stated preference ("a hard error is strictly better than silent 0") —
+      spar now rejects them. Fix: `scan_number` in
+      `crates/spar-parser/src/lexer.rs` recognizes a lone leading `0` glued to
+      a radix marker (`x`/`X`, `b`/`B`, `o`/`O`) followed by a valid digit of
+      that radix, and lexes the whole malformed run as one ERROR token; the
+      property-value grammar in `crates/spar-parser/src/grammar/properties.rs`
+      attaches a targeted diagnostic ("C-style radix literal is not valid AADL;
+      use based notation, e.g. `16#…#`") on that token.
+      PROVEN by executed oracles: lexer unit tests that `0x40003000` / `0X1F` /
+      `0b1010` / `0o17` each lex as a single ERROR token (confirmed red before
+      the fix — they split into `0` + IDENT), with negative controls that
+      `0 ns`, `0bar`, `0x`, and the AADL-native `16#40003000#` are unaffected;
+      an end-to-end lowering test that `=> 0x40003000;` no longer lowers to
+      `Integer(0, Some(unit))`; a parser test that the same input yields a
+      diagnostic and an ERROR token in the tree; and a positive control that
+      `16#40003000#` lowers to `Integer(1073754112, None)`. `spar parse`
+      reports the diagnostic with location and exits non-zero; `spar items`
+      no longer emits a deceptive `Integer[0]` for the input.
+      ASSUMED/NOT-CLAIMED: this closes the token-split silent-zero path (the
+      reported bug); it does not make `spar items` itself exit non-zero on the
+      malformed input (that command remains a best-effort structural dump).
+    status: verified
+    tags: [parsing, lexer, literals, as5506, bug]
+    fields:
+      release: v0.32.0
+    links:
+      - type: traces-to
+        target: REQ-PARSER-001
+
   # ── Property Verification ────────────────────────────────────────────
 
   - id: REQ-VERIFY-001

--- a/crates/spar-hir-def/src/lib.rs
+++ b/crates/spar-hir-def/src/lib.rs
@@ -2559,6 +2559,50 @@ end P;
     }
 
     #[test]
+    fn based_hex_integer_lowers_to_correct_value() {
+        // Positive control for #337: the AADL-native based form must lower to
+        // the correct integer value (0x40003000 == 1073754112).
+        let src = r#"package P
+public
+  system S
+    properties
+      Base => 16#40003000#;
+  end S;
+end P;
+"#;
+        let val = lower_first_typed_value(src);
+        assert_eq!(
+            val,
+            Some(item_tree::PropertyExpr::Integer(1073754112, None)),
+            "expected Integer(1073754112, None), got {:?}",
+            val
+        );
+    }
+
+    #[test]
+    fn c_style_hex_does_not_silently_lower_to_zero() {
+        // #337: `0x40003000` is not a valid AADL literal. It must NOT silently
+        // lower to `Integer(0, Some("x40003000"))` (value 0 with the dropped
+        // hex digits misread as a unit). After the fix the malformed literal
+        // is an ERROR token, so no INTEGER_VALUE node exists and lowering
+        // yields no typed value — a hard failure, never a silent wrong value.
+        let src = r#"package P
+public
+  system S
+    properties
+      Base => 0x40003000;
+  end S;
+end P;
+"#;
+        let val = lower_first_typed_value(src);
+        assert!(
+            !matches!(val, Some(item_tree::PropertyExpr::Integer(0, Some(_)))),
+            "0x40003000 silently lowered to a zero-with-bogus-unit integer: {:?}",
+            val
+        );
+    }
+
+    #[test]
     fn lower_real_value() {
         let src = r#"package P
 public

--- a/crates/spar-parser/src/grammar/properties.rs
+++ b/crates/spar-parser/src/grammar/properties.rs
@@ -257,10 +257,34 @@ fn property_expression_primary(p: &mut Parser) {
             property_expression_primary(p);
             m.complete(p, SyntaxKind::PROPERTY_EXPRESSION);
         }
+        SyntaxKind::ERROR if is_c_style_radix_literal(p.current_text()) => {
+            // A C-style radix literal (`0x40003000`, `0b1010`, `0o17`) — the
+            // lexer emits these as a single ERROR token because they are not
+            // valid AADL. Emit a targeted, actionable diagnostic and consume
+            // the token so the property association recovers to the `;` (#337).
+            let m = p.start();
+            p.error(
+                "C-style radix literal is not valid AADL; use based notation, \
+                 e.g. `16#…#` for hexadecimal",
+            );
+            p.bump_any();
+            m.complete(p, SyntaxKind::ERROR);
+        }
         _ => {
             p.error("expected property expression");
         }
     }
+}
+
+/// Whether `text` is a C-style radix-prefixed literal (`0x…`, `0b…`, `0o…`,
+/// any case). The lexer produces these as ERROR tokens; the parser uses this
+/// to attach a specific diagnostic rather than the generic "expected
+/// expression" message.
+fn is_c_style_radix_literal(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.len() > 2
+        && bytes[0] == b'0'
+        && matches!(bytes[1], b'x' | b'X' | b'o' | b'O' | b'b' | b'B')
 }
 
 /// Parse `applies to path1, path2 ...`

--- a/crates/spar-parser/src/lexer.rs
+++ b/crates/spar-parser/src/lexer.rs
@@ -111,6 +111,12 @@ fn is_hex_digit(b: u8) -> bool {
     b.is_ascii_hexdigit()
 }
 
+/// Whether ASCII byte `b` is a valid digit in the given `radix` (2, 8, or 16).
+/// Used to recognize C-style radix prefixes (`0x`/`0b`/`0o`) that AADL rejects.
+fn is_radix_digit(b: u8, radix: u32) -> bool {
+    (b as char).is_digit(radix)
+}
+
 /// Scan whitespace (one or more whitespace characters).
 fn scan_whitespace(c: &mut Cursor<'_>) {
     while !c.is_eof() && is_whitespace(c.current()) {
@@ -159,9 +165,42 @@ fn scan_string(c: &mut Cursor<'_>) -> bool {
 ///
 /// Returns the `SyntaxKind` for the scanned literal.
 fn scan_number(c: &mut Cursor<'_>) -> SyntaxKind {
+    let start = c.pos;
+
     // Consume leading decimal digits.
     while !c.is_eof() && is_digit(c.current()) {
         c.bump();
+    }
+
+    // Reject C-style radix-prefixed integer literals (`0x1F`, `0b1010`,
+    // `0o17`). These are NOT valid AADL v2.3 numeric literals — AADL uses
+    // based notation `base#digits#` (e.g. `16#1F#`). Without this guard the
+    // lexer would split `0x40003000` into `0` + identifier `x40003000`, and
+    // the parser would then silently treat the identifier as a *unit*,
+    // lowering the property to integer `0` with a bogus unit and no
+    // diagnostic (issue #337). Lex the whole malformed run as a single ERROR
+    // token so the parser reports a hard error instead of dropping the digits.
+    //
+    // The guard fires only on the exact C-style shape: a lone leading `0`,
+    // glued to a radix marker, followed by a valid digit of that radix. This
+    // leaves valid AADL untouched — `0 ns` (whitespace-separated unit) and
+    // `0bar` (`a` is not a binary digit) still lex as INTEGER_LIT + IDENT.
+    if c.pos - start == 1 && c.input.as_bytes()[start] == b'0' && !c.is_eof() {
+        let radix = match c.current() {
+            b'x' | b'X' => 16,
+            b'o' | b'O' => 8,
+            b'b' | b'B' => 2,
+            _ => 0,
+        };
+        if radix != 0 && is_radix_digit(c.peek(1), radix) {
+            c.bump(); // radix marker
+            // Consume the whole `[0-9A-Za-z_]` run so the malformed literal is
+            // one token, not a valid `0` followed by a stray identifier.
+            while !c.is_eof() && is_ident_continue(c.current()) {
+                c.bump();
+            }
+            return SyntaxKind::ERROR;
+        }
     }
 
     // Check for based literal: digits followed by `#`.
@@ -654,6 +693,79 @@ mod tests {
     fn integer_binary_with_underscores() {
         let tokens = lex_tokens("2#1010_1010#");
         assert_eq!(tokens, vec![(INTEGER_LIT, "2#1010_1010#")]);
+    }
+
+    // -- C-style radix literals are NOT valid AADL (#337) --
+
+    #[test]
+    fn c_style_hex_is_error() {
+        // `0x…` is not an AADL numeric literal (AADL uses based notation
+        // `16#…#`). Before the fix this split into `0` + IDENT `x40003000`,
+        // and the parser silently treated the identifier as a *unit* — the
+        // property lowered to integer 0 with a bogus unit and no diagnostic.
+        // The whole malformed literal must lex as ONE ERROR token so a hard
+        // error is reported instead of a silent wrong value.
+        let tokens = lex_tokens("0x40003000");
+        assert_eq!(tokens, vec![(ERROR, "0x40003000")]);
+    }
+
+    #[test]
+    fn c_style_hex_upper_is_error() {
+        let tokens = lex_tokens("0X1F");
+        assert_eq!(tokens, vec![(ERROR, "0X1F")]);
+    }
+
+    #[test]
+    fn c_style_binary_is_error() {
+        // Same silent-zero failure class as hex.
+        let tokens = lex_tokens("0b1010");
+        assert_eq!(tokens, vec![(ERROR, "0b1010")]);
+    }
+
+    #[test]
+    fn c_style_octal_is_error() {
+        let tokens = lex_tokens("0o17");
+        assert_eq!(tokens, vec![(ERROR, "0o17")]);
+    }
+
+    #[test]
+    fn c_style_hex_with_underscores_is_error() {
+        // A `_` separator inside the malformed literal must stay part of the
+        // single ERROR token, not split it.
+        let tokens = lex_tokens("0xDEAD_BEEF");
+        assert_eq!(tokens, vec![(ERROR, "0xDEAD_BEEF")]);
+    }
+
+    #[test]
+    fn based_literal_unaffected_by_c_style_guard() {
+        // The AADL-native form must still lex as a single INTEGER_LIT.
+        let tokens = lex_tokens("16#40003000#");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "16#40003000#")]);
+    }
+
+    #[test]
+    fn zero_with_unit_not_c_style() {
+        // `0 ns` (whitespace-separated unit) is a valid integer-with-unit and
+        // must keep lexing as INTEGER_LIT + IDENT — the guard only fires on a
+        // glued C-style radix marker followed by a valid digit of that radix.
+        let tokens = lex_tokens("0 ns");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "0"), (IDENT, "ns")]);
+    }
+
+    #[test]
+    fn glued_non_radix_ident_not_c_style() {
+        // `0bar`: `b` is a radix marker but `a` is not a binary digit, so this
+        // is NOT a C-style literal — it stays `0` + `bar` (as before).
+        let tokens = lex_tokens("0bar");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "0"), (IDENT, "bar")]);
+    }
+
+    #[test]
+    fn bare_zero_x_without_hex_digit_not_c_style() {
+        // `0x` with no following hex digit is not a C-style literal (no digits
+        // are silently dropped); it stays `0` + `x`.
+        let tokens = lex_tokens("0x");
+        assert_eq!(tokens, vec![(INTEGER_LIT, "0"), (IDENT, "x")]);
     }
 
     // -- Real literals --

--- a/crates/spar-syntax/tests/parser_tests.rs
+++ b/crates/spar-syntax/tests/parser_tests.rs
@@ -1718,3 +1718,47 @@ end Regression;
     check_no_errors(input);
     check_lossless(input);
 }
+
+// ── #337: C-style radix literals are rejected with a diagnostic ──────────
+
+/// A `0x…`-style hex literal in a property value must produce a parse
+/// diagnostic, not silently parse to integer 0 with the dropped hex digits
+/// misread as a unit. This is the exact regression from issue #337.
+#[test]
+fn c_style_hex_literal_in_property_reports_error() {
+    let input = "package M
+public
+  device Dev
+    properties
+      Base => 0x40003000;
+  end Dev;
+end M;
+";
+    let result = parse(input);
+    assert!(
+        !result.errors().is_empty(),
+        "expected a diagnostic for the C-style hex literal 0x40003000, got none"
+    );
+    // The malformed literal is surfaced as an ERROR token in the tree.
+    let root = result.syntax_node();
+    assert!(
+        root.descendants_with_tokens()
+            .filter_map(|e| e.into_token())
+            .any(|t| t.kind() == SyntaxKind::ERROR && t.text() == "0x40003000"),
+        "expected the whole `0x40003000` to be a single ERROR token"
+    );
+}
+
+/// The AADL-native based form must still parse cleanly (positive control).
+#[test]
+fn based_hex_literal_in_property_parses_clean() {
+    let input = "package M
+public
+  device Dev
+    properties
+      Base => 16#40003000#;
+  end Dev;
+end M;
+";
+    check_no_errors(input);
+}


### PR DESCRIPTION
## Summary

Closes #337. A `0x…`-style C-style hex integer literal in a property association **silently parsed to `0`** with no diagnostic. The lexer split `0x40003000` into INTEGER_LIT `0` + IDENT `x40003000`, and `property_expression_primary` then treated the trailing identifier as a **unit**, lowering the property to `Integer(0, unit="x40003000")`. A downstream consumer of `items --format json` reading `typed_value.Integer[0]` got a plausible-looking wrong value (`0`) with no signal.

## Decision: reject, don't extend the dialect

The issue offered two resolutions — accept `0x…` as hex, **or** emit a diagnostic — and stated *"a hard error is strictly better than silent 0."* C-style radix prefixes are **not** valid AADL v2.3 numeric literals; AADL uses based notation `base#digits#` (e.g. `16#40003000#`). Accepting `0x…` would introduce a spar-specific dialect divergence (cf. the interop/anti-dialect-drift concern in #246), and OSATE/Ocarina would reject it. So spar now **rejects** it, spec-faithfully. (`0x…` already appears in the tree only as opaque *string* content — e.g. the TSN `Gate_Control_List` GCL — which this change leaves untouched.)

## Fix

- **`crates/spar-parser/src/lexer.rs`** — `scan_number` recognizes a *lone* leading `0` glued to a radix marker (`x`/`X`, `b`/`B`, `o`/`O`) followed by a valid digit of that radix, and lexes the whole malformed run as one `ERROR` token (new `is_radix_digit` helper).
- **`crates/spar-parser/src/grammar/properties.rs`** — a new `ERROR` arm in `property_expression_primary` attaches a targeted diagnostic on that token and recovers to the `;` (new `is_c_style_radix_literal` helper).

Observable behavior: `spar parse` now reports `…:5:18: C-style radix literal is not valid AADL; use based notation, e.g. `16#…#` for hexadecimal` and **exits non-zero**; `spar items` no longer emits a deceptive `Integer[0]`.

## Oracles (all executed; production guard confirmed red-flips the parser/lowering/lexer tests)

- **Lexer** — `0x40003000`, `0X1F`, `0b1010`, `0o17`, `0xDEAD_BEEF` each lex as a single `ERROR` token (before the fix they split into `0` + IDENT). Negative controls: `0 ns` → `0`+`ns`, `0bar` → `0`+`bar`, `0x` (no hex digit) → `0`+`x`, `16#40003000#` → one INTEGER_LIT.
- **Lowering (end-to-end)** — `=> 0x40003000;` no longer lowers to `Integer(0, Some(unit))`; positive control `=> 16#40003000#;` lowers to `Integer(1073754112, None)`.
- **Parser** — the same input produces a diagnostic and a `0x40003000` `ERROR` token in the tree; `16#40003000#` parses clean.

## Verification

- `cargo test -p spar-parser -p spar-syntax -p spar-hir-def` — green (parser 77, syntax 291, hir-def 472); the 5 lexer + lowering + parser oracles confirmed red before the fix.
- `cargo fmt --check` clean; `cargo clippy -p spar-parser -p spar-hir-def -p spar-syntax --all-targets -- -D warnings` clean.
- `rivet validate` — PASS, 0 broken cross-refs, REQ-PARSER-003 present with resolving `traces-to`.
- Independent clean-room verification performed a true red-flip (production guard removed → exact bug `Integer(0, Some(Name("x40003000")))` reproduced), re-derived `0x40003000 = 1073754112`, swept 23 false-positive candidates (none), and confirmed the TSN hex-in-string GCL test stays green.

## Scope / honesty

Fixes the token-split silent-zero path (the reported bug) for hex **and** the same-class `0b`/`0o` prefixes. It does **not** make `spar items` itself exit non-zero on the malformed input — that command remains a best-effort structural dump; the hard error surfaces via `spar parse`/`analyze`. The unrelated silent-hex-in-property discussion is fully addressed by rejection here.

## Requirements

Adds `REQ-PARSER-003` (traces-to `REQ-PARSER-001`), release `v0.32.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017WmWbvQmVdkittfzMezpLj)_