### PR TITLE
feat(codegen): emit typed WIT list from Array data types (#345)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3055,6 +3055,58 @@ artifacts:
       - type: traces-to
         target: REQ-CODEGEN-WIT-STATE-001
 
+  - id: REQ-CODEGEN-WIT-ARRAY-001
+    type: requirement
+    title: "Structured WIT list from a Data Modeling Annex Array data type"
+    description: >
+      Codegen WIT emission shall map an AADL `data` type whose Data Modeling Annex
+      `Data_Representation` is `Array` to a typed WIT `list`, closing the #345 gap
+      where EVERY array data type degraded to the opaque `type x = list<u8>` blob
+      (element type, signedness/float, and dimension all dropped), so an inter-core
+      contract could only say `list`, not the real payload. Delivered and
+      oracle-verified:
+      (1) `resolve_data_shape` gains a `DataShape::Array { element, len }` arm
+      (spar-hir-def): a `data` type with `Data_Representation => Array` resolves its
+      `Base_Type` classifier to the element shape (recursively, reusing the same
+      scalar/record resolution as records) and reads the first `Dimension` value as
+      the length. Both the maintainer's list-wrapped property syntax
+      (`Base_Type => (classifier(Pkg::T))`, `Dimension => (16)`) and the bare forms
+      are accepted (typed_value: `List([ClassifierValue])`/`ClassifierValue`,
+      `List([Integer])`/`Integer`).
+      (2) A FIXED `Dimension` emits a BOUNDED fixed-size WIT `list<T, N>` — no
+      `cabi_realloc`, consistent with the RECORDS-002 no_alloc discipline (only
+      unbounded `list`/`string` force dynamic allocation); an array with NO
+      `Dimension` emits an unbounded `list<T>`; an `Array` with NO resolvable
+      `Base_Type` is NOT fabricated — it keeps the legacy opaque `list<u8>`.
+      (3) The element resolves through the shared `shape_wit_type` helper, so an
+      array-of-record and an array-typed record FIELD both work; the generated Rust
+      port type mirrors wit-bindgen's lowering (`list<T, N>` -> `[T; N]`,
+      `list<T>` -> `Vec<T>`).
+      ORACLE (executed unit tests, spar-codegen/src/wit_gen.rs): the #345 NavState
+      case (`Data_Representation => Array` + `Base_Type => (classifier(Float32))` +
+      `Dimension => (16)`) generates `type vehicle-state = list<f32, 16>;`; an
+      unbounded array -> `list<f32>`; a Base_Type-less array -> `list<u8>`
+      (negative control); an array-typed record field -> `nav: list<f32, 16>`. Each
+      asserts the emitted WIT PARSES + RESOLVES under `wit_parser` (a real
+      fixed-size-list bind, not a string match).
+      SCOPE / NOT CLAIMED: element bit-width comes from the `Base_Type`'s own
+      `Data_Size`; when the `Base_Type` resolves to an element with no concrete
+      shape (an unsized `Base_Types::Float` with no `Data_Size`, or an
+      unresolvable classifier) `array_of` returns `None`, so the array type is
+      NOT fabricated — a top-level array port GRACEFULLY falls back to the legacy
+      opaque `type x = list<u8>` (no regression, no hard error), and an
+      array-typed record FIELD takes the record no_alloc hard-error path (as an
+      opaque field would). Multi-dimensional arrays use only the first
+      `Dimension`. `list<T>`/`list<T, N>` byte-layout-vs-canonical-ABI
+      equivalence is NOT proven here (that is #327's ordeal work), and the Rust
+      port type (`[T; N]`/`Vec<T>`) mirrors wit-bindgen's documented lowering but
+      no compiled-crate oracle for array ports is asserted in this requirement.
+    status: implemented
+    tags: [codegen, wit, interop, no-alloc]
+    links:
+      - type: traces-to
+        target: REQ-CODEGEN-WIT-RECORDS-001
+
   - id: REQ-CODEGEN-VERIFY-WORKSPACE-001
     type: requirement
     title: "spar codegen --verify test/build emits inert artifacts"

--- a/crates/spar-codegen/src/rust_gen.rs
+++ b/crates/spar-codegen/src/rust_gen.rs
@@ -52,6 +52,16 @@ fn data_shape_to_rust_type(shape: &DataShape) -> String {
         DataShape::Record { type_name, .. } => {
             format!("crate::types::{}", to_pascal_case(type_name))
         }
+        // wit-bindgen lowers a fixed-size `list<T, N>` to a Rust `[T; N]` and an
+        // unbounded `list<T>` to `Vec<T>`; mirror that so the port field type
+        // matches the ABI lowering. REQ-CODEGEN-WIT-ARRAY-001 (#345).
+        DataShape::Array { element, len } => {
+            let elem = data_shape_to_rust_type(element);
+            match len {
+                Some(n) => format!("[{elem}; {n}]"),
+                None => format!("Vec<{elem}>"),
+            }
+        }
         DataShape::Opaque => "Vec<u8>".to_string(),
     }
 }
