### PR TITLE
fix(artifacts): put `release:` on the plane rivet actually reads (#370)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,38 @@ jobs:
             --artifacts-dir artifacts \
             --artifacts-dir safety/stpa
 
+      # ── release-plane guardrail (#370) ────────────────────────────────
+      # rivet has two field planes. `release` is a CORE field, read by the CLI
+      # query surface (`rivet list --release vX.Y`); separately each artifact
+      # may carry a `fields:` bag for schema-declared custom keys. Writing
+      # `release:` into the bag is valid YAML, is tolerated by the schema, and
+      # is completely invisible to the query.
+      #
+      # 59 of 85 assignments were on the wrong plane. Eleven shipped releases
+      # returned ZERO artifacts from `rivet list --release` — which renders
+      # identically to a genuinely empty release. Release readiness in this
+      # project is a query ("what must we implement for vX.Y"), and for eleven
+      # releases the query was answering "nothing to do".
+      #
+      # rivet DID diagnose it — `INFO: field 'release' is not defined in
+      # schema`, once per offending artifact, all 59 correct and precise. They
+      # sat under 276 unrelated `ERROR:` lines from #371. This is a gate rather
+      # than a lint because the diagnostic already existed and was unreadable.
+      #
+      # Same stdlib-only, fail-closed rationale as the pair above.
+      - name: Release-plane guardrail self-test
+        # Runs FIRST, same reason. Asserts the finding COUNTS, not just the
+        # exit code: `exit 1` on the violation fixture is equally consistent
+        # with a checker that reports every `release:` it sees — one that does
+        # not discriminate on plane at all. Mutation-tested: each of the four
+        # fixtures kills exactly one guard, and deleting any guard reds this.
+        run: tools/check_release_plane.py --self-test
+      - name: Release-plane guardrail
+        run: |
+          tools/check_release_plane.py \
+            --artifacts-dir artifacts \
+            --artifacts-dir safety/stpa
+
   # ── Bazel test sweep ───────────────────────────────────────────────
   # Issue #135 acceptance: `bazel test //...` to pick up Rust + Lean
   # targets via tools/bazel/rules_lean and rules_wasm_component.

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -585,8 +585,7 @@ artifacts:
       survives lexing + lowering intact.
     status: verified
     tags: [parsing, lexer, literals, as5506, bug]
-    fields:
-      release: v0.31.0
+    release: v0.31.0
     links:
       - type: traces-to
         target: REQ-PARSER-001
@@ -626,8 +625,7 @@ artifacts:
       malformed input (that command remains a best-effort structural dump).
     status: verified
     tags: [parsing, lexer, literals, as5506, bug]
-    fields:
-      release: v0.32.0
+    release: v0.32.0
     links:
       - type: traces-to
         target: REQ-PARSER-001
@@ -676,8 +674,8 @@ artifacts:
       bindings) or produce incompatible analysis results.
     status: planned
     tags: [diff, merge, v040]
+    release: v0.23.0
     fields:
-      release: v0.23.0
 
   # ── MCP Server ───────────────────────────────────────────────────────
 
@@ -690,8 +688,8 @@ artifacts:
       elements as MCP resources over stdio JSON-RPC transport.
     status: implemented
     tags: [mcp, integration, v040]
+    release: v0.14.0
     fields:
-      release: v0.14.0
 
   # ── Query Language ───────────────────────────────────────────────────
 
@@ -705,8 +703,8 @@ artifacts:
       and aggregation.
     status: planned
     tags: [query, instance, v040]
+    release: v0.23.0
     fields:
-      release: v0.23.0
 
   # ── Deployment Solver (v0.4.0+) ──────────────────────────────────────
 
