### PR TITLE
feat(codegen): emit target constants module + linker memory map (#338)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3108,6 +3108,87 @@ artifacts:
       - type: traces-to
         target: REQ-CODEGEN-WIT-RECORDS-001
 
+  - id: REQ-CODEGEN-TARGET-ARTIFACTS-001
+    type: requirement
+    title: "Emit hardware-target constants module + linker memory map from an AADL model"
+    description: >
+      Closes the memory-map slice of #338: make an analyzed *hardware* AADL model
+      the single source of truth for an embedded-target build, so downstream
+      (gale/gust) no longer re-derives structure spar already holds. Two build-time
+      artifacts, both reachable from the CLI as `spar emit --format <fmt> --root
+      Package::Type.Impl <files>` and derived purely from standard AADL
+      `Memory_Properties` on the RESOLVED instance model (type/impl inheritance and
+      `applies to` already folded in):
+      (1) `--format constants` — a Rust constants module: `pub const <NAME>_BASE`
+      (from `Base_Address`) and `<NAME>_SIZE` (from `Byte_Count`, else `Memory_Size`
+      normalized to bytes) for each `memory` component, plus `<NAME>_BASE` for each
+      memory-mapped `device` (peripheral base). Constant names are the component's
+      instance leaf name uppercased and identifier-sanitized.
+      (2) `--format linker` — a GNU-ld `MEMORY` block (the rust-embedded
+      `memory.x` shape), one region per sized `memory` component, `ORIGIN` in hex and
+      `LENGTH` in exact decimal bytes.
+      PROVEN by executed oracles (crates/spar-codegen/src/target_gen.rs unit tests +
+      crates/spar-cli/tests/emit_target.rs):
+      `constants_golden` / `linker_golden` assert byte-exact output for an
+      STM32-shaped fixture (flash via `Memory_Size => 1024 KByte`, sram via
+      `Byte_Count => 131072`, two mapped devices, one non-mapped device);
+      `constants_match_instance_model` is the #338 round-trip — every emitted
+      `*_BASE`/`*_SIZE` equals the value INDEPENDENTLY re-derived from the resolved
+      instance property map through the raw-string path (a different accessor +
+      parser than the emitter's typed `PropertyExpr`), and asserts the non-mapped
+      device emits no constant and exactly 2 memory + 2 devices are captured;
+      `non_hardware_model_errors` and the CLI `emit_constants_non_hardware_model_exits_nonzero`
+      assert that a model with no base-addressed memory/device is a HARD non-zero
+      error, never a vacuous empty artifact; `ident_sanitizes` pins the identifier
+      derivation and `collision_is_hard_error` builds two same-leaf-named memory
+      components under different parents and asserts the emitter returns an `Err`
+      rather than dropping/overwriting a constant. Base addresses use AADL based
+      notation (`16#08000000#`), consistent with the #337 radix-literal fix.
+      ASSUMED / NOT CLAIMED (honest scope): this emits ONLY base addresses and
+      sizes. Device register-detail OFFSETS, the device presence FLAG, and the WIT
+      device-driver WORLD binding (asks 1 and 3 of #338) are NOT implemented — see
+      the successor REQ-CODEGEN-TARGET-ARTIFACTS-002. Size sources are limited to
+      `Byte_Count` and `Memory_Size` (`Word_Count`×`Word_Size` is not handled).
+      Linker region names are the AADL component leaf names uppercased, NOT the
+      cortex-m-rt-conventional `FLASH`/`RAM`, so the firmware's `link.x` must
+      reference the emitted names (or the model must name the components accordingly).
+      `Base_Address` is taken verbatim (no bus/binding offset resolution). Constants
+      are typed `usize`, so a base or size ≥ 2^32 is emitted faithfully but only
+      compiles for a 64-bit-`usize` host/target. The generated module's constants are
+      valid Rust `const` items by construction (sanitized identifiers + hex integer
+      literals; sanitizer unit-tested), but a per-CI rustc-compilation oracle for the
+      generated file is NOT asserted. The existing `spar items --json` bridge remains
+      the supported downstream contract; this adds a first-class emission path over
+      the same model data.
+    status: implemented
+    tags: [codegen, target-artifacts, hardware, memory-map]
+    release: v0.34.0
+    links:
+      - type: traces-to
+        target: REQ-CODEGEN-001
+
+  - id: REQ-CODEGEN-TARGET-ARTIFACTS-002
+    type: requirement
+    title: "Emit device register offsets + a WIT device-driver world binding (successor)"
+    description: >
+      Successor to REQ-CODEGEN-TARGET-ARTIFACTS-001, covering the remaining #338
+      asks that require conventions AADL does not standardize: (1) device
+      REGISTER-DETAIL offsets and a presence FLAG in the emitted constants module —
+      needs an agreed property shape for register maps (a `Spar_*` property set or a
+      Data Modeling Annex layout) so offsets are read from the model rather than
+      guessed; (2) a WIT WORLD binding a generic device-driver import to the
+      target's device instance, so swapping the target is swapping the generated
+      binding (zero-runtime-cost retargeting). Acceptance = golden fixtures for the
+      register map + WIT world plus a round-trip that emitted offsets match the
+      model. Deferred deliberately: TARGET-ARTIFACTS-001 shipped the mechanical,
+      standard-property-backed base/size core first rather than over-claiming a
+      register/binding convention that is not yet decided.
+    status: proposed
+    tags: [codegen, target-artifacts, hardware, wit]
+    links:
+      - type: traces-to
+        target: REQ-CODEGEN-TARGET-ARTIFACTS-001
+
   - id: REQ-CODEGEN-VERIFY-WORKSPACE-001
     type: requirement
     title: "spar codegen --verify test/build emits inert artifacts"

--- a/crates/spar-cli/src/main.rs
+++ b/crates/spar-cli/src/main.rs
@@ -78,7 +78,7 @@ fn print_usage() {
     eprintln!("  allocate   Allocate threads to processors via bin-packing");
     eprintln!("  diff       Compare two model versions and report changes");
     eprintln!("  modes      Mode reachability analysis and SMV/DOT export");
-    eprintln!("  emit       Emit a text diagram (Mermaid flowchart) from an instantiated system");
+    eprintln!("  emit       Emit a Mermaid diagram, target constants module, or linker memory map");
     eprintln!("  render     Render architecture SVG from an instantiated system");
     eprintln!("  verify     Verify requirements against analysis results");
     eprintln!("  codegen    Generate code from an instantiated system model");
@@ -110,13 +110,15 @@ fn print_usage() {
     );
     eprintln!("  modes    --root Package::Type.Impl [--format text|smv|dot] <file...>");
     eprintln!(
-        "  emit     [--format mermaid|mermaid-class|mermaid-req] \
+        "  emit     [--format mermaid|mermaid-class|mermaid-req|constants|linker] \
          [--root Package::Type.Impl] [--category <cat,...>] \
-         [--max-depth N] [--no-connections] [-o output.md] [<file...>]\n\
+         [--max-depth N] [--no-connections] [-o output] [<file...>]\n\
          \n\
          \t\t  mermaid       flowchart TD (default)\n\
          \t\t  mermaid-class classDiagram of component types\n\
-         \t\t  mermaid-req   requirementDiagram from artifacts/requirements.yaml"
+         \t\t  mermaid-req   requirementDiagram from artifacts/requirements.yaml\n\
+         \t\t  constants     Rust constants module (memory/peripheral base addresses + sizes)\n\
+         \t\t  linker        GNU-ld MEMORY block / rust-embedded memory.x from memory components"
     );
     eprintln!("  render   --root Package::Type.Impl [-o output.svg] <file...>");
     eprintln!(
@@ -1351,12 +1353,12 @@ fn cmd_emit(args: &[String]) {
                 if i < args.len() {
                     let f = args[i].as_str();
                     match f {
-                        "mermaid" | "mermaid-class" | "mermaid-req" => {
+                        "mermaid" | "mermaid-class" | "mermaid-req" | "constants" | "linker" => {
                             format = f.to_string();
                         }
                         other => {
                             eprintln!(
-                                "--format only supports 'mermaid' | 'mermaid-class' | 'mermaid-req' (got '{other}')"
+                                "--format only supports 'mermaid' | 'mermaid-class' | 'mermaid-req' | 'constants' | 'linker' (got '{other}')"
                             );
                             process::exit(1);
                         }
@@ -1424,6 +1426,47 @@ fn cmd_emit(args: &[String]) {
             process::exit(1);
         });
         return emit_output(diagram, output);
+    }
+
+    // ── constants / linker: hardware-target artifacts from the instance model ─
+    if format == "constants" || format == "linker" {
+        let root = root.unwrap_or_else(|| {
+            eprintln!("--root Package::Type.Impl is required");
+            process::exit(1);
+        });
+        if files.is_empty() {
+            eprintln!("Missing file argument(s)");
+            process::exit(1);
+        }
+
+        let (pkg_name, type_name, impl_name) = parse_root_ref(&root);
+        let db = spar_hir_def::HirDefDatabase::default();
+        let mut trees = Vec::new();
+        for file_path in &files {
+            let source = read_file(file_path);
+            let sf = spar_base_db::SourceFile::new(&db, file_path.clone(), source);
+            trees.push(spar_hir_def::file_item_tree(&db, sf));
+        }
+        let scope = spar_hir_def::GlobalScope::from_trees(trees);
+        let inst = spar_hir_def::instance::SystemInstance::instantiate(
+            &scope,
+            &spar_hir_def::Name::new(&pkg_name),
+            &spar_hir_def::Name::new(&type_name),
+            &spar_hir_def::Name::new(&impl_name),
+        );
+
+        let result = if format == "constants" {
+            spar_codegen::target_gen::emit_constants(&inst, &root)
+        } else {
+            spar_codegen::target_gen::emit_linker(&inst, &root)
+        };
+        match result {
+            Ok(content) => return emit_output(content, output),
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
     }
 
     // ── mermaid / mermaid-class: require --root and AADL files ──────────────

--- a/crates/spar-cli/tests/emit_target.rs
+++ b/crates/spar-cli/tests/emit_target.rs
@@ -1,0 +1,152 @@
+//! Integration tests for `spar emit --format constants` and
+//! `spar emit --format linker` — the hardware-target artifact path
+//! (REQ-CODEGEN-TARGET-ARTIFACTS-001, #338).
+
+use std::env;
+use std::fs;
+use std::process::Command;
+
+fn spar() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_spar"))
+}
+
+/// A small STM32-shaped hardware target: two `memory` regions and one
+/// memory-mapped `device` peripheral.
+const MODEL: &str = "\
+package Target_Board
+public
+  memory Flash_Region
+  end Flash_Region;
+
+  memory Sram_Region
+  end Sram_Region;
+
+  device Uart
+  end Uart;
+
+  system Board
+  end Board;
+
+  system implementation Board.Impl
+    subcomponents
+      flash: memory Flash_Region {
+        Base_Address => 16#08000000#;
+        Memory_Size => 1024 KByte;
+      };
+      sram: memory Sram_Region {
+        Base_Address => 16#20000000#;
+        Byte_Count => 131072;
+      };
+      uart1: device Uart {
+        Base_Address => 16#40011000#;
+      };
+  end Board.Impl;
+end Target_Board;
+";
+
+fn write_model(tag: &str) -> std::path::PathBuf {
+    let path = env::temp_dir().join(format!(
+        "spar_emit_target_{}_{}.aadl",
+        std::process::id(),
+        tag
+    ));
+    fs::write(&path, MODEL).expect("write temp AADL");
+    path
+}
+
+#[test]
+fn emit_constants_produces_module() {
+    let model = write_model("constants");
+    let out = spar()
+        .args([
+            "emit",
+            "--format",
+            "constants",
+            "--root",
+            "Target_Board::Board.Impl",
+            model.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run spar emit");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("pub const FLASH_BASE: usize = 0x08000000;"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("pub const FLASH_SIZE: usize = 0x00100000;"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("pub const SRAM_BASE: usize = 0x20000000;"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("pub const UART1_BASE: usize = 0x40011000;"),
+        "{stdout}"
+    );
+    let _ = fs::remove_file(&model);
+}
+
+#[test]
+fn emit_linker_produces_memory_block() {
+    let model = write_model("linker");
+    let out = spar()
+        .args([
+            "emit",
+            "--format",
+            "linker",
+            "--root",
+            "Target_Board::Board.Impl",
+            model.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run spar emit");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("MEMORY"), "{stdout}");
+    assert!(
+        stdout.contains("FLASH : ORIGIN = 0x08000000, LENGTH = 1048576"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("SRAM : ORIGIN = 0x20000000, LENGTH = 131072"),
+        "{stdout}"
+    );
+    let _ = fs::remove_file(&model);
+}
+
+#[test]
+fn emit_constants_non_hardware_model_exits_nonzero() {
+    let path = env::temp_dir().join(format!(
+        "spar_emit_target_empty_{}.aadl",
+        std::process::id()
+    ));
+    fs::write(
+        &path,
+        "package P\npublic\n system S\n end S;\n system implementation S.Impl\n end S.Impl;\nend P;\n",
+    )
+    .unwrap();
+    let out = spar()
+        .args([
+            "emit",
+            "--format",
+            "constants",
+            "--root",
+            "P::S.Impl",
+            path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run spar emit");
+    assert!(!out.status.success(), "should fail on a non-hardware model");
+    let _ = fs::remove_file(&path);
+}

--- a/crates/spar-codegen/src/lib.rs
+++ b/crates/spar-codegen/src/lib.rs
@@ -7,6 +7,7 @@
 //! - **rust_gen**: Rust component skeletons per thread
 //! - **config_gen**: TOML/JSON configuration files
 //! - **test_gen**: Test harnesses per thread
+//! - **target_gen**: hardware-target constants module + linker memory map
 //! - **proof_gen**: Lean4 scheduling proofs + Kani harnesses
 //! - **doc_gen**: Rivet design documents with YAML frontmatter
 //! - **workspace_gen**: Cargo.toml + BUILD.bazel workspace generation
@@ -16,6 +17,7 @@ pub mod config_gen;
 pub mod doc_gen;
 pub mod proof_gen;
 pub mod rust_gen;
+pub mod target_gen;
 pub mod test_gen;
 pub mod wit_gen;
 pub mod workspace_gen;

--- a/crates/spar-codegen/src/target_gen.rs
+++ b/crates/spar-codegen/src/target_gen.rs
@@ -1,0 +1,562 @@
+//! Hardware-target artifact generation from an AADL instance model.
+//!
+//! REQ-CODEGEN-TARGET-ARTIFACTS-001 (#338).
+//!
+//! Emits build-time target artifacts derived from a *hardware* AADL model —
+//! the model becomes the single source of truth for an embedded target build:
+//!
+//! - a Rust **constants module** ([`emit_constants`], `spar emit --format
+//!   constants`): memory-region base addresses and sizes, plus peripheral
+//!   (`device`) base addresses, as `pub const` items a firmware crate `include!`s;
+//! - a **linker memory map** ([`emit_linker`], `spar emit --format linker`): a
+//!   GNU-ld `MEMORY { }` block (the rust-embedded `memory.x` shape), one region
+//!   per `memory` component.
+//!
+//! Both are derived purely from standard AADL `Memory_Properties` on the
+//! instantiated model: `Base_Address` (an `aadlinteger`) for the origin, and
+//! `Byte_Count` or `Memory_Size` for the length. Values are read from the
+//! resolved instance property map, so type/impl inheritance and `applies to`
+//! associations are already folded in.
+//!
+//! **Scope (honest).** This increment emits only base addresses and sizes —
+//! the mechanical, standard-property-backed core of the #338 ask. Device
+//! *register-detail offsets* and the *WIT device-driver world binding* (asks 1
+//! and 3 of the issue) are NOT emitted here; they require a register/binding
+//! convention AADL does not standardize and are tracked by the successor
+//! REQ-CODEGEN-TARGET-ARTIFACTS-002.
+
+use spar_hir_def::instance::SystemInstance;
+use spar_hir_def::item_tree::{ComponentCategory, PropertyExpr};
+use spar_hir_def::properties::PropertyMap;
+
+/// A memory region extracted from a `memory` component instance.
+struct Region {
+    /// Uppercase identifier derived from the component's instance path.
+    ident: String,
+    /// Full instance path (source comment + tie-break ordering).
+    path: String,
+    base: u64,
+    /// Size in bytes, if the model carries `Byte_Count`/`Memory_Size`.
+    size_bytes: Option<u64>,
+}
+
+/// A peripheral base extracted from a memory-mapped `device` component instance.
+struct Peripheral {
+    ident: String,
+    path: String,
+    base: u64,
+}
+
+/// Read `Base_Address` (an `aadlinteger`) off a resolved property map.
+///
+/// Accepts the standard `Memory_Properties::Base_Address` qualification and a
+/// bare unqualified `Base_Address`. Returns `None` when absent or not a
+/// non-negative integer.
+fn base_address(props: &PropertyMap) -> Option<u64> {
+    let expr = props
+        .get_typed("Memory_Properties", "Base_Address")
+        .or_else(|| props.get_typed("", "Base_Address"))?;
+    match expr {
+        PropertyExpr::Integer(v, _) if *v >= 0 => Some(*v as u64),
+        _ => None,
+    }
+}
+
+/// Read a memory-region size in **bytes** off a resolved property map.
+///
+/// Prefers `Byte_Count` (a plain byte count) and falls back to `Memory_Size`
+/// (an AADL `Size` with units, e.g. `256 KByte`). A `Memory_Size` that is not
+/// a whole number of bytes (sub-byte bit width) yields `None` rather than a
+/// truncated value.
+fn size_bytes(props: &PropertyMap) -> Option<u64> {
+    if let Some(PropertyExpr::Integer(v, _)) = props
+        .get_typed("Memory_Properties", "Byte_Count")
+        .or_else(|| props.get_typed("", "Byte_Count"))
+        && *v >= 0
+    {
+        return Some(*v as u64);
+    }
+    // `Memory_Size` is a Size property; property_accessors normalizes it to bits.
+    let bits = spar_analysis::property_accessors::get_size_property(props, "Memory_Size")?;
+    if bits.is_multiple_of(8) {
+        Some(bits / 8)
+    } else {
+        None
+    }
+}
+
+/// Derive a stable, C/Rust-identifier-safe constant name from an instance path.
+///
+/// Uses the leaf component name uppercased, mapping every character outside
+/// `[A-Za-z0-9_]` to `_` and prefixing `_` if it would start with a digit.
+fn ident_from_path(path: &str) -> String {
+    let leaf = path.rsplit('/').next().unwrap_or(path);
+    let mut out = String::with_capacity(leaf.len());
+    for ch in leaf.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch.to_ascii_uppercase());
+        } else {
+            out.push('_');
+        }
+    }
+    if out.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+/// Walk the instance model and collect memory regions and peripheral bases,
+/// each sorted by `(base, ident)` for deterministic output.
+///
+/// Returns an error if two collected items would collide on the same
+/// identifier (an ambiguous model the caller must disambiguate) — a hard,
+/// deterministic failure rather than a silently dropped constant.
+fn collect(inst: &SystemInstance) -> Result<(Vec<Region>, Vec<Peripheral>), String> {
+    let mut regions = Vec::new();
+    let mut peripherals = Vec::new();
+
+    for (idx, comp) in inst.all_components() {
+        let props = inst.properties_for(idx);
+        let path = inst.component_instance_path(idx);
+        match comp.category {
+            ComponentCategory::Memory => {
+                if let Some(base) = base_address(props) {
+                    regions.push(Region {
+                        ident: ident_from_path(&path),
+                        path,
+                        base,
+                        size_bytes: size_bytes(props),
+                    });
+                }
+            }
+            ComponentCategory::Device => {
+                // Only memory-mapped devices (those with a base address) get a
+                // peripheral constant; a non-mapped device is legitimately skipped.
+                if let Some(base) = base_address(props) {
+                    peripherals.push(Peripheral {
+                        ident: ident_from_path(&path),
+                        path,
+                        base,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    regions.sort_by(|a, b| a.base.cmp(&b.base).then_with(|| a.ident.cmp(&b.ident)));
+    peripherals.sort_by(|a, b| a.base.cmp(&b.base).then_with(|| a.ident.cmp(&b.ident)));
+
+    // Collision check across the full constant namespace.
+    let mut seen: std::collections::BTreeMap<&str, &str> = std::collections::BTreeMap::new();
+    for (ident, path) in regions
+        .iter()
+        .map(|r| (r.ident.as_str(), r.path.as_str()))
+        .chain(
+            peripherals
+                .iter()
+                .map(|p| (p.ident.as_str(), p.path.as_str())),
+        )
+    {
+        if let Some(prev) = seen.insert(ident, path) {
+            return Err(format!(
+                "target-artifact identifier collision: `{ident}` derived from both `{prev}` \
+                 and `{path}`; give the components distinct leaf names"
+            ));
+        }
+    }
+
+    Ok((regions, peripherals))
+}
+
+/// A human-readable byte-size annotation, e.g. `1048576 bytes (1024 KiB)`.
+fn size_comment(bytes: u64) -> String {
+    if bytes != 0 && bytes.is_multiple_of(1024 * 1024) {
+        format!("{bytes} bytes ({} MiB)", bytes / (1024 * 1024))
+    } else if bytes != 0 && bytes.is_multiple_of(1024) {
+        format!("{bytes} bytes ({} KiB)", bytes / 1024)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+/// Emit a Rust constants module from a hardware AADL instance model.
+///
+/// `root_ref` is the `Package::Type.Impl` reference the model was instantiated
+/// from, recorded in the generated header. Returns an error if the model
+/// yields no base-addressed memory/device components (an empty artifact is
+/// almost always a wrong or non-hardware model), or on identifier collision.
+pub fn emit_constants(inst: &SystemInstance, root_ref: &str) -> Result<String, String> {
+    let (regions, peripherals) = collect(inst)?;
+    if regions.is_empty() && peripherals.is_empty() {
+        return Err(
+            "no `memory` or `device` component with a `Base_Address` was found; \
+             this does not look like a hardware target model"
+                .to_string(),
+        );
+    }
+
+    let mut out = String::new();
+    out.push_str("// Generated by `spar emit --format constants`. DO NOT EDIT.\n");
+    out.push_str(&format!("// Source model: {root_ref}\n"));
+    out.push_str(
+        "// Target memory map and peripheral base addresses derived from the AADL model.\n",
+    );
+    out.push_str("#![allow(dead_code)]\n\n");
+
+    if !regions.is_empty() {
+        out.push_str("// ── Memory regions ──────────────────────────────────────────\n");
+        for r in &regions {
+            out.push_str(&format!("// {}\n", r.path));
+            out.push_str(&format!(
+                "pub const {}_BASE: usize = 0x{:08X};\n",
+                r.ident, r.base
+            ));
+            match r.size_bytes {
+                Some(size) => out.push_str(&format!(
+                    "pub const {}_SIZE: usize = 0x{:08X}; // {}\n",
+                    r.ident,
+                    size,
+                    size_comment(size)
+                )),
+                None => out.push_str(&format!(
+                    "// {}_SIZE: no Byte_Count/Memory_Size in the model\n",
+                    r.ident
+                )),
+            }
+        }
+        out.push('\n');
+    }
+
+    if !peripherals.is_empty() {
+        out.push_str("// ── Peripheral base addresses ───────────────────────────────\n");
+        for p in &peripherals {
+            out.push_str(&format!("// {}\n", p.path));
+            out.push_str(&format!(
+                "pub const {}_BASE: usize = 0x{:08X};\n",
+                p.ident, p.base
+            ));
+        }
+    }
+
+    Ok(out)
+}
+
+/// Emit a GNU-ld `MEMORY { }` block (rust-embedded `memory.x` shape) from a
+/// hardware AADL instance model — one region per base-addressed `memory`
+/// component. `ORIGIN` is emitted in hex, `LENGTH` in exact decimal bytes.
+///
+/// Regions without a resolvable size are omitted (a linker region requires a
+/// length); if that leaves the block empty, an error is returned.
+pub fn emit_linker(inst: &SystemInstance, root_ref: &str) -> Result<String, String> {
+    let (regions, _peripherals) = collect(inst)?;
+    let sized: Vec<&Region> = regions.iter().filter(|r| r.size_bytes.is_some()).collect();
+    if sized.is_empty() {
+        return Err("no `memory` component with both `Base_Address` and a size \
+             (`Byte_Count`/`Memory_Size`) was found; cannot emit a linker memory map"
+            .to_string());
+    }
+
+    let mut out = String::new();
+    out.push_str("/* Generated by `spar emit --format linker`. DO NOT EDIT. */\n");
+    out.push_str(&format!("/* Source model: {root_ref} */\n"));
+    out.push_str("MEMORY\n{\n");
+    for r in &sized {
+        let size = r.size_bytes.expect("filtered to Some above");
+        out.push_str(&format!(
+            "  {} : ORIGIN = 0x{:08X}, LENGTH = {} /* {} */\n",
+            r.ident,
+            r.base,
+            size,
+            size_comment(size)
+        ));
+    }
+    out.push_str("}\n");
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spar_hir_def::name::Name;
+    use spar_hir_def::resolver::GlobalScope;
+
+    /// A minimal STM32-shaped hardware target: two `memory` regions (flash via
+    /// `Memory_Size`, sram via `Byte_Count`), two memory-mapped `device`
+    /// peripherals, and one non-mapped device (no `Base_Address`).
+    const BOARD: &str = r#"
+package Target_Board
+public
+  processor Cortex_M4
+  end Cortex_M4;
+
+  memory Flash_Region
+  end Flash_Region;
+
+  memory Sram_Region
+  end Sram_Region;
+
+  device Uart
+  end Uart;
+
+  device Gpio
+  end Gpio;
+
+  device Led
+  end Led;
+
+  system Board
+  end Board;
+
+  system implementation Board.Impl
+    subcomponents
+      cpu: processor Cortex_M4;
+      flash: memory Flash_Region {
+        Base_Address => 16#08000000#;
+        Memory_Size => 1024 KByte;
+      };
+      sram: memory Sram_Region {
+        Base_Address => 16#20000000#;
+        Byte_Count => 131072;
+      };
+      uart1: device Uart {
+        Base_Address => 16#40011000#;
+      };
+      gpioa: device Gpio {
+        Base_Address => 16#40020000#;
+      };
+      status_led: device Led;
+  end Board.Impl;
+end Target_Board;
+"#;
+
+    fn board_instance() -> SystemInstance {
+        let db = spar_hir_def::HirDefDatabase::default();
+        let sf = spar_base_db::SourceFile::new(&db, "board.aadl".to_string(), BOARD.to_string());
+        let tree = spar_hir_def::file_item_tree(&db, sf);
+        let scope = GlobalScope::from_trees(vec![tree]);
+        SystemInstance::instantiate(
+            &scope,
+            &Name::new("Target_Board"),
+            &Name::new("Board"),
+            &Name::new("Impl"),
+        )
+    }
+
+    #[test]
+    fn constants_golden() {
+        let inst = board_instance();
+        let out = emit_constants(&inst, "Target_Board::Board.Impl").expect("emit");
+        let expected = "\
+// Generated by `spar emit --format constants`. DO NOT EDIT.
+// Source model: Target_Board::Board.Impl
+// Target memory map and peripheral base addresses derived from the AADL model.
+#![allow(dead_code)]
+
+// ── Memory regions ──────────────────────────────────────────
+// Board.Impl/flash
+pub const FLASH_BASE: usize = 0x08000000;
+pub const FLASH_SIZE: usize = 0x00100000; // 1048576 bytes (1 MiB)
+// Board.Impl/sram
+pub const SRAM_BASE: usize = 0x20000000;
+pub const SRAM_SIZE: usize = 0x00020000; // 131072 bytes (128 KiB)
+
+// ── Peripheral base addresses ───────────────────────────────
+// Board.Impl/uart1
+pub const UART1_BASE: usize = 0x40011000;
+// Board.Impl/gpioa
+pub const GPIOA_BASE: usize = 0x40020000;
+";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn linker_golden() {
+        let inst = board_instance();
+        let out = emit_linker(&inst, "Target_Board::Board.Impl").expect("emit");
+        let expected = "\
+/* Generated by `spar emit --format linker`. DO NOT EDIT. */
+/* Source model: Target_Board::Board.Impl */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 1048576 /* 1048576 bytes (1 MiB) */
+  SRAM : ORIGIN = 0x20000000, LENGTH = 131072 /* 131072 bytes (128 KiB) */
+}
+";
+        assert_eq!(out, expected);
+    }
+
+    /// Oracle (the #338 round-trip): every emitted `*_BASE` / `*_SIZE` value must
+    /// equal the value independently re-derived from the resolved instance
+    /// property map — i.e. the constants faithfully encode the model, matching
+    /// what `spar instance --json` would report. This re-reads the model through
+    /// a *different* code path (raw property text) than the emitter's typed one.
+    #[test]
+    fn constants_match_instance_model() {
+        let inst = board_instance();
+        let out = emit_constants(&inst, "Target_Board::Board.Impl").expect("emit");
+
+        // Independently collect (leaf-name -> base, size_bytes) from the model,
+        // parsing raw property strings rather than the typed PropertyExpr.
+        let mut expected: std::collections::BTreeMap<String, (u64, Option<u64>)> =
+            std::collections::BTreeMap::new();
+        for (idx, comp) in inst.all_components() {
+            if !matches!(
+                comp.category,
+                ComponentCategory::Memory | ComponentCategory::Device
+            ) {
+                continue;
+            }
+            let props = inst.properties_for(idx);
+            let base_raw = props
+                .get("Memory_Properties", "Base_Address")
+                .or_else(|| props.get("", "Base_Address"));
+            let Some(base_raw) = base_raw else { continue };
+            let base = parse_aadl_int(base_raw).expect("base parses");
+            let size = props
+                .get("Memory_Properties", "Byte_Count")
+                .or_else(|| props.get("", "Byte_Count"))
+                .and_then(parse_aadl_int)
+                .or_else(|| {
+                    props
+                        .get("Memory_Properties", "Memory_Size")
+                        .or_else(|| props.get("", "Memory_Size"))
+                        .and_then(parse_aadl_size_bytes)
+                });
+            expected.insert(comp.name.as_str().to_ascii_uppercase(), (base, size));
+        }
+
+        // Every expected constant must appear in the emitted module with the
+        // independently-derived value, and vice versa (no phantom constants).
+        for (ident, (base, size)) in &expected {
+            let base_line = format!("pub const {ident}_BASE: usize = 0x{base:08X};");
+            assert!(
+                out.contains(&base_line),
+                "missing/incorrect base for {ident}: expected `{base_line}`\n--- emitted ---\n{out}"
+            );
+            if let Some(sz) = size {
+                let size_line = format!("pub const {ident}_SIZE: usize = 0x{sz:08X};");
+                assert!(
+                    out.lines().any(|l| l.starts_with(&size_line)),
+                    "missing/incorrect size for {ident}: expected `{size_line}`\n--- emitted ---\n{out}"
+                );
+            }
+        }
+        // The non-mapped device must not have produced a constant.
+        assert!(
+            !out.contains("STATUS_LED_BASE"),
+            "non-mapped device leaked into output"
+        );
+        assert_eq!(expected.len(), 4, "expected 2 memory + 2 mapped devices");
+    }
+
+    /// Parse an AADL integer literal (decimal or based `base#digits#`) to u64.
+    fn parse_aadl_int(raw: &str) -> Option<u64> {
+        let s = raw.trim();
+        if let Some(hash) = s.find('#') {
+            let base: u32 = s[..hash].parse().ok()?;
+            let rest = &s[hash + 1..];
+            let end = rest.find('#')?;
+            return u64::from_str_radix(rest[..end].trim(), base).ok();
+        }
+        s.split_whitespace().next()?.parse().ok()
+    }
+
+    /// Parse an AADL `Size` value (`N Unit`) to bytes.
+    fn parse_aadl_size_bytes(raw: &str) -> Option<u64> {
+        let mut it = raw.split_whitespace();
+        let n: u64 = it.next()?.parse().ok()?;
+        let unit = it.next().unwrap_or("Bytes");
+        let bytes = match unit {
+            "bits" => {
+                return if n.is_multiple_of(8) {
+                    Some(n / 8)
+                } else {
+                    None
+                };
+            }
+            "Bytes" | "bytes" => 1,
+            "KByte" => 1024,
+            "MByte" => 1024 * 1024,
+            "GByte" => 1024 * 1024 * 1024,
+            _ => return None,
+        };
+        Some(n * bytes)
+    }
+
+    #[test]
+    fn non_hardware_model_errors() {
+        let aadl = "package P\npublic\n system S\n end S;\n system implementation S.Impl\n end S.Impl;\nend P;\n";
+        let db = spar_hir_def::HirDefDatabase::default();
+        let sf = spar_base_db::SourceFile::new(&db, "p.aadl".to_string(), aadl.to_string());
+        let tree = spar_hir_def::file_item_tree(&db, sf);
+        let scope = GlobalScope::from_trees(vec![tree]);
+        let inst = SystemInstance::instantiate(
+            &scope,
+            &Name::new("P"),
+            &Name::new("S"),
+            &Name::new("Impl"),
+        );
+        assert!(emit_constants(&inst, "P::S.Impl").is_err());
+        assert!(emit_linker(&inst, "P::S.Impl").is_err());
+    }
+
+    #[test]
+    fn ident_sanitizes() {
+        assert_eq!(ident_from_path("root/sub/uart1"), "UART1");
+        assert_eq!(ident_from_path("root/9pin"), "_9PIN");
+        assert_eq!(ident_from_path("root/a-b.c"), "A_B_C");
+    }
+
+    /// Two memory components under different parents that share a leaf name
+    /// collide on the derived identifier — the emitter must hard-error rather
+    /// than silently drop or overwrite a constant.
+    #[test]
+    fn collision_is_hard_error() {
+        let aadl = r#"
+package Coll
+public
+  memory Mem
+  end Mem;
+
+  system Sub
+  end Sub;
+
+  system implementation Sub.Impl
+    subcomponents
+      flash: memory Mem {
+        Base_Address => 16#08000000#;
+      };
+  end Sub.Impl;
+
+  system Top
+  end Top;
+
+  system implementation Top.Impl
+    subcomponents
+      a: system Sub.Impl;
+      b: system Sub.Impl;
+  end Top.Impl;
+end Coll;
+"#;
+        let db = spar_hir_def::HirDefDatabase::default();
+        let sf = spar_base_db::SourceFile::new(&db, "coll.aadl".to_string(), aadl.to_string());
+        let tree = spar_hir_def::file_item_tree(&db, sf);
+        let scope = GlobalScope::from_trees(vec![tree]);
+        let inst = SystemInstance::instantiate(
+            &scope,
+            &Name::new("Coll"),
+            &Name::new("Top"),
+            &Name::new("Impl"),
+        );
+        let err = emit_constants(&inst, "Coll::Top.Impl").expect_err("colliding leaf names");
+        assert!(
+            err.contains("collision") && err.contains("FLASH"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes the memory-map slice of #338: make an analyzed **hardware** AADL model the single source of truth for an embedded-target build, so downstream (gale/gust) no longer has to re-derive structure spar already holds. Two build-time artifacts, both reachable from the CLI as `spar emit --format <fmt> --root Package::Type.Impl <files>` and derived purely from standard AADL `Memory_Properties` on the **resolved** instance model (type/impl inheritance and `applies to` already folded in):

- **`--format constants`** — a Rust constants module: `pub const <NAME>_BASE` (from `Base_Address`) and `<NAME>_SIZE` (from `Byte_Count`, else `Memory_Size` normalized to bytes) for each `memory` component, plus `<NAME>_BASE` for each memory-mapped `device` (peripheral base).
- **`--format linker`** — a GNU-ld `MEMORY` block (the rust-embedded `memory.x` shape), one region per sized `memory` component, `ORIGIN` in hex and `LENGTH` in exact decimal bytes.

Constant/region names are the component instance **leaf name** uppercased + identifier-sanitized. Output is sorted by `(base, ident)` for deterministic golden output. A non-hardware model (no base-addressed memory/device) or an identifier collision is a **hard non-zero error**, never a vacuous/ambiguous artifact.

### Example

For an STM32-shaped model (`flash`/`sram` memory + `uart1` device):

```rust
// Generated by `spar emit --format constants`. DO NOT EDIT.
pub const FLASH_BASE: usize = 0x08000000;
pub const FLASH_SIZE: usize = 0x00100000; // 1048576 bytes (1 MiB)
pub const SRAM_BASE: usize  = 0x20000000;
pub const SRAM_SIZE: usize  = 0x00020000; // 131072 bytes (128 KiB)
pub const UART1_BASE: usize = 0x40011000;
```
```
MEMORY
{
  FLASH : ORIGIN = 0x08000000, LENGTH = 1048576 /* 1048576 bytes (1 MiB) */
  SRAM : ORIGIN = 0x20000000, LENGTH = 131072 /* 131072 bytes (128 KiB) */
}
```

## Honest scope

This emits base addresses and sizes **only** — the mechanical, standard-property-backed core of #338. Device **register-detail offsets**, the device **presence flag**, and the **WIT device-driver world binding** (asks 1 and 3 of the issue) are **not** implemented here; they need a register/binding convention AADL does not standardize and are tracked by the successor **REQ-CODEGEN-TARGET-ARTIFACTS-002** (proposed). Other explicit non-claims: size read from `Byte_Count`/`Memory_Size` only (no `Word_Count`×`Word_Size`); linker region names come from the model leaf names (not forced to cortex-m `FLASH`/`RAM`); `Base_Address` taken verbatim (no bus/binding offset resolution); constants are `usize` (a base/size ≥ 2³² compiles only for a 64-bit-`usize` target). The existing `spar items --json` bridge remains the supported downstream contract; this adds a first-class emission path over the same model data.

## Oracles (executed)

- **`constants_golden` / `linker_golden`** — byte-exact output for an STM32-shaped fixture (flash via `Memory_Size => 1024 KByte`, sram via `Byte_Count => 131072`, two mapped devices, one non-mapped device).
- **`constants_match_instance_model`** — the #338 round-trip: every emitted `*_BASE`/`*_SIZE` equals the value **independently re-derived** from the resolved instance property map through the raw-string path (a different accessor + parser than the emitter's typed `PropertyExpr`); also asserts the non-mapped device emits no constant and exactly 2 memory + 2 devices are captured.
- **`non_hardware_model_errors`** + CLI **`emit_constants_non_hardware_model_exits_nonzero`** — a model with no base-addressed memory/device is a hard non-zero error.
- **`collision_is_hard_error`** — two same-leaf-named memory components under different parents return an `Err` rather than dropping/overwriting a constant.
- **`ident_sanitizes`** — identifier derivation (uppercase, non-alnum → `_`, digit-prefix guard).
- **CLI integration** (`crates/spar-cli/tests/emit_target.rs`) — the built binary over a temp fixture, plus the non-zero-exit path.

An independent clean-room subagent re-derived the numeric conversions from base-notation, confirmed determinism, the PROVEN-vs-ASSUMED honesty, and clippy/fmt cleanliness; its one finding (an over-claim about the collision test) was fixed by adding the real `collision_is_hard_error` test before this PR.

## Requirements

- `REQ-CODEGEN-TARGET-ARTIFACTS-001` (status: implemented, traces-to `REQ-CODEGEN-001`)
- `REQ-CODEGEN-TARGET-ARTIFACTS-002` (status: proposed — deferred register offsets + WIT world binding)

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the spar-codegen + spar-cli test suites all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdtDSj1q4tYcdCgaDAvjFe)_