@@ -833,11 +843,17 @@ fn flatten_record_rust(
     }
     let mut rows = Vec::with_capacity(fields.len());
     for f in fields {
-        // Recurse into nested records first so they are defined before use.
+        // Recurse into nested records first so they are defined before use —
+        // including a record reached through array element(s) (#345), so an
+        // `array of record` field does not reference an undefined struct.
+        let mut inner = &f.shape;
+        while let DataShape::Array { element, .. } = inner {
+            inner = element;
+        }
         if let DataShape::Record {
             type_name: nt,
             fields: nf,
-        } = &f.shape
+        } = inner
         {
             flatten_record_rust(nt, nf, out, seen);
         }

--- a/crates/spar-codegen/src/rust_gen.rs
+++ b/crates/spar-codegen/src/rust_gen.rs
@@ -935,4 +935,89 @@ mod tests {
             "Vec<u8>"
         );
     }
+
+    /// REQ-CODEGEN-WIT-ARRAY-001 (#345): an `Array` shape mirrors wit-bindgen's
+    /// lowering — a fixed `Dimension` → a Rust fixed array `[T; N]`, an unbounded
+    /// array → `Vec<T>`, recursively over the element (scalar, record, or a
+    /// nested array).
+    #[test]
+    fn array_shape_maps_to_rust_types() {
+        let f32_scalar = || DataShape::Scalar {
+            bytes: 4,
+            kind: ScalarKind::Float,
+        };
+        // Fixed 16 × f32 (the #345 NavState case) → `[f32; 16]`.
+        assert_eq!(
+            data_shape_to_rust_type(&DataShape::Array {
+                element: Box::new(f32_scalar()),
+                len: Some(16)
+            }),
+            "[f32; 16]"
+        );
+        // Unbounded (no Dimension) → `Vec<f32>`.
+        assert_eq!(
+            data_shape_to_rust_type(&DataShape::Array {
+                element: Box::new(f32_scalar()),
+                len: None
+            }),
+            "Vec<f32>"
+        );
+        // Array of a record → `[crate::types::Nav; 4]`.
+        assert_eq!(
+            data_shape_to_rust_type(&DataShape::Array {
+                element: Box::new(DataShape::Record {
+                    type_name: "Nav".to_string(),
+                    fields: vec![]
+                }),
+                len: Some(4)
+            }),
+            "[crate::types::Nav; 4]"
+        );
+        // Nested array (array of arrays) recurses on both levels.
+        assert_eq!(
+            data_shape_to_rust_type(&DataShape::Array {
+                element: Box::new(DataShape::Array {
+                    element: Box::new(f32_scalar()),
+                    len: Some(3)
+                }),
+                len: Some(2)
+            }),
+            "[[f32; 3]; 2]"
+        );
+    }
+
+    /// REQ-CODEGEN-WIT-ARRAY-001 (#345): a record FIELD whose type is an array
+    /// of a nested record still emits the nested record's struct (the array
+    /// recursion in `flatten_record_rust`), so `crate::types::Inner` resolves.
+    #[test]
+    fn record_field_of_array_of_record_defines_the_inner_struct() {
+        let inner = DataField {
+            name: spar_hir_def::name::Name::new("hi"),
+            shape: DataShape::Scalar {
+                bytes: 2,
+                kind: ScalarKind::Unsigned,
+            },
+        };
+        let outer_fields = vec![DataField {
+            name: spar_hir_def::name::Name::new("items"),
+            shape: DataShape::Array {
+                element: Box::new(DataShape::Record {
+                    type_name: "Inner".to_string(),
+                    fields: vec![inner],
+                }),
+                len: Some(8),
+            },
+        }];
+        let mut structs = Vec::new();
+        let mut seen = std::collections::BTreeSet::new();
+        flatten_record_rust("Outer", &outer_fields, &mut structs, &mut seen);
+
+        // Both the outer and the array-nested inner struct are emitted, inner-first.
+        let names: Vec<&str> = structs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["Inner", "Outer"], "structs: {names:?}");
+        // The outer field references the array-of-record type.
+        let outer = &structs.iter().find(|(n, _)| n == "Outer").unwrap().1;
+        assert_eq!(outer[0].0, "items");
+        assert_eq!(outer[0].1, "[crate::types::Inner; 8]");
+    }
 }