@@ -756,9 +754,7 @@ artifacts:
       cost). Local solutions compose into globally valid configurations.
     status: planned
     tags: [solver, optimization, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-SOLVER-005
     type: requirement
     title: Optimality certificates for deployment solutions
@@ -769,9 +765,7 @@ artifacts:
       Uses dual bounds from MILP or exhaustive search proofs from CP-SAT.
     status: planned
     tags: [solver, verification, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-SOLVER-006
     type: requirement
     title: Multi-objective Pareto front computation
@@ -782,9 +776,7 @@ artifacts:
       both exact Pareto (small problems) and approximate (NSGA-II for large).
     status: planned
     tags: [solver, optimization, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-SOLVER-007
     type: requirement
     title: Source rewriting to apply deployment solutions
@@ -807,9 +799,7 @@ artifacts:
       ASIL, DO-178C DAL, and IEC 61508 SIL.
     status: planned
     tags: [solver, safety, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-SOLVER-009
     type: requirement
     title: Security zone and conduit validation
@@ -820,8 +810,8 @@ artifacts:
       security overhead (TLS latency, MAC computation) in timing analysis.
     status: planned
     tags: [solver, security, v040]
+    release: v0.23.0
     fields:
-      release: v0.23.0
 
   # ── Competitive Gap Requirements (v0.4.0+) ─────────────────────────
 
@@ -838,9 +828,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-TRANSFORM-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-WIT
     type: requirement
     title: Generate WIT interfaces from AADL processes
@@ -854,9 +842,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.13.0
-
+    release: v0.13.0
   - id: REQ-CODEGEN-RUST
     type: requirement
     title: Generate Rust crate skeletons from AADL
@@ -870,9 +856,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-BAZEL
     type: requirement
     title: Generate Bazel BUILD files for WASM + verification
@@ -887,9 +871,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-VERIFY-BUILD
     type: requirement
     title: Build-time AADL attribute verification
@@ -903,9 +885,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-VERIFY-TEST
     type: requirement
     title: Test-time contract + timing verification
@@ -919,9 +899,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-VERIFY-PROOF
     type: requirement
     title: Formal proof generation (Lean4 + Kani)
@@ -935,9 +913,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-CODEGEN-RIVET
     type: requirement
     title: Generate rivet design docs + verification artifacts
@@ -951,9 +927,7 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-001
-    fields:
-      release: v0.14.0
-
+    release: v0.14.0
   - id: REQ-KANI-CODEGEN-001
     type: requirement
     title: Kani harnesses for generated-code AADL contract preservation
@@ -1028,9 +1002,7 @@ artifacts:
       interactive zoom.
     status: planned
     tags: [visualization, scheduling, competitive-gap, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-SECURITY-001
     type: requirement
     title: Security rules analysis
@@ -1056,9 +1028,7 @@ artifacts:
       Resolute supports claim trees with sub-claims and computed evidence.
     status: planned
     tags: [verification, competitive-gap, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-BIDIRECTIONAL-001
     type: requirement
     title: Bidirectional diagram editing
@@ -1109,9 +1079,7 @@ artifacts:
       Requirements flow into rivet, trace to AADL components via spar verify.
     status: planned
     tags: [interop, requirements, v040]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-INTEROP-003
     type: requirement
     title: Capella/ARCADIA to AADL bridge
@@ -1655,9 +1623,7 @@ artifacts:
       Calculus for TSN; verified 2026-06-16 by independent falsification.]
     status: implemented
     tags: [network, tsn, wctt, network-calculus, soundness, tier1]
-    fields:
-      release: v0.21.0
-
+    release: v0.21.0
   - id: REQ-TSN-003
     type: requirement
     title: 802.1Qav CBS credit-pool service curve
@@ -2491,9 +2457,7 @@ artifacts:
       lacked). A no-EMV2 / port-only model must still yield 0.
     status: proposed
     tags: [emv2, analysis, safety, binding, capability]
-    fields:
-      release: v0.24.0
-
+    release: v0.24.0
   - id: REQ-WRPC-BINDING-002
     type: requirement
     title: Honor per-connection Actual_Connection_Binding (applies to <conn>) in wrpc-binding
@@ -2517,9 +2481,7 @@ artifacts:
       reference forms the resolver can't yet follow. Tracks GitHub #281.
     status: implemented
     tags: [wrpc, binding, analysis, bug]
-    fields:
-      release: v0.21.0
-
+    release: v0.21.0
   - id: REQ-WRPC-BINDING-003
     type: requirement
     title: Verify wrpc-binding Actual_Connection_Binding resolves to an actual bus
@@ -2795,8 +2757,7 @@ artifacts:
       into generate_wit. Follow-up recorded in #254/#255.
     status: implemented
     tags: [codegen, wit, interop]
-    fields:
-      release: v0.14.0
+    release: v0.14.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT
@@ -3415,8 +3376,7 @@ artifacts:
       runnable test/verification harness. Related to #319.
     status: proposed
     tags: [codegen, verify, workspace, bug]
-    fields:
-      release: v0.24.0
+    release: v0.24.0
     links:
       - type: traces-to
         target: REQ-CODEGEN-WIT-RECORDS-002
@@ -3432,8 +3392,7 @@ artifacts:
       calculus. Tracks issue #261.
     status: implemented
     tags: [proofs, lean, scheduling]
-    fields:
-      release: v0.15.0
+    release: v0.15.0
     links:
       - type: traces-to
         target: REQ-ANALYSIS-002
@@ -3466,8 +3425,7 @@ artifacts:
       network-calculus export in DEC-TSN-OSS-001.
     status: proposed
     tags: [proofs, lean, scheduling, kiln, substrate]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-PROOF-SCHED-001
@@ -3616,9 +3574,7 @@ artifacts:
       sysml2 and REQ-INGEST-ARXML-001 remain peer front-ends.
     status: proposed
     tags: [ingest, sysml2, grammar]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-PLUGFEST-002
     type: requirement
     title: "Plug-fest Tier-B — OSATE-in-Docker adjudication oracle + AAXL2 round-trip"
@@ -3631,8 +3587,7 @@ artifacts:
       Tier-B of issue #246.
     status: proposed
     tags: [interop, plugfest, osate]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -3656,8 +3611,7 @@ artifacts:
       REQ-PLUGFEST-005 under the Tier-B EMV2 oracle work. Issue #246.
     status: implemented
     tags: [parser, plugfest]
-    fields:
-      release: v0.16.0
+    release: v0.16.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -3675,8 +3629,7 @@ artifacts:
       spar invents but OSATE rejects is a false win). Issue #246.
     status: proposed
     tags: [parser, plugfest, emv2]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -3691,8 +3644,7 @@ artifacts:
       issue #246.
     status: proposed
     tags: [interop, plugfest, ocarina]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-PLUGFEST-001
@@ -3712,8 +3664,7 @@ artifacts:
       engine.rs §"Deliberately deferred"). Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-002
@@ -3731,8 +3682,7 @@ artifacts:
       DBC+FP-TFA TSN spine. Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-005
@@ -3751,8 +3701,7 @@ artifacts:
       DBC+FP-TFA TSN spine. Moved to v0.19.0.
     status: proposed
     tags: [trace-topology, reconciler, attestation]
-    fields:
-      release: v0.23.0
+    release: v0.23.0
     links:
       - type: traces-to
         target: REQ-TRACE-TOPOLOGY-008
@@ -3782,9 +3731,7 @@ artifacts:
       ARXML ingest; license-clean, no XSD to bundle.
     status: implemented
     tags: [ingest, dbc, can, tier1]
-    fields:
-      release: v0.17.0
-
+    release: v0.17.0
   - id: REQ-INGEST-DBC-FLOWS-001
     type: requirement
     title: "DBC message flows as AADL ports + bus connections"
@@ -3813,9 +3760,7 @@ artifacts:
       instantiate with zero diagnostics).
     status: implemented
     tags: [ingest, dbc, can, flows, tier1]
-    fields:
-      release: v0.20.0
-
+    release: v0.20.0
   - id: REQ-INGEST-ARXML-001
     type: requirement
     title: "ARXML (AUTOSAR) model ingest"
@@ -3831,9 +3776,7 @@ artifacts:
       carries enough for the target analysis.
     status: proposed
     tags: [ingest, arxml, autosar, tier1]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-NC-TFA-001
     type: requirement
     title: "FP-TFA / TFA++ network-calculus bounds"
@@ -3845,9 +3788,7 @@ artifacts:
       and the kiln async-scheduler math. [SOLID — Bouillard 2021]
     status: implemented
     tags: [network-calculus, tfa, substrate, tier1]
-    fields:
-      release: v0.17.0
-
+    release: v0.17.0
   - id: REQ-NC-PLP-001
     type: requirement
     title: "PLP (polynomial-LP) network-calculus bounds — feed-forward"
@@ -3890,9 +3831,7 @@ artifacts:
       [SOLID — Bouillard arXiv:2010.09263]
     status: implemented
     tags: [network-calculus, plp, substrate, tier1]
-    fields:
-      release: v0.18.0
-
+    release: v0.18.0
   - id: REQ-NC-PLP-002
     type: requirement
     title: "PLP network-calculus bounds — generic / cyclic topology"
@@ -3918,9 +3857,7 @@ artifacts:
       arXiv:2010.09263; Tabatabaee/Bouillard/Le Boudec arXiv:2208.11400]
     status: proposed
     tags: [network-calculus, plp, cyclic, substrate, tier1]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-NC-PLP-CONVERGE-001
     type: requirement
     title: "PLP on converging sink-trees via topological relabel"
