### PR TITLE
chore(release): bump to v0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3101,8 +3101,9 @@ artifacts:
       equivalence is NOT proven here (that is #327's ordeal work), and the Rust
       port type (`[T; N]`/`Vec<T>`) mirrors wit-bindgen's documented lowering but
       no compiled-crate oracle for array ports is asserted in this requirement.
-    status: implemented
+    status: verified
     tags: [codegen, wit, interop, no-alloc]
+    release: v0.33.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-RECORDS-001

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release the typed WIT list from Array data types (#345, feature merged in #346).

## Changes
- `[workspace.package]` version `0.32.0` → `0.33.0` (`Cargo.toml` + `Cargo.lock`)
- `vscode-spar` extension version `0.32.0` → `0.33.0`
- Promote **REQ-CODEGEN-WIT-ARRAY-001** to `status: verified`, `release: v0.33.0`

## What shipped in v0.33.0
An AADL `data` type with `Data_Representation => Array` now emits a **typed** WIT list from `spar codegen --format wit` instead of the opaque `list<u8>`: a fixed `Dimension` → bounded `list<T, N>`, unbounded → `list<T>`, element resolved from `Base_Type` (recursively). No-`Base_Type` / unsized-element arrays stay opaque (no regression). Oracle-verified against `wit-parser`.

Metadata-only bump; the feature and its tests landed in #346 (all required checks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016yT1pAR89FsY6zRpC48Bzj)_