### PR TITLE
chore(release): bump to v0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1640,14 +1640,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3242,7 +3242,7 @@ artifacts:
       codec. ASSUMED: the canonical-ABI alignment constants themselves. Scope:
       flat scalar records (1/2/4/8-byte fields); nested records/arrays are a
       successor increment (REQ-CODEGEN-LAYOUT-CERT-002, planned).
-    status: implemented
+    status: verified
     release: v0.35.0
     tags: [codegen, ordeal, certificate, layout, wit, v0350]
     links:

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release bump for **v0.35.0**, shipping the layout-equivalence certification that landed on main after v0.34.0:

- **feat(codegen): certify AADL↔WIT byte-layout equivalence via ordeal** (`REQ-CODEGEN-LAYOUT-CERT-001`, #327, PR #354) — spar's first ordeal integration. The AADL data-impl → WIT record → canonical-ABI offset/width table is now certificate-checked: both layouts are encoded as ordeal QF_BV terms and proven equivalent via `Solver::prove_valid`, with a re-checkable `ordeal-lrat` LRAT certificate. Closes the #319 layout gap.

Bumps:
- workspace + all `spar-*` crates `0.34.0` → `0.35.0`
- `vscode-spar` extension `0.34.0` → `0.35.0`
- `REQ-CODEGEN-LAYOUT-CERT-001` promoted to `verified` @ v0.35.0

`rivet validate`: PASS, 0 broken cross-refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019rUQpHxcgCnbZLv9Qrj41s)_