@@ -3955,9 +3892,7 @@ artifacts:
       [SOLID — Bouillard arXiv:2010.09263]
     status: implemented
     tags: [network-calculus, plp, converging, substrate, tier1]
-    fields:
-      release: v0.19.0
-
+    release: v0.19.0
   - id: REQ-NC-PLP-003
     type: requirement
     title: "PLP tightening to exact worst case (TFA-strengthened LP)"
@@ -3988,9 +3923,7 @@ artifacts:
       `oracles/panco/panco_bench.py`. [SOLID — Bouillard arXiv:2010.09263]
     status: implemented
     tags: [network-calculus, plp, substrate, tier1]
-    fields:
-      release: v0.19.0
-
+    release: v0.19.0
   - id: REQ-NC-PLP-MIN-001
     type: requirement
     title: "Authoritative per-flow NC bound = min(PLP, TFA)"
@@ -4082,9 +4015,7 @@ artifacts:
       REQ-NC-PLP-001, extract_network_graph, wctt::collect_streams]
     status: implemented
     tags: [network-calculus, bridge, tsn, substrate, tier1]
-    fields:
-      release: v0.18.0
-
+    release: v0.18.0
   - id: REQ-NC-VALIDATION-001
     type: requirement
     title: "NC-bound cross-validation against panco reference"
@@ -4108,9 +4039,7 @@ artifacts:
       [SOLID — Bouillard arXiv:2010.09263; Bouillard-Stea ValueTools 2012]
     status: implemented
     tags: [network-calculus, validation, oracle, substrate, tier1]
-    fields:
-      release: v0.18.0
-
+    release: v0.18.0
   - id: REQ-NC-CBS-AUDIT-001
     type: requirement
     title: "CBS/SP service-curve packetization audit"
@@ -4122,8 +4051,8 @@ artifacts:
       export leans on CBS curves (REQ-TSN-003). [SOLID]
     status: proposed
     tags: [network-calculus, cbs, qav, audit, tier1]
+    release: v0.23.0
     fields:
-      release: v0.23.0
 
   # --- Tier 2: the product bet (synthesis → export), kill-gated ---
 
@@ -4150,9 +4079,7 @@ artifacts:
       REQ-NC-PLP-CONVERGE-001 → REQ-NC-PLP-003. [SOLID]
     status: implemented
     tags: [tsn, synthesis, qbv, tier2]
-    fields:
-      release: v0.20.0
-
+    release: v0.20.0
   - id: REQ-TSN-SYNTH-QBV-SPLIT-BASE-001
     type: requirement
     title: "802.1Qbv window-splitting synthesis baseline — even K-split, smallest feasible K"
@@ -4181,9 +4108,7 @@ artifacts:
       synthesis (table-stakes vs RTaW), NOT the PLP≪TFA wedge. [SOLID]
     status: implemented
     tags: [tsn, synthesis, qbv, tier2]
-    fields:
-      release: v0.21.0
-
+    release: v0.21.0
   - id: REQ-TSN-SYNTH-QBV-GUARDBAND-001
     type: requirement
     title: "802.1Qbv guard-band-aware window-splitting (deployable GCL claim)"
@@ -4243,9 +4168,7 @@ artifacts:
       accepted ARXML→TSN+NC. [SOLID]
     status: proposed
     tags: [tsn, synthesis, qbv, tier2]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-NC-TAS-COMPOSE-001
     type: requirement
     title: "Sound network-wide composition of per-port TAS residual service curves (the PLP≪TFA wedge loop)"
@@ -4287,9 +4210,7 @@ artifacts:
       never exercises (C). [BLOCKED — research-grade]
     status: proposed
     tags: [network-calculus, tsn, tas, composition, wedge, research-grade, blocked]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-NC-SIM-FLOOR-001
     type: requirement
     title: "TAS-matched discrete-event simulation floor (oracle-kind-(a)) for gated-hop NC validation"
@@ -4309,9 +4230,7 @@ artifacts:
       it, the network-wide arm of REQ-TSN-SYNTH-MILP-001.
     status: proposed
     tags: [network-calculus, tsn, tas, simulation, oracle, substrate]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-NC-BUS-PAYLOAD-001
     type: requirement
     title: "Bus bandwidth shall report what it could not measure, not score it as zero"
@@ -4416,9 +4335,7 @@ artifacts:
       clean baseline yet. [gated]
     status: proposed
     tags: [tsn, synthesis, milp, tier2]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-TSN-SYNTH-CQF-BASE-001
     type: requirement
     title: "CQF synthesis baseline — single cycle-time, 2-buffer, literature-pinned delay bound"
