### PR TITLE
chore(artifacts): tag the three ordeal artifacts human-scoped

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3256,7 +3256,7 @@ artifacts:
       produces it. The ordeal beachhead moves to REQ-PROOF-RTA-OVERFLOW-001,
       where bit-precise u64 wraparound is exactly such a property.
     status: rejected
-    tags: [codegen, ordeal, certificate, layout, wit, withdrawn, v0350]
+    tags: [codegen, ordeal, certificate, layout, wit, withdrawn, v0350, human-scoped]
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-RECORDS-001
@@ -3280,7 +3280,7 @@ artifacts:
       goal that a wrong encoder can actually falsify, and justified against
       plain interval arithmetic. Not planned.
     status: rejected
-    tags: [codegen, ordeal, certificate, layout, wit, withdrawn]
+    tags: [codegen, ordeal, certificate, layout, wit, withdrawn, human-scoped]
     links:
       - type: traces-to
         target: REQ-CODEGEN-LAYOUT-CERT-001
@@ -3329,7 +3329,7 @@ artifacts:
       introduces a new multiplication cannot land silently.
     status: proposed
     release: v0.36.0
-    tags: [proofs, ordeal, certificate, rta, overflow, v0360]
+    tags: [proofs, ordeal, certificate, rta, overflow, v0360, human-scoped]
     links:
       - type: traces-to
         target: REQ-PROOF-SCHED-CODEGEN-001


### PR DESCRIPTION
Applies `human-scoped` to the three ordeal artifacts. #359 landed the
*mechanism* and tagged nothing with it.

That gap matters more than it looks. REQ-GUARD-HUMAN-SCOPED-001 exists because
the autonomous cron picked up `REQ-CODEGEN-LAYOUT-CERT-001`, implemented it,
self-recorded `status: verified` and merged it in about an hour — asserting a
proof that did not exist, because the SMT goal constant-folded and every input
produced a byte-identical certificate. Shipping the enforcement without applying
it to the artifact that motivated it leaves exactly the same hole open under a
new name: a checker that scans 431 artifacts and finds three pre-existing tags,
none of them on the ordeal work.

## What gets tagged, and why each qualifies

The guardrail's own definition of human-scoped is *first wiring of an external
dependency, narrowing a research-grade property to something a solver can
actually decide, or designing a falsification kill-criterion*. All three hit it:

| artifact | status | why |
|---|---|---|
| `REQ-CODEGEN-LAYOUT-CERT-001` | `rejected` | the artifact the guardrail already `traces-to`; tagged so a revival cannot repeat the promotion |
| `REQ-CODEGEN-LAYOUT-CERT-002` | `rejected` | its successor, whose own text says a future certificate "would have to be re-derived from scratch with a proof goal that a wrong encoder can actually falsify" — that sentence *is* the definition |
| `REQ-PROOF-RTA-OVERFLOW-001` | `proposed` | **the live one.** The re-aimed ordeal beachhead, `release: v0.36.0` — i.e. the next thing an unattended run would reach for |

`rejected` and `proposed` are both permitted, so this is green today. The tag
only bites on promotion to `implemented`/`verified`/`released`/`accepted`/
`passing`.

## Verified two-sidedly

A guard that never fires is indistinguishable from a guard that cannot fire, and
`exit 0` on its own demonstrates neither — it is equally consistent with "the tag
binds and nothing violates it" and "the tag was never read."

```
side 1   as committed                                    -> exit 0, 6 tagged, 0 violations
side 2   REQ-PROOF-RTA-OVERFLOW-001 flipped to
         status: verified in a scratch copy              -> exit 1
         "REQ-PROOF-RTA-OVERFLOW-001: status=verified  (requirements.yaml)"
```

Side 2 is the load-bearing half: it shows the tag binds on **this specific id**,
not merely that the checker executes. Run against `--artifacts-dir` on a copied
tree so the working tree was never left mutated.

`artifacts/requirements.yaml` also re-parsed clean under a real YAML parser
before pushing (225 artifacts), since the narrow in-repo parser is fail-closed
and a flow-sequence edit is exactly the shape that has broken `serde_yaml` here
before.

## Scope

Three lines. No status changes, no new artifacts, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