--- a/crates/spar-codegen/src/wit_gen.rs
+++ b/crates/spar-codegen/src/wit_gen.rs
@@ -49,6 +49,49 @@ fn scalar_wit(bytes: u64, kind: ScalarKind) -> Option<&'static str> {
 /// One emitted WIT record definition: `(wit-type-name, [(field, wit-type)])`.
 type RecordDef = (String, Vec<(String, String)>);
 
+/// Resolve a [`DataShape`] to the WIT type string used to reference it (a scalar
+/// keyword, a nested record name, or a `list<T[, N]>`), emitting any nested
+/// record definitions into `out` along the way. A non-encodable scalar/opaque
+/// leaf is collected into `errors` (the no_alloc hard-error policy) and a `u8`
+/// placeholder returned — the caller aborts on any error before emitting.
+/// REQ-CODEGEN-WIT-ARRAY-001 (#345) extends this to array elements.
+fn shape_wit_type(
+    shape: &DataShape,
+    out: &mut Vec<RecordDef>,
+    seen: &mut std::collections::BTreeSet<String>,
+    errors: &mut Vec<String>,
+) -> String {
+    match shape {
+        DataShape::Scalar { bytes, kind } => match scalar_wit(*bytes, *kind) {
+            Some(w) => w.to_string(),
+            None => {
+                errors.push(format!(
+                    "{bytes}-byte {kind:?} has no no_alloc WIT scalar (int 1/2/4/8, float 4/8 only)"
+                ));
+                "u8".to_string()
+            }
+        },
+        DataShape::Record { type_name, fields } => {
+            flatten_record(type_name, fields, out, seen, errors)
+        }
+        DataShape::Array { element, len } => {
+            let elem = shape_wit_type(element, out, seen, errors);
+            match len {
+                Some(n) => format!("list<{elem}, {n}>"),
+                None => format!("list<{elem}>"),
+            }
+        }
+        DataShape::Opaque => {
+            errors.push(
+                "array element type declares no Data_Size and has no fields — it cannot be \
+                 encoded without heap allocation"
+                    .to_string(),
+            );
+            "u8".to_string()
+        }
+    }
+}
+
 /// Recursively flatten a `Record` shape into WIT record definitions, appending
 /// each distinct record to `out` in NESTED-FIRST order (a record is pushed after
 /// the records it depends on) and returning the top record's WIT type name.