@@ -4445,9 +4362,7 @@ artifacts:
       REQ-TSN-SYNTH-QBV-BASE-001 → REQ-TSN-SYNTH-QBV-001. [SOLID]
     status: implemented
     tags: [tsn, synthesis, cqf, tier2]
-    fields:
-      release: v0.20.0
-
+    release: v0.20.0
   - id: REQ-TSN-SYNTH-CQF-BRIDGE-001
     type: requirement
     title: "AADL→CQF synthesis bridge — extract CqfFlow inputs from a SystemInstance and synthesize end-to-end"
@@ -4476,9 +4391,7 @@ artifacts:
       synthesize_cqf plus the existing spar-network property readers). [SOLID]
     status: implemented
     tags: [tsn, synthesis, cqf, bridge, aadl, tier2]
-    fields:
-      release: v0.20.0
-
+    release: v0.20.0
   - id: REQ-TSN-SYNTH-CQF-001
     type: requirement
     title: "Multi-CQF / TCQF synthesis (heterogeneous cycles, injection planning, larger scale)"
@@ -4513,9 +4426,7 @@ artifacts:
       baseline. [RESEARCH-GRADE]
     status: proposed
     tags: [tsn, synthesis, cqf, tier2, research-grade]
-    fields:
-      release: v0.23.0
-
+    release: v0.23.0
   - id: REQ-TSN-SYNTH-CQF-LONGLINK-001
     type: requirement
     title: "Multi-buffer single-cycle CQF for long links (B-buffer dead-time accommodation)"
@@ -4603,9 +4514,7 @@ artifacts:
       [SOLID — IEEE 802.1Qcw-2023 ieee802-dot1q-sched YANG]
     status: implemented
     tags: [tsn, export, yang, netconf, tier2]
-    fields:
-      release: v0.20.0
-
+    release: v0.20.0
   - id: REQ-TSN-SYNTH-ONLINE-001
     type: requirement
     title: "Online / incremental TSN admission & reconfiguration"
@@ -4616,8 +4525,8 @@ artifacts:
       lacks entirely. Later-stage Tier 2. [SOLID relative]
     status: proposed
     tags: [tsn, synthesis, online, reconfiguration, tier2]
+    release: v0.23.0
     fields:
-      release: v0.23.0
 
   # --- Tier 3: internal soundness ratchet (parallel, never marketed) ---
 
