### PR TITLE
fix(rivet): stop double-loading safety/stpa and de-duplicate RENDER-REQ (#360)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -260,54 +260,19 @@ artifacts:
     tags: [integration, serde]
 
   # ── Rendering (STPA-derived) ──────────────────────────────────────────
-
-  - id: RENDER-REQ-001
-    type: requirement
-    title: Orthogonal edge routing
-    description: >
-      Edges must use orthogonal routing to minimize visual crossings.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-002
-    type: requirement
-    title: Port visibility with directional indicators
-    description: >
-      Ports must be visible with directional indicators and type coloring.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-003
-    type: requirement
-    title: Interactive HTML with zoom/pan/minimap/search
-    description: >
-      Interactive HTML output must support zoom, pan, minimap, and search.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-004
-    type: requirement
-    title: Deterministic layout
-    description: >
-      Layout must be deterministic — same model always produces same layout.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-005
-    type: requirement
-    title: Selection and group highlighting
-    description: >
-      Selection and group highlighting must be supported in interactive mode.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-006
-    type: requirement
-    title: Semantic zoom for overview levels
-    description: >
-      Semantic zoom must reduce clutter at overview levels.
-    status: partial
-    tags: [rendering, stpa]
+  #
+  # RENDER-REQ-001..006 are NOT defined here. They live in
+  # safety/stpa/rendering-analysis.yaml, which is the canonical copy: it
+  # carries the hazards/satisfies/verified-by trace links that make them
+  # part of the STPA V, and the stubs that used to sit here carried none.
+  #
+  # Both files defined all six ids until #360. rivet silently kept ONE and
+  # dropped the other with no diagnostic, and which one won was load order,
+  # not a decision. The stubs were stale in BOTH directions -- they claimed
+  # RENDER-REQ-003 `implemented` (it is `partial`: minimap/search are
+  # Phase 3b, still `reserved` in etch) and RENDER-REQ-006 `partial` (it is
+  # `implemented`: etch/src/html.rs emits svg.zoom-low / svg.zoom-overview
+  # behind a wheel handler). Do not re-add them here.
 
   - id: REQ-WASM-001
     type: requirement

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -732,7 +732,7 @@ artifacts:
 
   - id: VAL-CODEGEN-001
     type: feature
-    status: pass
+    status: passing
     title: Golden model integration tests for codegen
     description: >
       19 golden model integration tests validating end-to-end code generation
@@ -754,7 +754,7 @@ artifacts:
 
   - id: VAL-CODEGEN-002
     type: feature
-    status: pass
+    status: passing
     title: WIT/Rust/Config/Test/Proof generation output validation
     description: >
       Tests validating each codegen output layer independently: WIT interface
@@ -795,7 +795,7 @@ artifacts:
 
   - id: VAL-SYSML2-LOWER-001
     type: feature
-    status: pass
+    status: passing
     title: SysML v2 lowering tests
     description: >
       Tests for SysML v2 to AADL lowering covering diagnostic handling for
@@ -814,7 +814,7 @@ artifacts:
 
   - id: VAL-VERIFY-MACROS-001
     type: feature
-    status: pass
+    status: passing
     title: Verify macro proc-macro tests
     description: >
       Tests for spar-verify-macros proc-macro crate covering #[aadl(...)]
@@ -837,7 +837,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — solver output implies no deadline miss
     description: >
       kani_schedule_implies_no_deadline_miss harness: for any TaskSet of
@@ -861,7 +861,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-002
     type: feature
-    status: pending
+    status: planned
     title: Kani — priority ordering is monotone and antisymmetric
     description: >
       kani_priority_monotonicity harness: for any two tasks in a ≤4-task
@@ -885,7 +885,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-003
     type: feature
-    status: pending
+    status: planned
     title: Kani — EDF accepts U=1 at n=2, RM rejects
     description: >
       kani_zero_laxity_handled harness: a 2-task implicit-deadline set
@@ -909,7 +909,7 @@ artifacts:
 
   - id: VAL-KANI-CODEGEN-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — codegen emission preserves schedule task IDs
     description: >
       kani_emit_preserves_schedule harness: for any Schedule of size
@@ -980,7 +980,7 @@ artifacts:
 
   - id: VAL-MUTATION-001
     type: feature
-    status: pass
+    status: passing
     title: Mutation testing for analysis passes
     description: >
       Mutation testing campaign covering 674 analysis tests. Validates that

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -18,16 +18,16 @@ project:
 sources:
   - path: artifacts
     format: generic-yaml
+  # The directory scan below already loads every *.yaml under safety/stpa.
+  # Four of those files used to ALSO be listed individually, to force
+  # `format: generic-yaml` on them — which loaded each one twice and made
+  # every id in it collide with itself: 184 phantom "declared more than
+  # once" errors, one per id, with the same path on both sides of the
+  # message (#360). The explicit entries are removed; see the measurement
+  # in the PR for the artifact-set equivalence check that says the
+  # directory scan alone loses nothing.
   - path: safety/stpa
     format: stpa-yaml
-  - path: safety/stpa/requirements.yaml
-    format: generic-yaml
-  - path: safety/stpa/architecture.yaml
-    format: generic-yaml
-  - path: safety/stpa/validation.yaml
-    format: generic-yaml
-  - path: safety/stpa/solver-requirements.yaml
-    format: generic-yaml
 
 docs:
   - docs

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -23,9 +23,28 @@ sources:
   # `format: generic-yaml` on them — which loaded each one twice and made
   # every id in it collide with itself: 184 phantom "declared more than
   # once" errors, one per id, with the same path on both sides of the
-  # message (#360). The explicit entries are removed; see the measurement
-  # in the PR for the artifact-set equivalence check that says the
-  # directory scan alone loses nothing.
+  # message (#360). The explicit entries are removed.
+  #
+  # This is NOT free, and the PR's first measurement said it was — wrongly.
+  # `rivet list --format json` WITHOUT `--full` emits only the summary view
+  # (`--help`: it omits `description`, `tags`, and `fields`), so the
+  # "byte-identical, loses nothing" equivalence check was run on a view
+  # structurally incapable of seeing field-level loss — the exact class of
+  # change a `format:` switch produces. Re-measured with `--full`:
+  #
+  #   +86 artifacts GAIN `mitigates` and `traces-to` (stpa-yaml really is
+  #       broadly a superset — but the original measurement didn't show that
+  #       either, it showed nothing)
+  #    -5 artifacts LOSE half of `test-name`: VAL-010/011/014/015/021 are
+  #       exactly the five whose on-disk value is a comma-separated pair, and
+  #       the stpa-yaml parser keeps only the first element.
+  #
+  #       on disk: tests::boolean_matches_aadl_boolean, tests::boolean_mismatches_aadl_string
+  #       rivet:   tests::boolean_matches_aadl_boolean
+  #
+  # Accepted deliberately — five truncated evidence pointers against 190
+  # phantom duplicate-id errors — and filed upstream as pulseengine/rivet#747
+  # rather than silently absorbed. Revert this trade if #747 lands a fix.
   - path: safety/stpa
     format: stpa-yaml
 


### PR DESCRIPTION
> [!WARNING]
> **Two claims below were refuted by cold-context verification and are withdrawn.** See [the correction comment](https://github.com/pulseengine/spar/pull/368#issuecomment-5134269008) and #371.
>
> 1. **"the directory scan alone loses nothing"** — measured on `rivet list --format json` *without* `--full`, a view that omits `fields` entirely. Re-measured: 5 artifacts (VAL-010/011/014/015/021) lose half their `test-name`. Fixed in `cce6fbd`; filed upstream as pulseengine/rivet#747.
> 2. **"the repo cannot widen `allowed-values` locally"** and its corollaries **"the v0.4.3 pin is load-bearing"** / **"measured as not viable"** — false. Vendoring `schemas/common.yaml` (v0.3.0, same as embedded) and widening the vocabulary takes `rivet validate` 276 → 0, exit 0. The remedy is still declined, but on the merits (#371), not on a constraint that doesn't exist.
>
> The duplicate-id result — 190 → 6 → **0** — is unaffected and was independently confirmed exact at all four measurement rows.

---

Closes #360.

`rivet validate` reported **466 errors on a clean tree**. This takes it to 276,
eliminates the duplicate-id class entirely, and — where the issue's own plan was
wrong — says so with the measurement rather than quietly dropping that step.

## The 190 phantom duplicates

`rivet.yaml` listed `safety/stpa` as a directory scan **and** listed four files
inside it individually, to force `format: generic-yaml` on them. Each of those
files was therefore loaded twice, and every id in them was "declared more than
once" — **colliding with itself**, with the same path on both sides of the
message.

Listing a directory and its own contents isn't additive, it's duplicative, and
the diagnostic couldn't hint at that because both copies had identical
provenance.

**Equivalence was measured, not assumed.** Dropping the explicit entries changes
those files' parse format, so before/after `rivet list --format json` was
compared: **883 ids and 1195 links, byte-identical**. `stpa-yaml` is a superset
of what `generic-yaml` was extracting here.

## The 6 real ones

`RENDER-REQ-001..006` were defined in **both** `artifacts/requirements.yaml` and
`safety/stpa/rendering-analysis.yaml`. rivet kept one copy and dropped the other
**with no diagnostic**, and which one won was load order, not a decision.

I deleted the `requirements.yaml` stubs and kept the STPA copy, because only the
STPA file carries the `hazards`/`satisfies`/`verified-by` links that make these
part of the STPA V. The stubs carried none.

**The stubs were stale in both directions**, which is why I checked against
source instead of keeping whichever file looked fresher:

| id | stub said | actually | evidence |
|----|-----------|----------|----------|
| RENDER-REQ-003 | `implemented` | `partial` | `minimap` is `/// Show minimap (Phase 3b — reserved)` |
| RENDER-REQ-006 | `partial` | `implemented` | `etch/src/html.rs:65-68` emits `svg.zoom-low` / `svg.zoom-overview`; `:131` asserts a `wheel` handler |

Verified at the **pinned etch rev `4c06709`**, not by grepping this repo — and
that distinction nearly cost me a false finding. A repo-scoped grep shows
`zoom-low` only in a checked-in playwright fixture and `semantic zoom` only in a
README bullet, which reads exactly like "asserted against a hand-authored
artifact, never implemented." It reads that way because the implementation lives
in a **git dependency**. "Not in this repo" and "not implemented" are
indistinguishable to grep.

## Where the issue was wrong

#360 predicted that with the overlap and the vocabulary both fixed, "the
residual 0.28.0 error count should be near zero." **That is false, and this PR
measures it rather than asserting it:**

| step | errors | duplicate-id |
|------|--------|--------------|
| baseline | 466 | 190 |
| drop source overlap | 282 | 6 |
| delete RENDER-REQ stubs | 276 | **0** |
| normalise `pass`/`pending` | **276** | 0 |

The normalisation **cannot** reduce the count, because its targets aren't in the
allowed set either:

```
allowed: draft, proposed, approved, implemented, verified,
         released, accepted, deprecated, rejected
```

Neither `passing` nor `planned` is there. So `pass` → `passing` moves 5 errors
between buckets (172 → 177) and `pending` → `planned` moves 4 (36 → 40). Net
zero, exactly as measured.

It's still worth doing — it leaves **4** non-conforming values to resolve instead
of 6 — but it is not an error fix, and booking it as one would have overstated
what this change buys.

## Why the v0.4.3 pin still can't be lifted

The residual 276 is entirely status-vocabulary skew: 177 `passing`, 51
`not-implemented`, 40 `planned`, 8 `partial`. These are **test/verification**
states, not approval-lifecycle states — a VAL record's "passing" is about whether
the test passes right now, which is a genuinely different axis from where an
artifact sits in an approval flow.

rivet names the two options itself: fix the artifacts, or add the values to the
`status` base-field's `allowed-values`. **The repo can't take the second one** —
`common@0.3.0` is embedded in the rivet binary, and `schemas/` only overrides
`sysml2`.

So `ci.yml`'s pin to `rivet-cli v0.4.3` is **load-bearing for the green check**,
not incidental. Lifting it turns a required context red with 276 errors that are
real under the current schema. The existing comment there calls a newer rivet's
findings "phantom errors"; for the duplicate-id class that was true and this PR
fixes it, but for the status class it isn't — those are genuine
non-conformances against `common@0.3.0` that the pin is holding back.

Resolving them is an upstream rivet conversation (does the lifecycle admit
test-execution states?), not something to force in this PR.

## What this does not do

- Does not reduce the 276 status errors. Named above with the reason.
- Does not lift the v0.4.3 pin. Measured as not viable; see above.
- Does not touch `safety/stpa/rendering-analysis.yaml`. The canonical statuses
  there were independently confirmed correct against etch, so there was nothing
  to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