@@ -84,6 +127,10 @@ fn flatten_record(
             } => {
                 let nested = flatten_record(nested_tn, nested_fields, out, seen, errors);
                 rows.push((wit_ident(field), nested));
+            }
+            DataShape::Array { .. } => {
+                let wit_ty = shape_wit_type(&f.shape, out, seen, errors);
+                rows.push((wit_ident(field), wit_ty));
             }
             DataShape::Opaque => errors.push(format!(
                 "record `{type_name}` field `{field}`: type declares no Data_Size and has no \
@@ -168,6 +215,13 @@ pub fn generate_wit(
             DataShape::Scalar { bytes, kind } => {
                 let wit_ty = scalar_wit(bytes, kind).unwrap_or(DEFAULT_WIT_TYPE);
                 aliases.push((ty.clone(), wit_ty.to_string()));
+            }
+            // An Array data type aliases to a `list<T[, N]>` (fixed-size when the
+            // Dimension is known — bounded, no `cabi_realloc`). Any nested record
+            // element is emitted into `record_defs` first. #345.
+            shape @ DataShape::Array { .. } => {
+                let wit_ty = shape_wit_type(&shape, &mut record_defs, &mut seen, &mut errors);
+                aliases.push((ty.clone(), wit_ty));
             }
             DataShape::Opaque => aliases.push((ty.clone(), DEFAULT_WIT_TYPE.to_string())),
         }
@@ -1004,6 +1058,274 @@ end NestPkg;
             .unwrap_or_else(|e| {
                 panic!(
                     "nested-record WIT failed to parse: {e}\n---\n{}",
+                    file.content
+                )
+            });
+    }
+
+    /// Fixture for REQ-CODEGEN-WIT-ARRAY-001 (#345): a Data Modeling Annex
+    /// `Array` data type — `Data_Representation => Array`, a `Base_Type`
+    /// classifier, and a fixed `Dimension` — the real jess NavState case
+    /// (16 × f32). Also declares an UNBOUNDED array (no `Dimension`), an
+    /// array with the maintainer's exact `(classifier(...))` / `(16)`
+    /// list-wrapped property syntax, and a NEGATIVE control (Array with no
+    /// `Base_Type`, which must stay opaque). Referenced by process ports.
+    fn build_array_test_instance() -> (GlobalScope, SystemInstance) {
+        let aadl = r#"
+package ArrPkg
+public
+    data Float32
+        properties
+            Data_Size => 4 Bytes;
+            Data_Representation => Float;
+    end Float32;
+
+    -- Fixed 16 x f32 (the #345 NavState message). Maintainer's exact
+    -- list-wrapped Base_Type / Dimension syntax.
+    data VehicleState
+        properties
+            Data_Representation => Array;
+            Base_Type => (classifier(Float32));
+            Dimension => (16);
+    end VehicleState;
+
+    -- Unbounded array (no Dimension) -> list<f32>.
+    data Samples
+        properties
+            Data_Representation => Array;
+            Base_Type => (classifier(Float32));
+    end Samples;
+
+    -- Array with no Base_Type -> must stay opaque (list<u8>), not fabricated.
+    data Mystery
+        properties
+            Data_Representation => Array;
+            Dimension => (8);
+    end Mystery;
+
+    -- Element with NO Data_Size (an unsized Float, like the standard
+    -- Base_Types::Float): the element does not resolve to a concrete WIT
+    -- type, so the array must NOT be fabricated -> stays opaque list<u8>.
+    data UnsizedF
+        properties
+            Data_Representation => Float;
+    end UnsizedF;
+
+    data Blurry
+        properties
+            Data_Representation => Array;
+            Base_Type => (classifier(UnsizedF));
+            Dimension => (4);
+    end Blurry;
+
+    process Estimator
+        features
+            state_out: out data port VehicleState;
+            samples_out: out data port Samples;
+            mystery_out: out data port Mystery;
+            blurry_out: out data port Blurry;
+    end Estimator;
+
+    process implementation Estimator.Impl
+        subcomponents
+            est_thread: thread EstThread.Impl;
+    end Estimator.Impl;
+
+    thread EstThread
+    end EstThread;
+
+    thread implementation EstThread.Impl
+    end EstThread.Impl;
+
+    system Top
+    end Top;
+
+    system implementation Top.Impl
+        subcomponents
+            est: process Estimator.Impl;
+    end Top.Impl;
+end ArrPkg;
+"#;
+        let db = spar_hir_def::HirDefDatabase::default();
+        let sf = spar_base_db::SourceFile::new(&db, "arr.aadl".to_string(), aadl.to_string());
+        let tree = spar_hir_def::file_item_tree(&db, sf);
+        let scope = GlobalScope::from_trees(vec![tree]);
+        let inst = SystemInstance::instantiate(
+            &scope,
+            &Name::new("ArrPkg"),
+            &Name::new("Top"),
+            &Name::new("Impl"),
+        );
+        (scope, inst)
+    }
+
+    /// RED-before-green oracle for REQ-CODEGEN-WIT-ARRAY-001 (#345): an AADL
+    /// `data` type with `Data_Representation => Array` + `Base_Type` + a fixed
+    /// `Dimension` must generate a bounded WIT `list<T, N>` (no `cabi_realloc`),
+    /// NOT the opaque `list<u8>` blob. An unbounded array (no `Dimension`) is a
+    /// plain `list<T>`, and an Array with no `Base_Type` stays opaque.
+    #[test]
+    fn array_data_type_becomes_wit_list() {
+        let (scope, inst) = build_array_test_instance();
+        let idx = inst
+            .all_components()
+            .find(|(_, c)| c.category == ComponentCategory::Process)
+            .map(|(idx, _)| idx)
+            .expect("test model has a process");
+        let file = generate_wit(&inst, &scope, idx).expect("wit generation should succeed");
+        let body: String = file
+            .content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Fixed Dimension -> bounded fixed-size list of the element scalar.
+        assert!(
+            body.contains("type vehicle-state = list<f32, 16>;"),
+            "fixed Array must map to `list<f32, 16>`, not opaque:\n{body}"
+        );
+        // Unbounded array -> plain list<f32>.
+        assert!(
+            body.contains("type samples = list<f32>;"),
+            "unbounded Array must map to `list<f32>`:\n{body}"
+        );
+        // No Base_Type -> the element is unknown, so it must NOT be fabricated;
+        // it stays the legacy opaque byte buffer.
+        assert!(
+            body.contains("type mystery = list<u8>;"),
+            "Array with no Base_Type must stay opaque `list<u8>`:\n{body}"
+        );
+        // Unsized element (Float with no Data_Size, like standard
+        // Base_Types::Float) -> element does not resolve, so the array must NOT
+        // be fabricated; it stays opaque `list<u8>` (no regression, no error).
+        assert!(
+            body.contains("type blurry = list<u8>;"),
+            "Array with an unsized element must stay opaque `list<u8>`:\n{body}"
+        );
+
+        // Authoritative: the fixed-size list must PARSE + RESOLVE under
+        // wit-parser (proves `list<f32, 16>` is real, bindable WIT).
+        let mut resolve = wit_parser::Resolve::new();
+        resolve
+            .push_str("array.wit", &file.content)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "generated array WIT failed to parse/resolve: {e}\n---\n{}",
+                    file.content
+                )
+            });
+    }
+
+    /// Fixture: a `data implementation` record whose field is itself an Array
+    /// data type (`nav: VehicleState` where VehicleState is 16 x f32).
+    fn build_record_with_array_field_instance() -> (GlobalScope, SystemInstance) {
+        let aadl = r#"
+package RecArrPkg
+public
+    data Float32
+        properties
+            Data_Size => 4 Bytes;
+            Data_Representation => Float;
+    end Float32;
+
+    data Word32
+        properties
+            Data_Size => 4 Bytes;
+    end Word32;
+
+    data VehicleState
+        properties
+            Data_Representation => Array;
+            Base_Type => (classifier(Float32));
+            Dimension => (16);
+    end VehicleState;
+
+    data Frame
+    end Frame;
+
+    data implementation Frame.Impl
+        subcomponents
+            seq: data Word32;
+            nav: data VehicleState;
+    end Frame.Impl;
+
+    process Store
+        features
+            frame_in: in data port Frame.Impl;
+    end Store;
+
+    process implementation Store.Impl
+        subcomponents
+            th: thread StoreThread.Impl;
+    end Store.Impl;
+
+    thread StoreThread
+    end SinkThread;
+
+    thread implementation StoreThread.Impl
+    end StoreThread.Impl;
+
+    system Top
+    end Top;
+
+    system implementation Top.Impl
+        subcomponents
+            store: process Store.Impl;
+    end Top.Impl;
+end RecArrPkg;
+"#;
+        let db = spar_hir_def::HirDefDatabase::default();
+        let sf = spar_base_db::SourceFile::new(&db, "recarr.aadl".to_string(), aadl.to_string());
+        let tree = spar_hir_def::file_item_tree(&db, sf);
+        let scope = GlobalScope::from_trees(vec![tree]);
+        let inst = SystemInstance::instantiate(
+            &scope,
+            &Name::new("RecArrPkg"),
+            &Name::new("Top"),
+            &Name::new("Impl"),
+        );
+        (scope, inst)
+    }
+
+    /// Oracle for an Array-typed record FIELD (#345): a record subcomponent whose
+    /// type is an Array data type becomes a `field: list<T, N>` inside the WIT
+    /// record — the element resolves recursively through `shape_wit_type`.
+    #[test]
+    fn record_field_of_array_type_becomes_list() {
+        let (scope, inst) = build_record_with_array_field_instance();
+        let idx = inst
+            .all_components()
+            .find(|(_, c)| c.category == ComponentCategory::Process)
+            .map(|(idx, _)| idx)
+            .expect("test model has a process");
+        let file = generate_wit(&inst, &scope, idx).expect("wit generation should succeed");
+        let body: String = file
+            .content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            body.contains("record frame-impl {"),
+            "expected record `frame-impl`:\n{body}"
+        );
+        assert!(
+            body.contains("seq: u32"),
+            "expected scalar field `seq: u32`:\n{body}"
+        );
+        assert!(
+            body.contains("nav: list<f32, 16>"),
+            "Array-typed record field must be `list<f32, 16>`:\n{body}"
+        );
+
+        let mut resolve = wit_parser::Resolve::new();
+        resolve
+            .push_str("recarr.wit", &file.content)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "record-with-array WIT failed to parse/resolve: {e}\n---\n{}",
                     file.content
                 )
             });