@@ -4701,3 +4610,57 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-LAYOUT-CERT-001
+
+  - id: REQ-GUARD-RELEASE-PLANE-001
+    type: requirement
+    title: "`release:` shall sit on the plane rivet's query surface reads"
+    description: >
+      rivet has two field planes. `release` is a CORE field, read by the CLI
+      query surface — `rivet list --release vX.Y` is the release-planning view.
+      Separately, each artifact may carry a `fields:` bag for schema-declared
+      custom keys (for `requirement` the declared set is baseline, category,
+      cited-source, priority, upstream-ref). Writing `release:` into the bag is
+      valid YAML, is tolerated by the schema, and is completely invisible to the
+      query. This requirement is that every `release:` assignment in this repo
+      sits on the artifact's own key plane, enforced mechanically.
+
+      WHY: 59 of 85 assignments were on the wrong plane (#370). `rivet list`
+      reported 26 artifacts carrying a release; ELEVEN shipped releases —
+      v0.13.0 through v0.21.0, plus v0.31.0 and v0.32.0 — returned zero
+      artifacts each. Release readiness in this project is defined as a query
+      ("what must we implement for vX.Y" = release: vX.Y AND status != verified),
+      and for eleven releases' worth of scope that query answered "nothing to
+      do". The failure renders identically to a genuinely empty release: the
+      recurring shape here is that an operation which can produce "nothing
+      happened" must render differently from one that worked.
+
+      WHY A GATE AND NOT A LINT: rivet already diagnosed this correctly. It
+      emitted `INFO: field 'release' is not defined in schema` once per
+      offending artifact — all 59, precise, naming the exact ids. They sat under
+      276 unrelated `ERROR:` lines from the status-vocabulary defect tracked as
+      #371. A correct diagnostic buried under an unrelated noise floor is not a
+      diagnostic. The remedy is therefore an exit code, not better prose.
+
+      IMPLEMENTATION CONSTRAINT: stdlib-only python3, fail-closed, for the same
+      reasons as REQ-GUARD-HUMAN-SCOPED-001. Two distinct fail-closed guards
+      exist ("no sequence entries" and "parsed zero artifacts") and each has its
+      own fixture. The checker parses rather than greps: `release:` inside a
+      `description: >` block scalar is prose at a deeper indent, so the obvious
+      `grep -nE '^ {6,}release: '` would red the build for an English sentence.
+
+      SELF-TEST CONSTRAINT: the self-test asserts the finding COUNTS, not merely
+      the process exit code. `exit 1` on the violation fixture is equally
+      consistent with a checker that reports every `release:` it sees — one that
+      does not discriminate on plane at all — so the exit code alone is too
+      coarse to carry the claim the tool's own output makes. Verified by
+      mutation: four independent mutations (drop plane discrimination, drop
+      block-scalar tracking, drop either fail-closed guard) each red the
+      self-test, and each fixture kills exactly one guard. The fourth fixture
+      exists BECAUSE a mutation survived the first draft — deleting the "parsed
+      zero artifacts" raise left all three original self-tests green.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling, traceability]
+    links:
+      - type: traces-to
+        target: REQ-GUARD-HUMAN-SCOPED-001

--- a/safety/stpa/rendering-analysis.yaml
+++ b/safety/stpa/rendering-analysis.yaml
@@ -204,5 +204,4 @@ artifacts:
     hazards: [H-R3]
     satisfies: [ARCH-R4]
     verified-by: [VAL-R5]
-    fields:
-      release: v0.22.0
+    release: v0.22.0

--- a/tools/check_release_plane.py
+++ b/tools/check_release_plane.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Fail if a `release:` assignment is nested where rivet cannot read it.
+
+rivet has two field planes. `release` is a **core** field, read by the CLI's own
+query surface — `rivet list --release vX.Y` is documented as *"the
+release-planning view"*. Separately, each artifact may carry a `fields:` bag for
+schema-declared custom keys (for `requirement` the declared set is `baseline`,
+`category`, `cited-source`, `priority`, `upstream-ref`).
+
+Writing `release:` into the bag is valid YAML, is tolerated by the schema, and is
+completely invisible to the query:
+
+    - id: REQ-A            - id: REQ-B
+      status: proposed       status: proposed
+      release: v0.36.0       fields:
+                               release: v0.23.0
+      ^ rivet sees this               ^ rivet does not
+
+WHY THIS EXISTS
+    59 of 85 release assignments were on the wrong plane (#370). `rivet list`
+    reported 25 artifacts with a release and 856 without, and **eleven shipped
+    releases** — v0.13.0 through v0.21.0, v0.31.0, v0.32.0 — returned zero
+    artifacts each. Release readiness in this project is supposed to be a query
+    ("what must we implement for vX.Y" = `release: vX.Y` + status != verified);
+    that query was answering "nothing to do" for eleven releases' worth of scope.
+
+    The failure renders identically to a genuinely empty release. That is the
+    recurring shape here: an operation that can produce "nothing happened" must
+    render differently from one that worked.
+
+    rivet did emit `INFO: field 'release' is not defined in schema` for all 59 —
+    correct, precise, and buried under 276 unrelated `ERROR:` lines from #371. A
+    diagnostic nobody can see is not a diagnostic, which is why this is a gate.
+
+WHY NOT JUST GREP FOR SIX SPACES
+    Because `release:` also appears inside `description: >` prose, where deeper
+    indentation is meaningless and a grep would red the build for a sentence.
+    This parser tracks block scalars and skips their bodies. There is no such
+    line in the tree today; the handling exists so that adding one is not a
+    trap. See the `release-plane-block-scalar` self-test.
+
+WHY NO PyYAML
+    Same reason as check_human_scoped.py: no workflow here installs a Python
+    package, so a required check must not depend on an unverified runner
+    package. A guardrail that cannot run reads as approval. Stdlib only, and
+    fail-closed — input this parser cannot fully read exits 2, not 0.
+
+Usage:
+    tools/check_release_plane.py [--artifacts-dir DIR ...]
+
+Exit code:
+    0  every `release:` assignment is on the artifact's own key plane
+    1  at least one is nested where rivet cannot read it (each listed on stderr)
+    2  INCONCLUSIVE — input unreadable, or syntax this parser does not fully
+       understand. Deliberately distinct from 1: "violated" and "could not
+       check" are different facts and must not be conflated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+#: A sequence entry. The *shallowest* such indent in a file is the artifact-list
+#: level; anything deeper is a nested sequence (e.g. `fields.steps`).
+_ITEM_RE = re.compile(r"^(?P<indent> *)-(?: +(?P<rest>\S.*))?$")
+
+#: A scalar mapping key.
+_KEY_RE = re.compile(r"^(?P<indent> *)(?P<key>[A-Za-z_][A-Za-z0-9_-]*): *(?P<val>.*)$")
+
+#: A block-scalar introducer: `>`, `|`, with optional chomping/indent modifiers
+#: (`>-`, `|+`, `>2`) and nothing else on the line.
+_BLOCK_RE = re.compile(r"^[>|][+-]?\d*$")
+
+FIELD = "release"
+
+
+class Unsupported(Exception):
+    """Input uses YAML this parser does not fully handle — never guess past it."""
+
+
+def scan_file(path: str) -> tuple[list[tuple[str, int, int]], int]:
+    """Return (findings, visible_count) for *path*.
+
+    A finding is (artifact_id, lineno, indent) for a `release:` key nested
+    deeper than the artifact's own key plane. `visible_count` counts the ones
+    correctly placed, so the caller can tell "all good" from "nothing to check".
+    """
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().splitlines()
+
+    indents = [m.group("indent") for m in (_ITEM_RE.match(ln) for ln in lines) if m]
+    if not indents:
+        raise Unsupported(f"{path}: no sequence entries found — is this artifact YAML?")
+    item_indent = min(len(i) for i in indents)
+    key_indent = item_indent + 2
+
+    findings: list[tuple[str, int, int]] = []
+    visible = 0
+    current_id: str | None = None
+    seen_record = False
+    #: While non-None, we are inside a block scalar introduced by a key at this
+    #: indent; every line indented deeper is prose and must not be parsed.
+    block_at: int | None = None
+
+    for lineno, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+
+        stripped_indent = len(line) - len(line.lstrip(" "))
+        if block_at is not None:
+            if stripped_indent > block_at:
+                continue  # prose inside a block scalar
+            block_at = None
+
+        if line.lstrip().startswith("#"):
+            continue
+
+        item = _ITEM_RE.match(line)
+        if item and len(item.group("indent")) == item_indent:
+            seen_record = True
+            current_id = None
+            inline = item.group("rest")
+            if inline:
+                kv = _KEY_RE.match(inline)
+                if kv and kv.group("key") == "id":
+                    current_id = kv.group("val").strip()
+            continue
+
+        kv = _KEY_RE.match(line)
+        if not kv:
+            continue
+
+        indent = len(kv.group("indent"))
+        key = kv.group("key")
+        val = kv.group("val").strip()
+
+        if key == "id" and indent == key_indent:
+            current_id = val
+
+        if _BLOCK_RE.match(val):
+            block_at = indent
+            continue
+
+        if key == FIELD and seen_record:
+            if indent == key_indent:
+                visible += 1
+            elif indent > key_indent:
+                findings.append((current_id or f"<unnamed>", lineno, indent))
+
+    if not seen_record:
+        raise Unsupported(f"{path}: parsed zero artifacts.")
+    return findings, visible
+
+
+def collect(dirs: list[str]) -> tuple[list[tuple[str, str, int, int]], int, int]:
+    """Return (findings, visible_count, files_scanned) across *dirs*.
+
+    Split out from run_check so the self-test can assert on the finding SET
+    rather than on the process's single-integer summary. `exit 1` is necessary
+    for "reported the nested one" but not sufficient — it is equally consistent
+    with reporting every `release:` in the file, which is the specific bug the
+    violation fixture exists to rule out.
+    """
+    all_findings: list[tuple[str, str, int, int]] = []
+    total_visible = 0
+    scanned = 0
+    for artifacts_dir in dirs:
+        paths = sorted(glob.glob(os.path.join(artifacts_dir, "*.yaml")))
+        if not paths:
+            raise Unsupported(f"no *.yaml under {artifacts_dir!r}")
+        for path in paths:
+            findings, visible = scan_file(path)
+            scanned += 1
+            total_visible += visible
+            base = os.path.basename(path)
+            all_findings.extend((base, i, ln, ind) for i, ln, ind in findings)
+    return all_findings, total_visible, scanned
+
+
+def run_check(dirs: list[str], out=None, err=None) -> int:
+    """The whole check. Returns the process exit code (see module docstring)."""
+    out = out or sys.stdout
+    err = err or sys.stderr
+
+    try:
+        all_findings, total_visible, scanned = collect(dirs)
+    except (OSError, Unsupported) as exc:
+        print(f"INCONCLUSIVE: {exc}", file=err)
+        print(
+            "This check could not read its input, which is NOT the same as the "
+            "property holding. Treat it as red.",
+            file=err,
+        )
+        return 2
+
+    print("== release-plane guardrail ==", file=out)
+    print(f"files scanned: {scanned} from {', '.join(d + '/' for d in dirs)}", file=out)
+    print(f"`{FIELD}:` on the artifact key plane (rivet sees these): {total_visible}", file=out)
+    print(f"`{FIELD}:` nested deeper (rivet is blind to these):     {len(all_findings)}", file=out)
+
+    if total_visible == 0 and not all_findings:
+        # A guardrail with nothing to guard passes trivially, which is how a
+        # check silently becomes decorative. Say so rather than printing a
+        # reassuring nothing.
+        print(
+            f"WARNING: no `{FIELD}:` assignment found anywhere, so this check "
+            f"asserted nothing.",
+            file=err,
+        )
+
+    if all_findings:
+        print(file=err)
+        print(
+            f"error: {len(all_findings)} `{FIELD}:` assignment(s) are nested "
+            f"below the artifact's own keys, where rivet cannot read them.",
+            file=err,
+        )
+        for source, art_id, lineno, indent in all_findings:
+            print(f"  {art_id}: {source}:{lineno} (indent {indent})", file=err)
+        print(file=err)
+        print(
+            f"Move `{FIELD}:` to the artifact's own key level — a sibling of "
+            f"`status:` and `tags:`, not a member of `fields:`. Verify with "
+            f"`rivet list --release <version>`: it must return the artifact.",
+            file=err,
+        )
+        return 1
+
+    return 0
+
+
+#: (fixture directory, required exit code, required nested count, required
+#: visible count, what it proves). `None` for a count means "not asserted"
+#: — used only where collect() raises and there are no counts to assert.
+#:
+#: These run on every CI invocation via --self-test. A guardrail exercised only
+#: against compliant input cannot distinguish "the property holds" from "the
+#: check does nothing".
+#:
+#: The counts are asserted, not just the exit code, because the exit code is
+#: too coarse to carry the claim. `exit 1` on the violation fixture is equally
+#: consistent with a checker that reports EVERY `release:` it sees — which
+#: would be a checker that does not discriminate on plane at all, i.e. exactly
+#: the regression this fixture is here to catch. (nested=1, visible=1) is the
+#: assertion that actually means what the `proves` text says.
+SELF_TESTS = [
+    (
+        "release-plane-violation",
+        1,
+        1,
+        1,
+        "a `fields:`-nested release is reported, while a top-level one in the "
+        "same file is NOT (nested=1, visible=1, from two artifacts differing "
+        "only in indentation) — so the check discriminates on PLANE, not "
+        "merely on the presence of a `release:` key",
+    ),
+    (
+        "release-plane-block-scalar",
+        0,
+        0,
+        1,
+        "`release:` appearing inside a `description: >` block scalar is prose, "
+        "not an assignment, and does not trip the check — a plain indentation "
+        "grep would red the build here. visible=1 pins that the file was still "
+        "genuinely parsed, so exit 0 is not the silence of a dead parser",
+    ),
+    (
+        "release-plane-unsupported",
+        2,
+        None,
+        None,
+        "an artifact layout the parser cannot read is refused as INCONCLUSIVE "
+        "rather than passing vacuously — note the fixture's only `release:` is "
+        "fields-nested, so a checker without the guard would exit 0, not 1",
+    ),
+    (
+        "release-plane-no-artifacts",
+        2,
+        None,
+        None,
+        "the SECOND fail-closed guard fires: sequence syntax was found, an "
+        "artifact plane was inferred from it, and zero artifacts parsed at "
+        "that plane. Added because a mutation test showed deleting this raise "
+        "left the other three self-tests green",
+    ),
+]
+
+
+def self_test() -> int:
+    """Assert the checker still fails on input it must fail on."""
+    fixtures = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+    devnull = open(os.devnull, "w", encoding="utf-8")
+    failures = 0
+    for name, want, want_nested, want_visible, proves in SELF_TESTS:
+        path = os.path.join(fixtures, name)
+        got = run_check([path], devnull, devnull)
+        detail = f"exit {got} (want {want})"
+        ok = got == want
+        if want_nested is not None:
+            try:
+                findings, visible, _ = collect([path])
+                nested = len(findings)
+            except (OSError, Unsupported):
+                nested, visible = None, None
+            ok = ok and nested == want_nested and visible == want_visible
+            detail += (
+                f", nested {nested} (want {want_nested})"
+                f", visible {visible} (want {want_visible})"
+            )
+        failures += not ok
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+        print(f"       proves: {proves}")
+    devnull.close()
+    if failures:
+        print(
+            f"\nerror: {failures} self-test(s) failed — the guardrail is not "
+            f"detecting what it claims to detect.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\n{len(SELF_TESTS)} self-test(s) passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts-dir",
+        action="append",
+        dest="dirs",
+        metavar="DIR",
+        help="directory of rivet artifact YAML; repeatable (default: artifacts)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="verify the checker still rejects the fixtures, then exit",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    return run_check(args.dirs or ["artifacts"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fixtures/release-plane-block-scalar/requirements.yaml
+++ b/tools/fixtures/release-plane-block-scalar/requirements.yaml
@@ -1,0 +1,41 @@
+# Fixture for tools/check_release_plane.py — NOT part of the real trace.
+#
+# Proves the checker parses rather than greps. `release:` inside a
+# `description: >` block scalar is PROSE — it is indented deeper than the
+# artifact's key plane, so the obvious implementation
+#
+#     grep -nE '^ {6,}release: '
+#
+# reds the build for a sentence. There is no such line in the real tree today;
+# this fixture exists so that writing one is not a trap, and so the block-scalar
+# branch is an exercised claim rather than an asserted one.
+#
+# The second artifact carries a genuine top-level `release:`. Without it, exit 0
+# would be consistent with "the checker found nothing anywhere" — including a
+# checker that had stopped parsing entirely. With it, exit 0 means the checker
+# read the file, counted the real assignment, and still declined to count the
+# prose.
+artifacts:
+  - id: FIXTURE-RELEASE-PLANE-PROSE
+    type: requirement
+    title: release mentioned in prose, not assigned
+    description: >
+      This requirement was originally scoped for v0.23.0 and the field
+      release: v0.23.0 appeared in the plan at the time. The line above is
+      narrative — it is inside a folded block scalar, so YAML reads it as part
+      of this sentence and rivet never sees a `release` key here. A checker that
+      reports it is reporting an English sentence as a configuration defect.
+    status: proposed
+    fields:
+      category: fixture
+
+  - id: FIXTURE-RELEASE-PLANE-REAL
+    type: requirement
+    title: a real release assignment, so exit 0 is not vacuous
+    description: >
+      Carries an actual top-level `release:`. This is what makes the fixture
+      assert that the checker is still reading the file at all.
+    status: proposed
+    release: v0.36.0
+    fields:
+      category: fixture

--- a/tools/fixtures/release-plane-no-artifacts/requirements.yaml
+++ b/tools/fixtures/release-plane-no-artifacts/requirements.yaml
@@ -1,0 +1,35 @@
+# Fixture for tools/check_release_plane.py — NOT part of the real trace.
+#
+# Reaches the SECOND fail-closed guard. There are two, and they fire on
+# different inputs:
+#
+#   `no sequence entries found` — the file has no `- ` lines at all
+#                                 (see release-plane-unsupported)
+#   `parsed zero artifacts`     — the file HAS `- ` lines, the parser inferred
+#                                 an artifact plane from them, and then read
+#                                 zero artifacts at that plane  <- this fixture
+#
+# The second is reachable exactly when every `- ` line is inside a block scalar:
+# the artifact-plane indent is computed over raw lines (before block tracking),
+# but the parse loop correctly skips block bodies as prose. The result is a
+# self-inconsistent read — "I found a list, and there was no list" — which the
+# parser must refuse rather than resolve in its own favour.
+#
+# This fixture was added because a mutation test caught the gap: deleting the
+# `parsed zero artifacts` raise left all THREE original self-tests passing, so
+# the guard was an unexercised claim inside a checker whose entire purpose is
+# to distrust unexercised claims.
+#
+# Without the guard this file exits 0 with zero findings and zero visible
+# assignments. The `WARNING: ... asserted nothing` line does fire — and is not
+# enough: a warning on stderr does not fail a build. The exit code is the only
+# part CI reads, so the exit code is what has to differ.
+notes: >
+  Release plan for the next cycle. The following items are still open and
+  need a release assignment before the scope query is trustworthy:
+  - id: REQ-EXAMPLE-STILL-UNASSIGNED
+  - id: REQ-EXAMPLE-ALSO-UNASSIGNED
+  Neither line above is an artifact — both are prose inside this folded
+  scalar. A parser that treated them as records would invent two artifacts
+  that do not exist.
+release: v0.36.0

--- a/tools/fixtures/release-plane-unsupported/requirements.yaml
+++ b/tools/fixtures/release-plane-unsupported/requirements.yaml
@@ -1,0 +1,24 @@
+# Fixture for tools/check_release_plane.py — NOT part of the real trace.
+#
+# Proves the FAIL-CLOSED branch actually fires. The parser handles the block
+# *sequence* artifact layout — `artifacts:` followed by `- id: …` entries — which
+# is the sole form the real files use. This file uses a mapping keyed by id
+# instead, which is also legal rivet-ish YAML and which the parser cannot read.
+#
+# The tempting shortcut is to treat an unreadable layout as "no artifacts here,
+# nothing to report" and exit 0. That is the exact vacuity this whole check
+# exists to prevent: a guardrail that cannot see its input reads as approval.
+#
+# Note the artifact below is ALSO a would-be violation — its `release:` is in the
+# `fields:` bag. So if the fail-closed guard were removed, the checker would not
+# fall back to catching it as a violation; it would find zero sequence entries,
+# report zero findings, and exit 0. That is what makes 2-vs-0 the meaningful
+# assertion here rather than 2-vs-1.
+artifacts:
+  REQ-FIXTURE-MAPPING-STYLE:
+    type: requirement
+    title: Artifact in a layout the parser does not handle
+    status: verified
+    fields:
+      category: fixture
+      release: v0.36.0

--- a/tools/fixtures/release-plane-violation/requirements.yaml
+++ b/tools/fixtures/release-plane-violation/requirements.yaml
@@ -1,0 +1,38 @@
+# Fixture for tools/check_release_plane.py — NOT part of the real trace.
+#
+# The falsification edge. TEST-GUARD-RELEASE-PLANE runs the checker against
+# this directory and requires exit 1, so a regression that makes the checker
+# toothless turns the gate red instead of green.
+#
+# Two artifacts, deliberately differing ONLY in where `release:` sits. That is
+# what makes the fixture discriminate on the *plane* rather than on the mere
+# presence of a `release:` key — a checker that simply grepped for `release:`
+# would report both, and a checker that reported neither would also "pass" a
+# one-sided fixture. Requiring exactly one finding pins both edges at once.
+artifacts:
+  - id: FIXTURE-RELEASE-PLANE-NESTED
+    type: requirement
+    title: release recorded inside the fields bag (must be reported)
+    description: >
+      Represents the #370 failure: 59 of 85 release assignments were written
+      into the `fields:` extension bag, which is valid YAML and tolerated by
+      the schema but completely invisible to `rivet list --release`. Eleven
+      shipped releases reported zero artifacts as a result, rendering
+      identically to a genuinely empty release.
+    status: proposed
+    fields:
+      category: fixture
+      release: v0.23.0
+
+  - id: FIXTURE-RELEASE-PLANE-VISIBLE
+    type: requirement
+    title: release on the artifact's own key plane (must NOT be reported)
+    description: >
+      Identical to the artifact above except for the indentation of the
+      `release:` line. This is the correct placement — a sibling of `status:`,
+      which is where rivet's query surface reads it. Its presence here is what
+      forces the check to discriminate on plane rather than on the key.
+    status: proposed
+    release: v0.36.0
+    fields:
+      category: fixture


### PR DESCRIPTION
Closes #370.

## The defect

rivet has two field planes. `release` is a **core** field, read by the CLI query
surface — `rivet list --release vX.Y` is the release-planning view. Separately,
each artifact may carry a `fields:` bag for schema-declared custom keys (for
`requirement`: `baseline`, `category`, `cited-source`, `priority`,
`upstream-ref`). Writing `release:` into the bag is valid YAML, is tolerated by
the schema, and is **completely invisible to the query**.

```yaml
- id: REQ-A                - id: REQ-B
  status: proposed           status: proposed
  release: v0.36.0           fields:
                               release: v0.23.0
  ^ rivet sees this                     ^ rivet does not
```

59 of 85 assignments were in the bag.

## Measurement

A/B with **one binary** (rivet 0.28.0 local — note CI pins v0.4.3), same query,
`origin/main` @ `2b11af9` vs this branch:

| | before | after |
|---|---|---|
| artifacts with a release | 26 | **86** |
| releases populated | 18 | **29** |

The eleven that went from **zero artifacts** to non-zero are exactly the eleven
named in the issue — v0.13.0, v0.14.0, v0.15.0, v0.16.0, v0.17.0, v0.18.0,
v0.19.0, v0.20.0, v0.21.0, v0.31.0, v0.32.0. Every one is a **shipped** release
whose scope query answered "nothing to do".

(86 = 85 promoted/existing + 1 new artifact added by this PR.)

## Why it stayed hidden

rivet diagnosed it correctly and 59 times: `INFO: field 'release' is not defined
in schema`, naming the exact ids. Those lines sat under **276 unrelated `ERROR:`
lines** from the status-vocabulary defect tracked as #371.

A correct diagnostic buried under an unrelated noise floor is not a diagnostic.
So the remedy here is an exit code, not better prose.

## The transform

Text-level, so comments and block scalars survive; **semantically verified**
per-artifact through PyYAML — each artifact's release value must appear on the
new plane, all its other fields must be unchanged, and the id set must be
identical. 58 in `artifacts/requirements.yaml`, 1 in
`safety/stpa/rendering-analysis.yaml`.

## The gate

`tools/check_release_plane.py`, wired into the `rivet-validate` job — which
deliberately has no `changes` path filter, so it runs on every PR. Behind a
filter it would be skipped by exactly the artifact-light PR that reintroduces
the bug.

It **parses rather than greps**: `release:` inside a `description: >` block
scalar is prose at a deeper indent, so the obvious `grep -nE '^ {6,}release: '`
would red the build for an English sentence. Stdlib-only and fail-closed, same
rationale as `check_human_scoped.py`.

### The self-test asserts counts, not just the exit code

`exit 1` on the violation fixture is *necessary* for "reported the nested one"
but not *sufficient* — it is equally consistent with a checker that reports
**every** `release:` it sees, i.e. one that does not discriminate on plane at
all. So the self-test asserts `(nested, visible)`.

Mutation-tested. Each fixture kills exactly one guard:

| mutation | reds |
|---|---|
| drop plane discrimination | `violation`, `block-scalar` |
| drop block-scalar tracking | `block-scalar` |
| drop "parsed zero artifacts" guard | `no-artifacts` |
| drop "no sequence entries" guard | `unsupported` |

**The fourth fixture exists because a mutation survived the first draft.**
Deleting the `parsed zero artifacts` raise left all three original self-tests
green — making that guard an unexercised claim inside a checker whose entire
purpose is to distrust unexercised claims. `release-plane-no-artifacts` closes
it.

## Scope note

This does **not** fix #371 (the 276 `ERROR:` lines). `rivet validate` was A/B'd
before and after at the same error count with identical error classes; the noise
floor is unchanged and tracked separately.

Also note #137: `REQ-TSN-SYNTH-QBV-001` carries `status: proposed` with a stale
`release: v0.23.0` that is now *visible* to rivet for the first time. It needs
re-scoping; that is deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)