### PR TITLE
ci: make rivet-validate deterministic to fix stale-binary false-red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,12 +310,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        # Do NOT restore/save ~/.cargo/bin here. rust-cache caches installed
+        # binaries by default (cache-bin: true), which lets a `rivet` built
+        # elsewhere be restored under this job's key. `cargo install` then sees
+        # `rivet` already present and skips the pinned reinstall, so validation
+        # silently runs the wrong rivet — the source of the v0.33.0 bump's
+        # false-red (464 phantom errors vs the pinned v0.4.3's genuine PASS).
+        with:
+          cache-bin: false
       - name: Install rivet CLI
         # The binary `rivet` ships in the `rivet-cli` package (renamed
         # in the 0.4.x rework). v0.1.0 used a single `rivet` package
         # and treated unknown fields as errors, which fails on legitimate
         # schema-extension fields used by Track A/B/D/E artifacts.
-        run: cargo install --locked --git https://github.com/pulseengine/rivet --tag v0.4.3 rivet-cli
+        # `--force` guarantees this exact pinned tag is the binary that runs,
+        # even if a stale `rivet` is present, so the gate is deterministic.
+        run: cargo install --force --locked --git https://github.com/pulseengine/rivet --tag v0.4.3 rivet-cli
       - name: rivet validate
         run: rivet validate --format text
 


### PR DESCRIPTION
## Problem

`main` is red. The **`Rivet validate (artifacts)`** required check flipped to **FAIL (464 errors, 614 warnings)** on the v0.33.0 bump commit (#347, `4cd5948`). The immediately preceding commit (#346, `b39068e`) was **PASS (0 errors, 122 warnings)**, and the v0.33.0 bump changed only:

- workspace version `0.32.0 → 0.33.0` (Cargo.toml / Cargo.lock / vscode-spar), and
- promoted one requirement (`REQ-CODEGEN-WIT-ARRAY-001`) to `verified` + `release: v0.33.0`.

That content cannot produce 464 errors — it is the same promotion every prior release bump (v0.30–v0.32) made while staying green.

## Root cause — it's tooling, not the artifacts

Reproduced locally with the pinned `rivet-cli v0.4.3` (built fresh from the `v0.4.3` tag) against the exact `main` HEAD tree:

```
### CURRENT TREE (main HEAD = v0.33.0 bump 4cd5948)
Result: PASS (122 warnings)
### PRE-BUMP TREE (b39068e = #346)
Result: PASS (122 warnings)
```

Both trees **PASS** under genuine v0.4.3. The 464-error CI failure came from a **different rivet binary** than the pinned one:

- The failing job's *Install rivet CLI* step took **~1s** (vs **2m14s** to build fresh on the green run) — i.e. `cargo install` skipped the build because a `rivet` binary was already present.
- `Swatinem/rust-cache@v2` caches `~/.cargo/bin` by default (`cache-bin: true`), and these are **persistent self-hosted runners**, so a `rivet` built elsewhere (a stricter/newer build) can already be on disk under this job's cache key.
- `cargo install` without `--force` sees `rivet` installed and skips the pinned reinstall, so the gate silently validated with the wrong rivet and emitted the 464 phantom errors that are precisely the stricter "missing design-decision / version-skew" baseline the pinned v0.4.3 does not enforce.

## Fix

Make the gate deterministic so it always runs exactly the pinned `v0.4.3`:

- `cache-bin: false` on this job's `rust-cache` step — don't restore/save `~/.cargo/bin`, so no stale `rivet` is pulled in via the Actions cache.
- `--force` on `cargo install` — always (re)install the pinned tag, overriding any `rivet` already present on the persistent runner.

No artifact or code change; the check now reflects the artifacts rather than whatever `rivet` happens to be on the runner.

## Scope / follow-ups

- Focused on the required `ci.yml` `rivet-validate` job (the one that failed). `.github/workflows/verification-gate.yml` installs rivet with the same `cargo install --git … rivet` pattern and could hit the same latent skew; worth the same guard in a follow-up, but it is not the failing required check and is left untouched here to keep this minimal.
- **The v0.33.0 release is staged but not tagged.** The bump is merged on `main`; no `v0.33.0` tag exists yet. Once this fix turns the required checks green, the signed tag still needs to be cut by a maintainer with the signing key (`git tag -s v0.33.0 && git push origin v0.33.0`) — this PR only unblocks the gate.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean; job renders as expected.
- Genuine `rivet-cli v0.4.3` → `Result: PASS (122 warnings)` on `main` HEAD (shown above). The 122 warnings are the benign pre-existing `missing: design-decision` set, not errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq2srAapqgzVCW3aP4QyQ3)_