--- a/crates/spar-hir-def/src/resolver.rs
+++ b/crates/spar-hir-def/src/resolver.rs
@@ -45,6 +45,15 @@ pub enum DataShape {
         type_name: String,
         fields: Vec<DataField>,
     },
+    /// A `data` classifier whose Data Modeling Annex `Data_Representation` is
+    /// `Array`: a homogeneous sequence of `element`, with `len` copies when the
+    /// `Dimension` property fixes the size (→ a bounded WIT `list<T, N>`) or
+    /// `None` for an unbounded array (→ `list<T>`). REQ-CODEGEN-WIT-ARRAY-001
+    /// (GitHub #345).
+    Array {
+        element: Box<DataShape>,
+        len: Option<u64>,
+    },
     /// A `data` classifier with neither a `Data_Size` nor subcomponents, or one
     /// that does not resolve — opaque (codegen keeps its legacy handling).
     Opaque,
@@ -400,7 +409,98 @@ impl GlobalScope {
         if let Some((bytes, kind)) = self.scalar_of(from_package, classifier) {
             return DataShape::Scalar { bytes, kind };
         }
+        // A data type declaring an Array Data_Representation = a WIT list of its
+        // Base_Type element (fixed-size when Dimension is set).
+        if let Some(array) = self.array_of(from_package, classifier) {
+            return array;
+        }
         DataShape::Opaque
+    }
+
+    /// Resolve a `data` type whose Data Modeling Annex `Data_Representation` is
+    /// `Array` into a [`DataShape::Array`]: the element shape comes from the
+    /// `Base_Type` classifier (resolved recursively) and the length from the
+    /// first `Dimension` value (absent → unbounded). Returns `None` when the
+    /// classifier is not an `Array` `data` type or has no resolvable
+    /// `Base_Type`. REQ-CODEGEN-WIT-ARRAY-001 (GitHub #345).
+    fn array_of(&self, from_package: &Name, classifier: &ClassifierRef) -> Option<DataShape> {
+        use crate::item_tree::PropertyExpr;
+        let resolved = self.resolve_classifier(from_package, classifier);
+        let (loc, decl_package) = match &resolved {
+            ResolvedClassifier::ComponentType { loc, package } => (*loc, package.clone()),
+            _ => return None,
+        };
+        let ct = self.get_component_type(loc)?;
+        if ct.category != crate::item_tree::ComponentCategory::Data {
+            return None;
+        }
+        let tree = self.tree(loc.tree)?;
+        // Last path segment of an enum literal, so a qualified value like
+        // `Data_Model::Array` still matches `Array`.
+        fn leaf(v: &str) -> &str {
+            v.rsplit("::").next().unwrap_or(v).trim()
+        }
+        // A `Base_Type => (classifier(Pkg::T))` value lowers to a `List` holding
+        // one `ClassifierValue`; a bare `classifier(Pkg::T)` lowers to the
+        // `ClassifierValue` directly. Accept both shapes.
+        fn first_classifier(expr: &PropertyExpr) -> Option<&ClassifierRef> {
+            match expr {
+                PropertyExpr::ClassifierValue(cr) => Some(cr),
+                PropertyExpr::List(items) => items.iter().find_map(first_classifier),
+                _ => None,
+            }
+        }
+        // A `Dimension => (16)` value lowers to a `List` holding one `Integer`;
+        // a bare `16` lowers to the `Integer` directly.
+        fn first_int(expr: &PropertyExpr) -> Option<i64> {
+            match expr {
+                PropertyExpr::Integer(n, _) => Some(*n),
+                PropertyExpr::List(items) => items.iter().find_map(first_int),
+                _ => None,
+            }
+        }
+        let mut is_array = false;
+        let mut base_type: Option<ClassifierRef> = None;
+        let mut dim: Option<u64> = None;
+        for &pa_idx in &ct.property_associations {
+            let pa = &tree.property_associations[pa_idx];
+            let pn = pa.name.property_name.as_str();
+            if pn.eq_ignore_ascii_case("Data_Representation") {
+                is_array = match &pa.typed_value {
+                    Some(PropertyExpr::Enum(n)) => n.as_str().eq_ignore_ascii_case("Array"),
+                    _ => leaf(&pa.value).eq_ignore_ascii_case("Array"),
+                };
+            } else if pn.eq_ignore_ascii_case("Base_Type") {
+                base_type = pa.typed_value.as_ref().and_then(first_classifier).cloned();
+            } else if pn.eq_ignore_ascii_case("Dimension") {
+                dim = pa
+                    .typed_value
+                    .as_ref()
+                    .and_then(first_int)
+                    .filter(|&n| n >= 0)
+                    .map(|n| n as u64);
+            }
+        }
+        if !is_array {
+            return None;
+        }
+        // Without a Base_Type the element is unknown — leave it Opaque so codegen
+        // keeps its legacy handling rather than fabricating an element type.
+        let base = base_type?;
+        let element = self.resolve_data_shape(&decl_package, &base);
+        // If the element itself does not resolve to a concrete shape (an unsized
+        // or unresolvable Base_Type — e.g. a `Base_Types::Float` with no
+        // `Data_Size`), do NOT fabricate a typed list. Fall back to Opaque so a
+        // top-level array port keeps its legacy `list<u8>` (no regression) and an
+        // array-typed record field hits the record no_alloc hard-error path,
+        // rather than emitting a `list<u8-of-unknown-element>`.
+        if matches!(element, DataShape::Opaque) {
+            return None;
+        }
+        Some(DataShape::Array {
+            element: Box::new(element),
+            len: dim,
+        })
     }
 
     /// Resolve a `data` classifier's declared `Data_Size`, in bytes. Mirrors the


### PR DESCRIPTION
## Summary

Closes the #345 gap: `spar codegen --format wit` mapped **every** AADL `data` type with `Data_Representation => Array` to an opaque `type x = list<u8>`, dropping the element type and dimension — so an inter-core WIT contract could only say `list`, not the real payload (the jess NavState `16 × f32`).

This teaches codegen to emit a **typed** WIT list from a Data Modeling Annex `Array` data type.

## What changed

- **`spar-hir-def` (`resolver.rs`)** — new `DataShape::Array { element, len }`. `resolve_data_shape` recognizes `Data_Representation => Array`, resolves the `Base_Type` classifier to the element shape (recursively, reusing the existing scalar/record resolution), and reads the first `Dimension` as the length. Both the maintainer's list-wrapped property syntax (`Base_Type => (classifier(Pkg::T))`, `Dimension => (16)`) and the bare forms are accepted.
- **`spar-codegen` (`wit_gen.rs`)** — a fixed `Dimension` emits a **bounded** fixed-size `list<T, N>` (no `cabi_realloc`, consistent with the RECORDS‑002 no_alloc discipline where only unbounded `list`/`string` force dynamic allocation); no `Dimension` emits `list<T>`. The element resolves through a shared `shape_wit_type` helper, so an array-of-record and an array-typed record **field** both work.
- **`spar-codegen` (`rust_gen.rs`)** — the Rust port type mirrors wit-bindgen's lowering: `list<T, N>` → `[T; N]`, `list<T>` → `Vec<T>`.

## Honest scoping / no regression

An `Array` whose `Base_Type` is absent **or** resolves to an unsized/unresolvable element (e.g. the standard `Base_Types::Float`, which carries no `Data_Size`) is **not fabricated**: `array_of` returns `None`, so a top-level array port **gracefully keeps the legacy `list<u8>`** (no regression, no hard error), and an array-typed record field takes the record no_alloc hard-error path — exactly as an opaque field would.

Not claimed here: `list` byte-layout ↔ canonical-ABI equivalence (that's #327's ordeal work); multi-dimensional arrays use only the first `Dimension`; no compiled-crate oracle for array *ports* on the Rust side.

## Oracles (executed unit tests, `spar-codegen/src/wit_gen.rs`)

- #345 NavState → `type vehicle-state = list<f32, 16>;`
- unbounded array → `type samples = list<f32>;`
- no `Base_Type` → `type mystery = list<u8>;` (negative control)
- unsized element → `type blurry = list<u8>;` (graceful fallback, no error)
- array-typed record field → `nav: list<f32, 16>`

Each asserts the emitted WIT **parses + resolves** under `wit_parser` (a real fixed-size-list bind, not a string match).

`cargo test -p spar-codegen --lib` → 56 passed. `cargo test -p spar-hir-def --lib` → 471 passed. `cargo fmt --check` clean; `cargo clippy` on both crates clean. An independent clean-room agent re-derived each claim against its own fixtures.

Tracked as **REQ-CODEGEN-WIT-ARRAY-001**.

Note: case (b) of #345 (a `data implementation` with subcomponents) already works today when the port references the **implementation** classifier (`VehicleState.nav`) rather than the bare `data` type — details in the issue reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016yT1pAR89FsY6zRpC48Bzj)_