### PR TITLE
fix(artifacts): move 276 statuses onto rivet's lifecycle vocabulary

### DIFF
--- a/artifacts/architecture.yaml
+++ b/artifacts/architecture.yaml
@@ -456,7 +456,7 @@ artifacts:
 
   - id: ARCH-MCP-001
     type: design-decision
-    status: planned
+    status: proposed
     title: MCP server as CLI command with stdio JSON-RPC transport
     description: >
       The MCP server is a new spar CLI subcommand (spar mcp) that
@@ -503,7 +503,7 @@ artifacts:
 
   - id: ARCH-QUERY-001
     type: design-decision
-    status: planned
+    status: proposed
     title: "Path-expression query language: components.where().property() pattern"
     description: >
       Query expressions use a method-chain syntax over the instance model:
@@ -527,7 +527,7 @@ artifacts:
 
   - id: ARCH-KNOWLEDGE-001
     type: design-decision
-    status: planned
+    status: proposed
     title: Instance model is the knowledge base; query layer on top
     description: >
       The spar instance model (SystemInstance with its arena-allocated
@@ -555,7 +555,7 @@ artifacts:
 
   - id: ARCH-SOLVER-001
     type: design-decision
-    status: planned
+    status: proposed
     title: "NDS-layered hierarchical solving"
     description: >
       Deployment optimization uses 4 hierarchical layers analogous to NDS
@@ -659,7 +659,7 @@ artifacts:
 
   - id: ARCH-SOLVER-006
     type: design-decision
-    status: planned
+    status: proposed
     title: "Dual solver strategy (WASM heuristic + native exact)"
     description: >
       Two solver tiers. Tier 1 (WASM): pure Rust heuristics (FFD/BFD

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -121,7 +121,11 @@ artifacts:
     description: >
       Trace connections through the hierarchy resolving across, up,
       and down patterns to produce end-to-end connection instances.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      The unimplemented residue is deliberately not itemized here — see
+      REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [instance, as5506-ch14]
 
   - id: REQ-INST-004
@@ -226,7 +230,11 @@ artifacts:
       Enforce AADL naming rules, category restrictions, direction rules,
       connection rules, flow rules, binding rules, mode rules, and
       subcomponent rules. Target 50+ rules.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      How many rules are actually enforced against the 50+ target is
+      deliberately not asserted here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [analysis, legality]
 
   - id: REQ-ANALYSIS-008
@@ -309,7 +317,7 @@ artifacts:
     description: >
       Import cargo metadata to generate virtual AADL packages
       representing Rust crate architecture.
-    status: planned
+    status: proposed
     tags: [transform, rust]
 
   - id: REQ-TRANSFORM-003
@@ -318,7 +326,7 @@ artifacts:
     description: >
       Read WAC composition files and generate AADL system
       implementations with subcomponents and connections.
-    status: planned
+    status: proposed
     tags: [transform, wac]
 
   - id: REQ-TRANSFORM-004
@@ -327,7 +335,7 @@ artifacts:
     description: >
       Map wRPC transports (NATS, TCP, QUIC) to AADL bus components
       with deployment bindings.
-    status: planned
+    status: proposed
     tags: [transform, wrpc]
 
   - id: REQ-TRANSFORM-005
@@ -336,7 +344,7 @@ artifacts:
     description: >
       Map WASI P3 async functions, streams, and futures to AADL
       thread components with scheduling properties.
-    status: planned
+    status: proposed
     tags: [transform, wasi-p3]
 
   # ── STPA Analysis Coverage Records (STPA-REQ-022) ────────────────
@@ -428,7 +436,11 @@ artifacts:
     description: >
       modal.rs computes SOMs. Scheduling and latency analyses evaluate
       per-SOM when modal property associations exist.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which Ch.12 obligations remain open is deliberately not asserted
+      here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     links:
       - type: satisfies
         target: REQ-INST-004
@@ -466,7 +478,7 @@ artifacts:
       Not yet covered: Ch.7 (prototypes — parsed but not analyzed).
       Ch.6 type extensions now resolved via extends chain walking (v0.5.0).
       Property expression evaluation now covered by text fallback parser (v0.5.0).
-    status: partial
+    status: approved
     links:
       - type: satisfies
         target: REQ-MODEL-005
@@ -639,7 +651,7 @@ artifacts:
       Detect architectural conflicts in three-way merges where concurrent
       changes affect the same structural elements (components, connections,
       bindings) or produce incompatible analysis results.
-    status: planned
+    status: proposed
     tags: [diff, merge, v040]
     fields:
       release: v0.23.0
@@ -668,7 +680,7 @@ artifacts:
       category == thread).property(Period)) to select and filter instance
       model elements. Supports predicate filtering, property extraction,
       and aggregation.
-    status: planned
+    status: proposed
     tags: [query, instance, v040]
     fields:
       release: v0.23.0
@@ -719,7 +731,7 @@ artifacts:
       subsystems to hardware zones (topology + bandwidth + safety). Layer 3
       (Global) — optimize across all zones (E2E latency, safety decomposition,
       cost). Local solutions compose into globally valid configurations.
-    status: planned
+    status: proposed
     tags: [solver, optimization, v040]
     fields:
       release: v0.23.0
@@ -732,7 +744,7 @@ artifacts:
       machine-checkable certificate proving it is globally optimal (for
       exact methods) or within a bounded optimality gap (for heuristics).
       Uses dual bounds from MILP or exhaustive search proofs from CP-SAT.
-    status: planned
+    status: proposed
     tags: [solver, verification, v040]
     fields:
       release: v0.23.0
@@ -745,7 +757,7 @@ artifacts:
       maximize safety margins), compute the Pareto front of non-dominated
       solutions. Present to the engineer for interactive selection. Support
       both exact Pareto (small problems) and approximate (NSGA-II for large).
-    status: planned
+    status: proposed
     tags: [solver, optimization, v040]
     fields:
       release: v0.23.0
@@ -770,7 +782,7 @@ artifacts:
       freedom from interference is ensured (spatial via MMU, temporal via
       scheduling, communication via controlled interfaces). Supports ISO 26262
       ASIL, DO-178C DAL, and IEC 61508 SIL.
-    status: planned
+    status: proposed
     tags: [solver, safety, v040]
     fields:
       release: v0.23.0
@@ -783,7 +795,7 @@ artifacts:
       with security-level properties. Validate that cross-zone connections
       have appropriate protection (encryption, authentication). Account for
       security overhead (TLS latency, MAC computation) in timing analysis.
-    status: planned
+    status: proposed
     tags: [solver, security, v040]
     fields:
       release: v0.23.0
@@ -991,7 +1003,7 @@ artifacts:
       margins. Cheddar and Ellidiss MARZHIN offer this — spar has static
       RMA/RTA but no temporal visualization. Output as SVG/HTML with
       interactive zoom.
-    status: planned
+    status: proposed
     tags: [visualization, scheduling, competitive-gap, v040]
     fields:
       release: v0.23.0
@@ -1005,7 +1017,7 @@ artifacts:
       interfaces, secure boot chain verification, trust boundary validation.
       Ellidiss has a security rules checker; OSATE has none. Maps to
       IEC 62443 zones/conduits and ISO 21434 threat analysis.
-    status: planned
+    status: proposed
     tags: [security, competitive-gap, v040]
     links:
       - type: traces-to
@@ -1019,7 +1031,7 @@ artifacts:
       claims: hierarchical claim decomposition, evidence linking, and
       reusable claim libraries. Currently spar verify has flat assertions;
       Resolute supports claim trees with sub-claims and computed evidence.
-    status: planned
+    status: proposed
     tags: [verification, competitive-gap, v040]
     fields:
       release: v0.23.0
@@ -1033,7 +1045,7 @@ artifacts:
       to AADL source via rowan CST. Currently spar renders read-only
       diagrams. OSATE graphical editor and Ellidiss STOOD both support
       bidirectional editing.
-    status: planned
+    status: proposed
     tags: [rendering, editing, competitive-gap, v050]
 
   # ── Interoperability Requirements (v0.5.0+) ────────────────────────
@@ -1072,7 +1084,7 @@ artifacts:
       Import OMG ReqIF XML into rivet artifacts. Bridges enterprise ALM
       tools (DOORS, Jama, Polarion) with spar's architecture verification.
       Requirements flow into rivet, trace to AADL components via spar verify.
-    status: planned
+    status: proposed
     tags: [interop, requirements, v040]
     fields:
       release: v0.23.0
@@ -1085,7 +1097,7 @@ artifacts:
       implementations, Functional Chains → end-to-end flows, Components →
       AADL components. Lighter than the N7 Space Capella-to-TASTE bridge
       (no Eclipse dependency).
-    status: planned
+    status: proposed
     tags: [interop, capella, bridge, v050]
 
   - id: REQ-INTEROP-004
@@ -1096,7 +1108,7 @@ artifacts:
       → process/thread bindings, Service Instance Manifests → connections,
       Machine Manifests → processor configurations. Enables spar analysis
       on existing AUTOSAR models without manual AADL modeling.
-    status: planned
+    status: proposed
     tags: [interop, autosar, bridge, v050]
 
   # ── IRQ-aware RTA (Track A, v0.7.0) ────────────────────────────────
@@ -4666,3 +4678,61 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-CODEGEN-LAYOUT-CERT-001
+
+  - id: REQ-GUARD-STATUS-VOCAB-001
+    type: requirement
+    title: "`status:` shall be a member of the schema's allowed set"
+    description: >
+      Every artifact's `status:` shall be one of the nine values the active
+      schema allows (draft, proposed, approved, implemented, verified, released,
+      accepted, deprecated, rejected). spar had 276 that were not: `passing`,
+      `planned`, `not-implemented` and `partial` — a private vocabulary that
+      read as meaningful and validated as nothing.
+
+      WHY IT MATTERS: `passing` was the largest group (177). It is a verification
+      VERDICT living in a lifecycle field, and a hand-edited YAML file cannot
+      honestly assert that a test passes — only that the measure exists. The
+      status plane records where an artifact sits in its lifecycle; it is not
+      a place to record the result of a run nobody re-derives.
+
+      THE MAPPING, and what it costs: passing -> implemented, planned ->
+      proposed, not-implemented -> proposed, partial -> approved. Only the last
+      is lossy. `partial` sits strictly between `approved` and `implemented`,
+      and the vocabulary has no such rung, so `approved` is chosen as the
+      CONSERVATIVE FLOOR — the strongest claim that is certainly true —
+      rather than `implemented`, which would overstate. The eight affected
+      requirements each say so in their own description. Two of them
+      (RENDER-REQ-003, COVERAGE-GAPS) already itemized their residue and were
+      left alone; the other five state that the residue is NOT itemized. That
+      wording is deliberate: an explicit "not measured" is falsifiable, whereas
+      a plausible invented figure ("32 of 50 rules") is not, and inventing one
+      is the precise failure #294 was reopened for.
+
+      THE GUARD IS NOT NEW CODE. rivet already ships `status-allowed-values` at
+      ERROR severity, and `rivet validate` is already a required check, so the
+      regression is mechanically blocked from the moment this lands. Writing a
+      bespoke checker here would have added a second, weaker oracle next to a
+      working one. This is the opposite of REQ-GUARD-RELEASE-PLANE-001, which
+      needed a tool precisely because rivet was BLIND to the defect.
+
+      TWO HOLES REMAIN OPEN, and neither is closed by this requirement:
+      (1) six `status:` values in safety/stpa/architecture.yaml sit inside the
+      `fields:` extension bag, where rivet cannot see them — the #370 defect one
+      field over, on `status:` instead of `release:`; (2) safety/requirements.yaml
+      holds 21 more, and rivet never loads that file at all because it is not
+      under any path in rivet.yaml's `sources:`. Both are invisible to the guard
+      above, which is exactly why they are named here rather than silently
+      absorbed into the 276.
+
+      RECONCILIATION (measured, not asserted): 303 raw `status:` text matches
+      across 9 committed files, minus 21 in the unloaded file, minus 6 in the
+      fields bag, equals the 276 errors rivet reports. The three planes agree.
+      NOTE ON THE MISSING LINK: this artifact deliberately carries no
+      `traces-to: REQ-GUARD-RELEASE-PLANE-001`, even though that is its natural
+      sibling. That artifact arrives in a different unmerged PR, and a `links:`
+      target is resolved at validate time — so the link would make this branch's
+      oracle pass or fail depending on which PR merges first. Add it once both
+      have landed; a flaky gate is not a traceability improvement.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, traceability, rivet, tooling]

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -260,54 +260,19 @@ artifacts:
     tags: [integration, serde]
 
   # ── Rendering (STPA-derived) ──────────────────────────────────────────
-
-  - id: RENDER-REQ-001
-    type: requirement
-    title: Orthogonal edge routing
-    description: >
-      Edges must use orthogonal routing to minimize visual crossings.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-002
-    type: requirement
-    title: Port visibility with directional indicators
-    description: >
-      Ports must be visible with directional indicators and type coloring.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-003
-    type: requirement
-    title: Interactive HTML with zoom/pan/minimap/search
-    description: >
-      Interactive HTML output must support zoom, pan, minimap, and search.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-004
-    type: requirement
-    title: Deterministic layout
-    description: >
-      Layout must be deterministic — same model always produces same layout.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-005
-    type: requirement
-    title: Selection and group highlighting
-    description: >
-      Selection and group highlighting must be supported in interactive mode.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-006
-    type: requirement
-    title: Semantic zoom for overview levels
-    description: >
-      Semantic zoom must reduce clutter at overview levels.
-    status: partial
-    tags: [rendering, stpa]
+  #
+  # RENDER-REQ-001..006 are NOT defined here. They live in
+  # safety/stpa/rendering-analysis.yaml, which is the canonical copy: it
+  # carries the hazards/satisfies/verified-by trace links that make them
+  # part of the STPA V, and the stubs that used to sit here carried none.
+  #
+  # Both files defined all six ids until #360. rivet silently kept ONE and
+  # dropped the other with no diagnostic, and which one won was load order,
+  # not a decision. The stubs were stale in BOTH directions -- they claimed
+  # RENDER-REQ-003 `implemented` (it is `partial`: minimap/search are
+  # Phase 3b, still `reserved` in etch) and RENDER-REQ-006 `partial` (it is
+  # `implemented`: etch/src/html.rs emits svg.zoom-low / svg.zoom-overview
+  # behind a wheel handler). Do not re-add them here.
 
   - id: REQ-WASM-001
     type: requirement

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -598,7 +598,7 @@ artifacts:
 
   - id: VAL-RTA-001
     type: feature
-    status: planned
+    status: proposed
     title: RTA response time analysis tests
     description: >
       Tests for Response Time Analysis covering deadline miss detection,
@@ -616,7 +616,7 @@ artifacts:
 
   - id: VAL-BUS-001
     type: feature
-    status: planned
+    status: proposed
     title: Bus bandwidth utilization tests
     description: >
       Tests for bus bandwidth analysis covering overload detection when
@@ -634,7 +634,7 @@ artifacts:
 
   - id: VAL-MEMBUD-001
     type: feature
-    status: planned
+    status: proposed
     title: Memory budget analysis tests
     description: >
       Tests for memory budget analysis covering budget violations when
@@ -652,7 +652,7 @@ artifacts:
 
   - id: VAL-WEIGHTPOWER-001
     type: feature
-    status: planned
+    status: proposed
     title: Weight/power aggregation tests
     description: >
       Tests for weight and power property aggregation up the component
@@ -670,7 +670,7 @@ artifacts:
 
   - id: VAL-VERIFY-001
     type: feature
-    status: planned
+    status: proposed
     title: Property assertion rule tests
     description: >
       Tests for the property assertion DSL covering passing assertions,
@@ -688,7 +688,7 @@ artifacts:
 
   - id: VAL-DIFF-001
     type: feature
-    status: planned
+    status: proposed
     title: Structural diff and analysis impact tests
     description: >
       Tests for git-aware structural diff covering component addition/
@@ -711,7 +711,7 @@ artifacts:
 
   - id: VAL-MCP-001
     type: feature
-    status: planned
+    status: proposed
     title: MCP server JSON-RPC request/response tests
     description: >
       Tests for the MCP server covering JSON-RPC initialize handshake,
@@ -732,7 +732,7 @@ artifacts:
 
   - id: VAL-CODEGEN-001
     type: feature
-    status: passing
+    status: implemented
     title: Golden model integration tests for codegen
     description: >
       19 golden model integration tests validating end-to-end code generation
@@ -754,7 +754,7 @@ artifacts:
 
   - id: VAL-CODEGEN-002
     type: feature
-    status: passing
+    status: implemented
     title: WIT/Rust/Config/Test/Proof generation output validation
     description: >
       Tests validating each codegen output layer independently: WIT interface
@@ -795,7 +795,7 @@ artifacts:
 
   - id: VAL-SYSML2-LOWER-001
     type: feature
-    status: passing
+    status: implemented
     title: SysML v2 lowering tests
     description: >
       Tests for SysML v2 to AADL lowering covering diagnostic handling for
@@ -814,7 +814,7 @@ artifacts:
 
   - id: VAL-VERIFY-MACROS-001
     type: feature
-    status: passing
+    status: implemented
     title: Verify macro proc-macro tests
     description: >
       Tests for spar-verify-macros proc-macro crate covering #[aadl(...)]
@@ -837,7 +837,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-001
     type: feature
-    status: planned
+    status: proposed
     title: Kani — solver output implies no deadline miss
     description: >
       kani_schedule_implies_no_deadline_miss harness: for any TaskSet of
@@ -861,7 +861,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-002
     type: feature
-    status: planned
+    status: proposed
     title: Kani — priority ordering is monotone and antisymmetric
     description: >
       kani_priority_monotonicity harness: for any two tasks in a ≤4-task
@@ -885,7 +885,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-003
     type: feature
-    status: planned
+    status: proposed
     title: Kani — EDF accepts U=1 at n=2, RM rejects
     description: >
       kani_zero_laxity_handled harness: a 2-task implicit-deadline set
@@ -909,7 +909,7 @@ artifacts:
 
   - id: VAL-KANI-CODEGEN-001
     type: feature
-    status: planned
+    status: proposed
     title: Kani — codegen emission preserves schedule task IDs
     description: >
       kani_emit_preserves_schedule harness: for any Schedule of size
@@ -931,7 +931,7 @@ artifacts:
 
   - id: TEST-KANI-CODEGEN
     type: feature
-    status: passing
+    status: implemented
     title: Kani — AADL contract preservation harnesses for codegen
     description: >
       The #[kani::proof] harnesses in crates/spar-codegen/tests/kani_contracts.rs
@@ -980,7 +980,7 @@ artifacts:
 
   - id: VAL-MUTATION-001
     type: feature
-    status: passing
+    status: implemented
     title: Mutation testing for analysis passes
     description: >
       Mutation testing campaign covering 674 analysis tests. Validates that
@@ -1003,7 +1003,7 @@ artifacts:
     description: >
       Features, subcomponents, connections, and properties are inherited
       through extends chains with cycle detection and deduplication.
-    status: passing
+    status: implemented
     tags: [v0.5.0, instance-model]
     links:
       - type: satisfies
@@ -1015,7 +1015,7 @@ artifacts:
     description: >
       Salsa-memoized file_item_tree, CST-aware completion, rename safety,
       LineIndex O(1) positions, duplicate package detection, DidClose handler.
-    status: passing
+    status: implemented
     tags: [v0.5.0, lsp]
     links:
       - type: satisfies
@@ -1027,7 +1027,7 @@ artifacts:
     description: >
       6 analysis checks for AI/ML components: inference deadline, fallback
       coverage/timing, OOD coverage, model deployment, redundancy.
-    status: passing
+    status: implemented
     tags: [v0.5.0, analysis, ai-ml]
     links:
       - type: satisfies
@@ -1039,7 +1039,7 @@ artifacts:
     description: >
       Maps EMV2 fault tree analysis to STPA hazard artifacts. Composite
       error states to hazards, propagation paths to loss scenarios.
-    status: passing
+    status: implemented
     tags: [v0.5.0, safety]
     links:
       - type: satisfies
@@ -1052,7 +1052,7 @@ artifacts:
       Rowan-based SysML v2 parser handles full KerML grammar including
       part, port, connection, requirement, constraint, action, and state
       definitions with lossless CST and error recovery.
-    status: passing
+    status: implemented
     tags: [v0.5.0, sysml2]
     links:
       - type: satisfies
@@ -1064,7 +1064,7 @@ artifacts:
     description: >
       Extract requirements with satisfy/verify/refine/allocate/derive
       relationships, architecture context, and roundtrip generation.
-    status: passing
+    status: implemented
     tags: [v0.5.0, sysml2]
     links:
       - type: satisfies
@@ -1078,7 +1078,7 @@ artifacts:
     description: >
       requires_modes flag stored in ItemTree. Modal filtering utility
       for connectivity and scheduling analysis passes.
-    status: passing
+    status: implemented
     tags: [v0.5.0, modes]
     links:
       - type: satisfies
@@ -1090,7 +1090,7 @@ artifacts:
     description: >
       Text-based fallback parser handles booleans, references, classifiers,
       ranges, lists, numerics with units, and enums when CST lowering fails.
-    status: passing
+    status: implemented
     tags: [v0.5.0, properties]
     links:
       - type: satisfies
@@ -1102,7 +1102,7 @@ artifacts:
     description: >
       XSS prevention in SVG rendering, YAML/TOML injection prevention,
       path traversal protection, UTF-8 safe percent decoding, arena bounds checks.
-    status: passing
+    status: implemented
     tags: [v0.5.0, security]
     links:
       - type: satisfies
@@ -1115,7 +1115,7 @@ artifacts:
       WebviewPanel integration renders architecture diagrams live in
       VS Code. Automatic refresh on file save, theme-aware styling,
       pan/zoom controls in the webview.
-    status: passing
+    status: implemented
     tags: [v0.5.0, tooling, vscode]
     links:
       - type: satisfies
@@ -1134,7 +1134,7 @@ artifacts:
       scheduling, connectivity, ARINC 653, resource budget, memory budget,
       weight/power, bus bandwidth, binding check. Diagnostics prefixed
       with [mode: <name>] for per-SOM results.
-    status: passing
+    status: implemented
     tags: [v0.6.0, analysis, modes]
     links:
       - type: satisfies
@@ -1153,7 +1153,7 @@ artifacts:
       GlobalScope follows package renames, classifier renames, and feature
       group renames declarations. Aliases stored in resolver and resolved
       during name lookup. Enables cross-package aliasing per AS5506 Ch.4.
-    status: passing
+    status: implemented
     tags: [v0.6.0, resolution]
     links:
       - type: satisfies
@@ -1169,7 +1169,7 @@ artifacts:
       OneToOne (element i to element i, requires same array size) and
       AllToAll (cartesian product, default). Property parsed from nested
       list format or simple identifier, case-insensitive matching.
-    status: passing
+    status: implemented
     tags: [v0.6.0, instance-model, connections]
     links:
       - type: satisfies
@@ -1189,7 +1189,7 @@ artifacts:
       PropertyMap to analysis passes. get_typed() on PropertyMap returns
       typed property values. All 7 instance.rs construction sites propagate
       typed_value. Extends chain survival tested.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties]
     links:
       - type: satisfies
@@ -1207,7 +1207,7 @@ artifacts:
       to try get_typed() before falling back to text parsing. Covers
       timing properties, scheduling, bus bandwidth, memory, weight/power,
       and binding properties. Reduces text-parsing fragility.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties, analysis]
     links:
       - type: satisfies
@@ -1224,7 +1224,7 @@ artifacts:
       MAX_RENDER_DEPTH=5 constant prevents stack overflow on deeply nested
       hierarchies. Components beyond the depth limit are reparented to the
       nearest visible ancestor. 5 new tests covering deep nesting scenarios.
-    status: passing
+    status: implemented
     tags: [v0.6.0, rendering, bugfix]
     links:
       - type: satisfies
@@ -1240,7 +1240,7 @@ artifacts:
       statements (satisfy, verify, refine, allocate, derive) from rivet
       artifacts. Supports action/state/connection keywords via tags.
       Sanitizes identifiers for SysML v2 compliance.
-    status: passing
+    status: implemented
     tags: [v0.6.0, sysml2]
     links:
       - type: satisfies
@@ -1256,7 +1256,7 @@ artifacts:
       nested list values. PropertyExpr::Record variant added. 670+ lines
       of lowering enhancements in item_tree/lower.rs covering record
       fields, nested lists, and complex property expression combinations.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties]
     links:
       - type: satisfies
@@ -1277,7 +1277,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_timing test_spar_property_sets_resolved_via_global_scope
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, properties]
     links:
       - type: satisfies
@@ -1300,7 +1300,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_trace test_spar_property_sets_resolved_via_global_scope
-    status: passing
+    status: implemented
     tags: [v0.8.0, trace, verification, properties]
     links:
       - type: satisfies
@@ -1394,7 +1394,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests scheduling_verified
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, rta]
     links:
       - type: satisfies
@@ -1419,7 +1419,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --test rta_fixtures
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, rta, fixtures]
     links:
       - type: satisfies
@@ -1446,7 +1446,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_network test_spar_network_property_set_resolved_via_global_scope test_spar_network_unknown_property_returns_none
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn, properties]
     links:
       - type: satisfies
@@ -1477,7 +1477,7 @@ artifacts:
             standard_properties::tests::test_standard_properties_in_spar_migration
             standard_properties::tests::test_spar_migration_property_set_resolved_via_global_scope
             standard_properties::tests::test_spar_migration_unknown_property_returns_none
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1502,7 +1502,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib -- migration::tests
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1535,7 +1535,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib -- overlay::tests
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1577,7 +1577,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_verify
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli]
     links:
       - type: satisfies
@@ -1622,7 +1622,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_enumerate
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli]
     links:
       - type: satisfies
@@ -1678,7 +1678,7 @@ artifacts:
         - run: cargo test -p spar --test moves_enumerate_objectives
         - run: "cargo test -p spar-solver enumerate::"
         - run: "cargo test -p spar moves::enumerate_tests"
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli, solver]
     links:
       - type: satisfies
@@ -1725,7 +1725,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_variant
-    status: passing
+    status: implemented
     tags: [migration, variants, track-e, track-b, v080, cli]
     links:
       - type: satisfies
@@ -1756,7 +1756,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn, extract]
     links:
       - type: satisfies
@@ -1788,7 +1788,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- curves::tests
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, network-calculus]
     links:
       - type: satisfies
@@ -1818,7 +1818,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --test nc_validation
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, validation, oracle]
     links:
       - type: satisfies
@@ -1864,7 +1864,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_xval"
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, plp, validation, oracle]
     links:
       - type: satisfies
@@ -1905,7 +1905,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_xval::panco_converge"
-    status: passing
+    status: implemented
     tags: [v0.19.0, network, network-calculus, plp, converging, validation, oracle]
     links:
       - type: satisfies
@@ -1937,7 +1937,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-analysis --lib --features milp-solver network_wide_authoritative_bound"
         - run: "cargo test -p spar-analysis --lib --no-default-features network_wide_authoritative_bound"
-    status: passing
+    status: implemented
     tags: [v0.22.0, network, network-calculus, plp, tfa, bridge, oracle]
     links:
       - type: satisfies
@@ -1977,7 +1977,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_str_xval"
-    status: passing
+    status: implemented
     tags: [v0.19.0, network, network-calculus, plp, validation, oracle]
     links:
       - type: satisfies
@@ -2031,7 +2031,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib wctt::tests::network_wide"
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, bridge, tsn, tfa, plp]
     links:
       - type: satisfies
@@ -2062,7 +2062,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- wctt::tests
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn]
     links:
       - type: satisfies
@@ -2106,7 +2106,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- latency::tests
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, latency]
     links:
       - type: satisfies
@@ -2140,7 +2140,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-variants
-    status: passing
+    status: implemented
     tags: [variants, track-b, v07x]
     links:
       - type: satisfies
@@ -2166,7 +2166,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests scheduling_verified property_accessors
-    status: passing
+    status: implemented
     tags: [v0.7.1, timing, irq, rta, pip, pcp, blocking]
     links:
       - type: satisfies
@@ -2194,7 +2194,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cd proofs && lake build
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, network-calculus, lean, proofs]
     links:
       - type: satisfies
@@ -2224,7 +2224,7 @@ artifacts:
       method: formal-proof
       steps:
         - run: cd proofs && lake build
-    status: passing
+    status: implemented
     tags: [v0.15.0, scheduling, lean, proofs, rta, edf]
     links:
       - type: satisfies
@@ -2253,7 +2253,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, properties]
     links:
       - type: satisfies
@@ -2290,7 +2290,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, wctt, tas]
     links:
       - type: satisfies
@@ -2326,7 +2326,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- tas_sound"
-    status: passing
+    status: implemented
     tags: [network, tsn, wctt, tas, soundness, oracle]
     links:
       - type: satisfies
@@ -2363,7 +2363,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- synth"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, synthesis, qbv, oracle]
     links:
       - type: satisfies
@@ -2392,7 +2392,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- split_"
-    status: passing
+    status: implemented
     tags: [v0.21.0, network, tsn, synthesis, qbv, oracle]
     links:
       - type: satisfies
@@ -2433,7 +2433,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- guard"
-    status: passing
+    status: implemented
     tags: [v0.22.0, network, tsn, synthesis, qbv, guard-band, oracle]
     links:
       - type: satisfies
@@ -2468,7 +2468,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- yang"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, export, yang, netconf, oracle]
     links:
       - type: satisfies
@@ -2505,7 +2505,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- cqf"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, synthesis, cqf, oracle]
     links:
       - type: satisfies
@@ -2549,7 +2549,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- cqf"
-    status: passing
+    status: implemented
     tags: [v0.23.0, network, tsn, synthesis, cqf, longlink, oracle]
     links:
       - type: satisfies
@@ -2586,7 +2586,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- cqf_synth"
-    status: passing
+    status: implemented
     tags: [v0.20.0, analysis, tsn, synthesis, cqf, bridge, oracle]
     links:
       - type: satisfies
@@ -2627,7 +2627,7 @@ artifacts:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn::tests::cbs
         - run: cargo test -p spar-analysis --lib -- wctt::tests::cbs
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, cbs, qav, wctt]
     links:
       - type: satisfies
@@ -2665,7 +2665,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, preemption, qbu, wctt]
     links:
       - type: satisfies
@@ -2701,7 +2701,7 @@ artifacts:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.9.1, network, wctt, soundness, gptp, quantization]
     links:
       - type: satisfies
@@ -2750,7 +2750,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- curves::piecewise
-    status: passing
+    status: implemented
     tags: [v0.9.3, network, wctt, network-calculus, piecewise]
     links:
       - type: satisfies
@@ -2777,7 +2777,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests::stop_for_lock
         - run: cargo test -p spar-analysis --lib -- arinc653
-    status: passing
+    status: implemented
     tags: [v0.9.2, analysis, rta, arinc653, soundness]
     links:
       - type: satisfies
@@ -2804,7 +2804,7 @@ artifacts:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, tsn, cbs, wctt]
     links:
       - type: satisfies
@@ -2825,7 +2825,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- context_switch
-    status: passing
+    status: implemented
     tags: [v0.9.2, analysis, rta, soundness, scheduling]
     links:
       - type: satisfies
@@ -2849,7 +2849,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- wctt
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, wctt, sensitivity]
     links:
       - type: satisfies
@@ -2872,7 +2872,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- rta_wctt
         - run: cargo test -p spar-analysis --lib -- no_dispatch_jitter
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, wctt, rta, coupling]
     links:
       - type: satisfies
@@ -2903,7 +2903,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- pmoo
         - run: cargo test -p spar-analysis --lib -- pmoo_flag
-    status: passing
+    status: implemented
     tags: [v0.9.3, network, wctt, pmoo, ludb, lp]
     links:
       - type: satisfies
@@ -2930,7 +2930,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-insight
-    status: passing
+    status: implemented
     tags: [v0.9.0, insight, trace, ctf, tier1]
     links:
       - type: satisfies
@@ -2973,7 +2973,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-mcp
-    status: passing
+    status: implemented
     tags: [mcp, migration, track-e, v090, integration]
     links:
       # v0.14.0 link-and-promote: the tool-surface tests exercise the MCP
@@ -3017,7 +3017,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-trace-topology
-    status: passing
+    status: implemented
     tags: [v0.10.0, trace-topology, track-g, properties]
     links:
       - type: satisfies
@@ -3041,7 +3041,7 @@ artifacts:
         - run: cargo test -p spar-analysis rta::tests::interrupt_overhead_inflates_isr_wcet
         - run: cargo test -p spar-analysis rta::tests::no_interrupt_overhead_byte_identical_to_pre_c1
         - run: cargo test -p spar-analysis rta::tests::interrupt_overhead_combined_with_context_switch_for_handler
-    status: passing
+    status: implemented
     tags: [rta, isr, v093]
     links:
       - type: satisfies
@@ -3060,7 +3060,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, lldp, v0100]
     links:
       - type: satisfies
@@ -3080,7 +3080,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, pcapng, v0100]
     links:
       - type: satisfies
@@ -3099,7 +3099,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, qcc, yang, v0100]
     links:
       - type: satisfies
@@ -3118,7 +3118,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, gptp, v0100]
     links:
       - type: satisfies
@@ -3136,7 +3136,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- identity::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, properties, identity, ip, v0100]
     links:
       - type: satisfies
@@ -3161,7 +3161,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-trace-topology --lib -- engine::tests
         - run: cargo test -p spar-trace-topology --test identity_reconcile
-    status: passing
+    status: implemented
     tags: [trace-topology, reconcile, engine, v0110, track-g]
     links:
       - type: satisfies
@@ -3189,7 +3189,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-trace-topology --lib -- engine::tests::gptp_
         - run: cargo test -p spar-trace-topology --test gptp_out_of_budget
-    status: passing
+    status: implemented
     tags: [trace-topology, reconcile, engine, gptp, v0110, track-g]
     links:
       - type: satisfies
@@ -3209,7 +3209,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def overlay
         - run: cargo test -p spar --test applies_to_nested
-    status: passing
+    status: implemented
     tags: [binding, hir-def, v093]
     links:
       - type: satisfies
@@ -3235,7 +3235,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- binding_rules::tests
-    status: passing
+    status: implemented
     tags: [binding, analysis, v0111]
     links:
       - type: satisfies
@@ -3254,7 +3254,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis classifier_match
-    status: passing
+    status: implemented
     tags: [classifier-match, connections, v093]
     links:
       - type: satisfies
@@ -3274,7 +3274,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --bin spar -- assertion::tests::eval_count
-    status: passing
+    status: implemented
     tags: [assertions, eval, v093]
     links:
       - type: satisfies
@@ -3294,7 +3294,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --bin spar -- assertion::tests::has
-    status: passing
+    status: implemented
     tags: [assertions, v093]
     links:
       - type: satisfies
@@ -3314,7 +3314,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test applies_to_feature_path
-    status: passing
+    status: implemented
     tags: [hir-def, properties, v093]
     links:
       - type: satisfies
@@ -3343,7 +3343,7 @@ artifacts:
       steps:
         - run: "test -f proofs/Proofs/Scheduling/Latency.lean"
         - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Latency.lean"
-    status: passing
+    status: implemented
     tags: [proof, latency, lean, v0100]
     links:
       - type: satisfies
@@ -3366,7 +3366,7 @@ artifacts:
       steps:
         - run: "test -f proofs/Proofs/Scheduling/Arinc653Isolation.lean"
         - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Arinc653Isolation.lean"
-    status: passing
+    status: implemented
     tags: [proof, arinc653, lean, v0100]
     links:
       - type: satisfies
@@ -3387,7 +3387,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-mermaid
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3407,7 +3407,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test emit_mermaid
-    status: passing
+    status: implemented
     tags: [mermaid, cli, v0100]
     links:
       - type: satisfies
@@ -3431,7 +3431,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis emv2_propagation
-    status: passing
+    status: implemented
     tags: [emv2, analysis, v0100, safety]
     links:
       - type: satisfies
@@ -3462,7 +3462,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-annex --lib model
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, annex]
     links:
       - type: verifies
@@ -3492,7 +3492,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib emv2
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, hir-def]
     links:
       - type: verifies
@@ -3526,7 +3526,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib emv2_
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, hir-def]
     links:
       - type: verifies
@@ -3565,7 +3565,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --test emv2_chain
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, capability]
     links:
       - type: verifies
@@ -3588,7 +3588,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- wrpc_binding"
-    status: passing
+    status: implemented
     tags: [wrpc, binding, analysis, bug]
     links:
       - type: satisfies
@@ -3615,7 +3615,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- wrpc_binding"
-    status: passing
+    status: implemented
     tags: [wrpc, binding, analysis]
     links:
       - type: satisfies
@@ -3637,7 +3637,7 @@ artifacts:
       steps:
         - run: "tools/run_verification.py --filter '(and (= type \"feature\") (has-tag \"classifier-match\"))' --results-json /tmp/verify-smoke.json"
         - run: "python3 -c 'import json,sys; d=json.load(open(\"/tmp/verify-smoke.json\")); sys.exit(0 if d[\"passed_count\"]==1 and d[\"failed_count\"]==0 else 1)'"
-    status: passing
+    status: implemented
     tags: [ci, rivet, verification, v0100]
     links:
       - type: satisfies
@@ -3661,7 +3661,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-mermaid
         - run: cargo test -p spar --test emit_mermaid emit_mermaid_class_happy_path
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3683,7 +3683,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-mermaid
         - run: cargo test -p spar --test emit_mermaid emit_mermaid_req_happy_path
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3705,7 +3705,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --test golden_test
-    status: passing
+    status: implemented
     tags: [codegen, wit, cli, v0100]
     links:
       - type: satisfies
@@ -3732,7 +3732,7 @@ artifacts:
         - run: cargo run -q -p spar -- codegen --root Threads::Sys.impl --output /tmp/threads-out /tmp/threads.aadl
         - run: cargo run -q -p spar -- codegen --root Proc::Sys.impl --format wit --output /tmp/proc-out /tmp/proc.aadl
         - run: cargo run -q -p spar -- codegen --root Threads::Sys.impl --format rust --output /tmp/threads-rust-out /tmp/threads.aadl
-    status: passing
+    status: implemented
     tags: [codegen, wit, cli, diagnostics, v0110]
     links:
       - type: satisfies
@@ -3763,7 +3763,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology fixtures::transform
-    status: passing
+    status: implemented
     tags: [trace-topology, fixtures, v0110]
     links:
       - type: satisfies
@@ -3784,7 +3784,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo build -p spar-trace-topology --bin fixture-vm
-    status: passing
+    status: implemented
     tags: [trace-topology, fixtures, ci, v0110]
     links:
       - type: satisfies
@@ -3822,7 +3822,7 @@ artifacts:
         - run: "grep -q \"cosign-release: 'v2.4.1'\" .github/workflows/release.yml"
         - run: grep -q 'cosign sign-blob' .github/workflows/release.yml
         - run: grep -q 'build-env.txt' .github/workflows/release.yml
-    status: passing
+    status: implemented
     tags: [release, supply-chain, cosign, slsa, sbom, v0110]
     links:
       - type: satisfies
@@ -3847,7 +3847,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test osate_corpus -- --nocapture
-    status: passing
+    status: implemented
     tags: [interop, plugfest, aadl, parser, osate, v0120]
     links:
       - type: satisfies
@@ -3871,7 +3871,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, interop, v0130]
     links:
       - type: satisfies
@@ -3894,7 +3894,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, interop, v0140]
     links:
       - type: satisfies
@@ -3918,7 +3918,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, interop, v0240]
     links:
       - type: satisfies
@@ -3950,7 +3950,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-codegen --test lifecycle_bindings
         - run: cargo test -p spar-codegen --test lifecycle_bindings -- --ignored
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, wit-bindgen, interop, v0240]
     links:
       - type: satisfies
@@ -3983,7 +3983,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-codegen --test lifecycle_bindings
         - run: cargo test -p spar-codegen --test lifecycle_bindings -- --ignored
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, wit-bindgen, no-alloc, v0240]
     links:
       - type: satisfies
@@ -4013,7 +4013,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- tfa
-    status: passing
+    status: implemented
     tags: [network-calculus, tfa, substrate, tier1, v0170]
     links:
       - type: satisfies
@@ -4040,7 +4040,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-dbc
-    status: passing
+    status: implemented
     tags: [ingest, dbc, can, tier1, v0170]
     links:
       - type: satisfies
@@ -4067,7 +4067,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-dbc --test roundtrip sample_dbc_emits_message_flows
-    status: passing
+    status: implemented
     tags: [ingest, dbc, can, flows, tier1, v0200]
     links:
       - type: satisfies
@@ -4119,7 +4119,7 @@ artifacts:
       steps:
         - run: tools/check_human_scoped.py --self-test
         - run: tools/check_human_scoped.py --artifacts-dir artifacts --artifacts-dir safety/stpa
-    status: passing
+    status: implemented
     tags: [process, guardrail, autonomy, ci, tooling, v0360]
     links:
       - type: satisfies
@@ -4162,7 +4162,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib bus_bandwidth
-    status: passing
+    status: implemented
     tags: [network-calculus, bus, honesty, analysis, oracle, v0350]
     links:
       - type: satisfies

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -732,7 +732,7 @@ artifacts:
 
   - id: VAL-CODEGEN-001
     type: feature
-    status: pass
+    status: passing
     title: Golden model integration tests for codegen
     description: >
       19 golden model integration tests validating end-to-end code generation
@@ -754,7 +754,7 @@ artifacts:
 
   - id: VAL-CODEGEN-002
     type: feature
-    status: pass
+    status: passing
     title: WIT/Rust/Config/Test/Proof generation output validation
     description: >
       Tests validating each codegen output layer independently: WIT interface
@@ -795,7 +795,7 @@ artifacts:
 
   - id: VAL-SYSML2-LOWER-001
     type: feature
-    status: pass
+    status: passing
     title: SysML v2 lowering tests
     description: >
       Tests for SysML v2 to AADL lowering covering diagnostic handling for
@@ -814,7 +814,7 @@ artifacts:
 
   - id: VAL-VERIFY-MACROS-001
     type: feature
-    status: pass
+    status: passing
     title: Verify macro proc-macro tests
     description: >
       Tests for spar-verify-macros proc-macro crate covering #[aadl(...)]
@@ -837,7 +837,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — solver output implies no deadline miss
     description: >
       kani_schedule_implies_no_deadline_miss harness: for any TaskSet of
@@ -861,7 +861,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-002
     type: feature
-    status: pending
+    status: planned
     title: Kani — priority ordering is monotone and antisymmetric
     description: >
       kani_priority_monotonicity harness: for any two tasks in a ≤4-task
@@ -885,7 +885,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-003
     type: feature
-    status: pending
+    status: planned
     title: Kani — EDF accepts U=1 at n=2, RM rejects
     description: >
       kani_zero_laxity_handled harness: a 2-task implicit-deadline set
@@ -909,7 +909,7 @@ artifacts:
 
   - id: VAL-KANI-CODEGEN-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — codegen emission preserves schedule task IDs
     description: >
       kani_emit_preserves_schedule harness: for any Schedule of size
@@ -980,7 +980,7 @@ artifacts:
 
   - id: VAL-MUTATION-001
     type: feature
-    status: pass
+    status: passing
     title: Mutation testing for analysis passes
     description: >
       Mutation testing campaign covering 674 analysis tests. Validates that

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -18,16 +18,16 @@ project:
 sources:
   - path: artifacts
     format: generic-yaml
+  # The directory scan below already loads every *.yaml under safety/stpa.
+  # Four of those files used to ALSO be listed individually, to force
+  # `format: generic-yaml` on them — which loaded each one twice and made
+  # every id in it collide with itself: 184 phantom "declared more than
+  # once" errors, one per id, with the same path on both sides of the
+  # message (#360). The explicit entries are removed; see the measurement
+  # in the PR for the artifact-set equivalence check that says the
+  # directory scan alone loses nothing.
   - path: safety/stpa
     format: stpa-yaml
-  - path: safety/stpa/requirements.yaml
-    format: generic-yaml
-  - path: safety/stpa/architecture.yaml
-    format: generic-yaml
-  - path: safety/stpa/validation.yaml
-    format: generic-yaml
-  - path: safety/stpa/solver-requirements.yaml
-    format: generic-yaml
 
 docs:
   - docs

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -23,9 +23,28 @@ sources:
   # `format: generic-yaml` on them — which loaded each one twice and made
   # every id in it collide with itself: 184 phantom "declared more than
   # once" errors, one per id, with the same path on both sides of the
-  # message (#360). The explicit entries are removed; see the measurement
-  # in the PR for the artifact-set equivalence check that says the
-  # directory scan alone loses nothing.
+  # message (#360). The explicit entries are removed.
+  #
+  # This is NOT free, and the PR's first measurement said it was — wrongly.
+  # `rivet list --format json` WITHOUT `--full` emits only the summary view
+  # (`--help`: it omits `description`, `tags`, and `fields`), so the
+  # "byte-identical, loses nothing" equivalence check was run on a view
+  # structurally incapable of seeing field-level loss — the exact class of
+  # change a `format:` switch produces. Re-measured with `--full`:
+  #
+  #   +86 artifacts GAIN `mitigates` and `traces-to` (stpa-yaml really is
+  #       broadly a superset — but the original measurement didn't show that
+  #       either, it showed nothing)
+  #    -5 artifacts LOSE half of `test-name`: VAL-010/011/014/015/021 are
+  #       exactly the five whose on-disk value is a comma-separated pair, and
+  #       the stpa-yaml parser keeps only the first element.
+  #
+  #       on disk: tests::boolean_matches_aadl_boolean, tests::boolean_mismatches_aadl_string
+  #       rivet:   tests::boolean_matches_aadl_boolean
+  #
+  # Accepted deliberately — five truncated evidence pointers against 190
+  # phantom duplicate-id errors — and filed upstream as pulseengine/rivet#747
+  # rather than silently absorbed. Revert this trade if #747 lands a fix.
   - path: safety/stpa
     format: stpa-yaml
 

--- a/safety/stpa/rendering-analysis.yaml
+++ b/safety/stpa/rendering-analysis.yaml
@@ -159,7 +159,7 @@ artifacts:
   - id: RENDER-REQ-003
     type: requirement
     title: Interactive HTML with zoom/pan/minimap/search
-    status: partial
+    status: approved
     description: >
       The interactive HTML output must support zoom, pan, a minimap
       for orientation in large models, and text search to locate

--- a/safety/stpa/requirements.yaml
+++ b/safety/stpa/requirements.yaml
@@ -458,7 +458,7 @@ artifacts:
       with explicit arms for known non-semantic kinds and a catch-all that
       emits a warning diagnostic "unhandled SysML v2 construct: {kind}".
       This mirrors the AADL lowering exhaustiveness (STPA-REQ-004).
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, lowering, stpa]
     traces-to: [CC-15]
     mitigates: [H-7]
@@ -473,7 +473,7 @@ artifacts:
       it must not be classified as system. A test suite must cover all
       category inference paths with at least one test per SysML v2
       construct type (part def, action def, state def, etc.).
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, category, stpa]
     traces-to: [CC-16]
     mitigates: [H-7, H-1]
@@ -487,7 +487,7 @@ artifacts:
       the referenced type definition's category, not hardcoded to
       ComponentCategory::System. When the referenced type is not
       available, a warning diagnostic must be emitted.
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, category, stpa]
     traces-to: [CC-16]
     mitigates: [H-7, H-3]
@@ -501,7 +501,7 @@ artifacts:
       produce typed PropertyExpr values (IntegerLit/RealLit with unit
       annotation), not Opaque strings. Only expressions that genuinely
       cannot be parsed should use PropertyExpr::Opaque.
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, properties, stpa]
     traces-to: [CC-17]
     mitigates: [H-7, H-6]
@@ -515,7 +515,12 @@ artifacts:
       AADL ItemTree has the correct category, features, subcomponents,
       connections, and property associations. A golden model test must
       verify end-to-end lowering of a non-trivial SysML v2 model.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Tests exist, but which of the 14+ lowering rules each one covers
+      has not been mapped, so per-rule coverage is deliberately not
+      asserted here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [safety, sysml2, testing, stpa]
     traces-to: [CC-15, CC-16]
     mitigates: [H-7]
@@ -534,7 +539,7 @@ artifacts:
       the rule must fail with a clear error message, not produce a
       cached success artifact. The check must use `which` or equivalent
       and verify the tool version meets minimum requirements.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-18]
     mitigates: [H-8]
@@ -548,7 +553,7 @@ artifacts:
       generating code that includes verification annotations. An
       integration test must verify that generated BUILD.bazel files
       contain at least one verification target per generated crate.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-19]
     mitigates: [H-8]
@@ -563,7 +568,7 @@ artifacts:
       "verification results" summary line. The lean_verify rule must
       check that the log contains "All proofs verified." A log that
       contains only error messages must cause the rule to fail.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-18]
     mitigates: [H-8]
@@ -601,7 +606,7 @@ artifacts:
       diagnostics and halt code generation. Default value substitution
       (the current 10ms/1ms fallback) must emit a warning diagnostic
       rather than proceeding silently.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, stpa-sec]
     traces-to: [CC-SEC-2]
     mitigates: [H-SEC-2]
@@ -616,7 +621,7 @@ artifacts:
       (via .., symlinks, or absolute paths), codegen must emit an error
       and skip that file. This check must occur after all path component
       construction, including process name and thread name interpolation.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, filesystem, stpa-sec]
     traces-to: [CC-SEC-3]
     mitigates: [H-SEC-6]
@@ -631,7 +636,12 @@ artifacts:
       SyntaxKind name, source offset, and parent context. A golden-file
       test must verify that all semantic SysML v2 constructs produce
       either a lowered AADL item or a diagnostic.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which half is outstanding — the diagnostic itself or the
+      golden-file test that would prove it exhaustive — is deliberately
+      not asserted here; see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [security, sysml2, lowering, stpa-sec]
     traces-to: [CC-SEC-4]
     mitigates: [H-SEC-3]
@@ -647,7 +657,7 @@ artifacts:
       workspace Cargo.toml. Process names must be checked against a
       reserved list of common crate names (serde, tokio, rand, etc.)
       and must be prefixed with "aadl_" if they collide.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, supply-chain, stpa-sec]
     traces-to: [CC-SEC-5]
     mitigates: [H-SEC-4]
@@ -664,7 +674,7 @@ artifacts:
       (e.g., verify_{name}_no_deadline_miss_base_case). The codegen
       must also generate a coverage_manifest.json listing each
       verification artifact and its scope.
-    status: not-implemented
+    status: proposed
     tags: [security, verification, stpa-sec]
     traces-to: [CC-SEC-6]
     mitigates: [H-SEC-5]
@@ -679,7 +689,7 @@ artifacts:
       paths must never be concatenated into shell command strings. If
       run_shell is unavoidable (e.g., for piping), all interpolated paths
       must be shell-quoted using shlex or equivalent escaping.
-    status: not-implemented
+    status: proposed
     tags: [security, build, bazel, stpa-sec]
     traces-to: [CC-SEC-7]
     mitigates: [H-SEC-1, H-SEC-4]
@@ -695,7 +705,7 @@ artifacts:
       current build invocation (via Bazel's action dependency graph,
       not filesystem timestamps). Content hashing of the core module
       should be logged for audit.
-    status: not-implemented
+    status: proposed
     tags: [security, build, wasm, stpa-sec]
     traces-to: [CC-SEC-8]
     mitigates: [H-SEC-1, H-SEC-2]
@@ -710,7 +720,7 @@ artifacts:
       100,000). When a limit is exceeded, codegen must emit an error
       diagnostic and halt. These limits must be configurable via CLI
       flags (--max-files, --max-output-size, --max-components).
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, resource-limits, stpa-sec]
     traces-to: [SC-SEC-6]
     mitigates: [H-SEC-7]
@@ -725,7 +735,11 @@ artifacts:
       clippy). This test verifies that generated code is syntactically
       valid Rust. A second test must verify that generated WIT files
       pass wasm-tools component wit validation.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which of the two tests is in place is deliberately not asserted
+      here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [security, codegen, testing, stpa-sec]
     traces-to: [CC-SEC-1, CC-SEC-2]
     mitigates: [H-SEC-1, H-SEC-2]
@@ -740,7 +754,7 @@ artifacts:
       as system: no action/state usages found"). Engineers must be
       able to override the inference via a SysML v2 annotation or
       comment convention (e.g., `/* @aadl-category: thread */`).
-    status: not-implemented
+    status: proposed
     tags: [security, sysml2, lowering, stpa-sec]
     traces-to: [CC-SEC-4]
     mitigates: [H-SEC-3]
@@ -756,7 +770,7 @@ artifacts:
       proof uses default 10ms) must be reported as an error. This
       cross-reference should be implemented as a post-codegen
       validation step.
-    status: not-implemented
+    status: proposed
     tags: [security, verification, consistency, stpa-sec]
     traces-to: [CC-SEC-2, CC-SEC-6]
     mitigates: [H-SEC-2, H-SEC-5]

--- a/safety/stpa/solver-requirements.yaml
+++ b/safety/stpa/solver-requirements.yaml
@@ -25,7 +25,7 @@ artifacts:
       for LP relaxations), the final feasibility check must use
       conservative integer rounding (ceiling for utilization, floor
       for available time).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, numeric, stpa]
     traces-to: [CC-S1, CC-S20]
     mitigates: [H-S2, H-S12]
@@ -40,7 +40,7 @@ artifacts:
       When a single value is specified, it is treated as both best-case
       and worst-case. The RTA must emit a diagnostic if only a single
       value is provided, advising the engineer to specify a range.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, stpa]
     traces-to: [CC-S1]
     mitigates: [H-S2]
@@ -55,7 +55,7 @@ artifacts:
       are not specified in the model, the RTA must emit a warning that
       overhead is not accounted for and that the schedulability result
       is optimistic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, overhead, stpa]
     traces-to: [CC-S1]
     mitigates: [H-S2]
@@ -70,7 +70,7 @@ artifacts:
       (whose thread sets have changed) and re-run RTA for each dirty
       processor before reporting feasibility. An integration test must
       verify that no populated processor is skipped.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, completeness, stpa]
     traces-to: [CC-S2]
     mitigates: [H-S2]
@@ -85,7 +85,7 @@ artifacts:
       The quick utilization test may be used as a pre-filter to reject
       obviously infeasible allocations, but the full RTA must confirm
       feasibility before the allocation is committed.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, incremental, stpa]
     traces-to: [CC-S2]
     mitigates: [H-S2, H-S9]
@@ -105,7 +105,7 @@ artifacts:
       processor they reside on, not once per process that accesses them.
       An integration test must verify resource sums against hand-calculated
       values for a reference model.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, resources, stpa]
     traces-to: [CC-S3]
     mitigates: [H-S10]
@@ -120,7 +120,7 @@ artifacts:
       as soft constraints. When an allocation violates an affinity
       constraint, the diagnostic must name the constraint, the component,
       and the conflicting binding.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, constraints, stpa]
     traces-to: [CC-S4]
     mitigates: [H-S3]
@@ -135,7 +135,7 @@ artifacts:
       different processors, different buses, and (when specified)
       different cabinets. The solver must detect redundancy annotations
       and apply anti-affinity automatically.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, redundancy, stpa]
     traces-to: [CC-S4]
     mitigates: [H-S3]
@@ -155,7 +155,7 @@ artifacts:
       utilization exceeds capacity, the assignment must be rejected.
       The bandwidth check must account for protocol overhead (framing,
       headers, retransmission).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, bandwidth, stpa]
     traces-to: [CC-S5]
     mitigates: [H-S4]
@@ -170,7 +170,7 @@ artifacts:
       check). The virtual bus library must declare security properties.
       Connections without a matching secure protocol must produce an
       error diagnostic, not be silently assigned to an insecure protocol.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, security, stpa]
     traces-to: [CC-S6]
     mitigates: [H-S4]
@@ -186,7 +186,7 @@ artifacts:
       cross-processor connection must receive a bus binding. A
       completeness check must verify that no cross-processor connection
       is unbound after Layer 2 completes.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, completeness, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S4]
@@ -201,7 +201,7 @@ artifacts:
       Nominal values may be used only for optimization objective
       evaluation (not for constraint satisfaction). Library entries
       without worst-case values must produce a warning diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, protocol-library, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -221,7 +221,7 @@ artifacts:
       context-switch time, and queuing delay. Each segment must be
       individually reported in the latency breakdown. Missing segments
       must produce a diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, e2e-latency, stpa]
     traces-to: [CC-S8]
     mitigates: [H-S1, H-S9]
@@ -237,7 +237,7 @@ artifacts:
       stop), (c) time and space partitioning is specified. If any
       containment mechanism is missing, the co-location must be rejected
       with an error diagnostic identifying the missing mechanism.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, mixed-criticality, containment, stpa]
     traces-to: [CC-S9]
     mitigates: [H-S3]
@@ -255,7 +255,7 @@ artifacts:
       schedulability. The global validation must use the composed
       solution (not individual layer results) and must report all
       violations, not just the first one found.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, global-validation, composition, stpa]
     traces-to: [CC-S10]
     mitigates: [H-S9]
@@ -272,7 +272,7 @@ artifacts:
       processes X and Y"). Full automated backtracking is desirable
       but manual-with-guidance is acceptable for the initial
       implementation.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, backtracking, global-validation, stpa]
     traces-to: [CC-S10]
     mitigates: [H-S9]
@@ -292,7 +292,7 @@ artifacts:
       by text search on the CST). When the path does not resolve to
       exactly one CST node, the rewriter must emit an error and skip
       the rewrite for that component.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, targeting, stpa]
     traces-to: [CC-S11]
     mitigates: [H-S5]
@@ -308,7 +308,7 @@ artifacts:
       none exists. Before insertion, the rewriter must check whether the
       property already exists; if so, it must update the value in place
       rather than inserting a duplicate.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, preservation, stpa]
     traces-to: [CC-S12]
     mitigates: [H-S5]
@@ -323,7 +323,7 @@ artifacts:
       back (original files restored) and an error diagnostic must
       identify which file has the syntax error and the approximate
       insertion location.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, validation, stpa]
     traces-to: [CC-S13]
     mitigates: [H-S5]
@@ -338,7 +338,7 @@ artifacts:
       If any file cannot be written (permissions, disk error), no files
       must be modified. The rewriter should write to temporary files
       first, then rename all atomically.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, atomicity, stpa]
     traces-to: [CC-S14]
     mitigates: [H-S5]
@@ -353,7 +353,7 @@ artifacts:
       as a workspace edit). The engineer must have the option to accept
       or reject the changes. No source modification without explicit
       engineer approval.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, review, stpa]
     traces-to: [CC-S14]
     mitigates: [H-S5, H-S4]
@@ -374,7 +374,7 @@ artifacts:
       certificate must contain sufficient data for an independent
       verifier to reproduce the gap calculation without running the
       solver.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, verification, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -389,7 +389,7 @@ artifacts:
       solution satisfies all constraints by re-evaluating constraints
       against the reported binding, (c) flag any inconsistency. The
       verifier must be included in the CI test suite.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, independent-check, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -405,7 +405,7 @@ artifacts:
       results (certificate must include the infeasibility proof or
       state which constraint set is unsatisfiable). Solutions without
       certificates must not be reported to the user.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, completeness, stpa]
     traces-to: [CC-S16]
     mitigates: [H-S6]
@@ -420,7 +420,7 @@ artifacts:
       hash matches the solver's objective function hash. Mismatched
       objectives must produce an internal error, not a misleading
       certificate.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, consistency, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -439,7 +439,7 @@ artifacts:
       analysis must use the rewritten model (not the pre-solve model).
       Any analysis diagnostic at error severity must cause the solver to
       report failure, even if the solver's internal validation passed.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, validation, post-solve, stpa]
     traces-to: [CC-S17]
     mitigates: [H-S1, H-S8]
@@ -456,7 +456,7 @@ artifacts:
       rewritten property values (not stale pre-rewrite values) by
       checking that a solver-inserted binding property appears in the
       post-solve analysis output.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, validation, cache-coherence, stpa]
     traces-to: [CC-S17]
     mitigates: [H-S8]
@@ -478,7 +478,7 @@ artifacts:
       produce error diagnostics. The solver must refuse to run until
       all required properties are present or the engineer explicitly
       acknowledges the gaps.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, completeness, pre-solve, stpa]
     traces-to: [CC-S18]
     mitigates: [H-S11]
@@ -495,7 +495,7 @@ artifacts:
       must produce an explicit diagnostic. If the engineer provides an
       explicit default via a solver configuration flag, the solver must
       emit a warning listing all properties using the override default.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, completeness, defaults, stpa]
     traces-to: [CC-S18]
     mitigates: [H-S11]
@@ -515,7 +515,7 @@ artifacts:
       criterion (lexicographic ordering of component names). A CI test
       must run the solver 10 times on the same input and verify
       identical output.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, determinism, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S7]
@@ -531,7 +531,7 @@ artifacts:
       utilization for each processor/bus/memory, and a hash of the
       input model. Re-running the solver with the same input hash
       must produce the same binding or report a divergence diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, reproducibility, persistence, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S7]
@@ -551,7 +551,7 @@ artifacts:
       check that declared properties (bandwidth, latency, frame size)
       are within the ranges specified by the referenced standard.
       Library entries without standard references must produce a warning.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, protocol-library, validation, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -567,7 +567,7 @@ artifacts:
       emit a warning identifying the sensitive flows and the margin.
       This accounts for virtual bus library inaccuracies and real-world
       protocol variability.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, sensitivity, protocol-library, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -586,7 +586,7 @@ artifacts:
       each layer, and what properties the virtual bus library must
       provide. This documentation must be updated when the constraint
       model changes and must be reviewable by safety engineers.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, documentation, stpa]
     traces-to: [SC-S1]
     mitigates: [H-S1]
@@ -602,7 +602,7 @@ artifacts:
       pass/fail status, (e) the optimality certificate, (f) list of
       all diagnostics by severity. The report must be both human-readable
       (text) and machine-parseable (JSON).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, reporting, stpa]
     traces-to: [SC-S1]
     mitigates: [H-S1, H-S5, H-S6]

--- a/safety/stpa/validation.yaml
+++ b/safety/stpa/validation.yaml
@@ -17,7 +17,7 @@ artifacts:
     description: >
       Verifies that parsing AADL with an annex library produces a
       LoweringDiagnostic containing "annex" with Warning severity.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -35,7 +35,7 @@ artifacts:
       Verifies that parsing a clean AADL package with a system type
       produces no "unhandled" warnings. This validates that the
       explicit no-op arms correctly cover all non-semantic SyntaxKinds.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -52,7 +52,7 @@ artifacts:
     description: >
       Verifies that a complete AADL package with types, implementations,
       features, and subcomponents produces zero lowering diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -75,7 +75,7 @@ artifacts:
     description: >
       Verifies that an integer expression validates successfully against
       an AadlInteger property type definition.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -92,7 +92,7 @@ artifacts:
     description: >
       Verifies that a string expression against an integer type produces
       a type mismatch diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -109,7 +109,7 @@ artifacts:
     description: >
       Verifies that an enumeration value not in the declared variant
       list produces a diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -125,7 +125,7 @@ artifacts:
     title: Case-insensitive enum matching
     description: >
       Verifies that enumeration matching is case-insensitive per AADL spec.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -142,7 +142,7 @@ artifacts:
     description: >
       Verifies that list elements are individually checked against the
       list element type, and mismatched elements produce diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -159,7 +159,7 @@ artifacts:
     description: >
       Verifies that opaque (unparsed) property values do not produce
       false positive type mismatch diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -176,7 +176,7 @@ artifacts:
     description: >
       Verifies boolean expressions match AadlBoolean and mismatch
       AadlString with appropriate diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -193,7 +193,7 @@ artifacts:
     description: >
       Verifies that range min/max expressions are checked against the
       inner type, and mismatched bounds produce diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -210,7 +210,7 @@ artifacts:
     description: >
       Verifies that record field expressions are checked against the
       corresponding field type in the RecordType definition.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -227,7 +227,7 @@ artifacts:
     description: >
       Verifies that UnitValue delegates type checking to its inner
       expression.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -244,7 +244,7 @@ artifacts:
     description: >
       Verifies that classifier values match Classifier types and
       reference values match Reference types.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -261,7 +261,7 @@ artifacts:
     description: >
       Verifies that computed values and type references skip validation
       (cannot be checked statically).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -279,7 +279,7 @@ artifacts:
       Verifies that when two imported packages both export a classifier
       with the same unqualified name, resolution produces an "ambiguous"
       warning listing the candidate packages.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -296,7 +296,7 @@ artifacts:
     description: >
       Verifies that fully qualified references (Pkg::Type) do not
       produce ambiguity warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -313,7 +313,7 @@ artifacts:
     description: >
       Verifies that references resolved within the same package do not
       produce ambiguity warnings even when imports have matching names.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -335,7 +335,7 @@ artifacts:
       Verifies that a model with mutual containment (A.Impl contains
       B, B.Impl contains A) produces a diagnostic containing "circular"
       or "cycle".
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -352,7 +352,7 @@ artifacts:
     description: >
       Verifies that SystemInstance::instantiate produces a circular
       containment diagnostic when given a model with cycles.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -369,7 +369,7 @@ artifacts:
     description: >
       Verifies that a linear (non-circular) hierarchy does not produce
       spurious circular containment diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -386,7 +386,7 @@ artifacts:
     description: >
       Verifies that an array with dimension 0 produces a diagnostic
       and the function returns 1 as fallback.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -403,7 +403,7 @@ artifacts:
     description: >
       Verifies that a valid positive array dimension produces no
       diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -420,7 +420,7 @@ artifacts:
     description: >
       Indirectly verifies that the Builder max_depth is 100 by testing
       that instantiation of deep hierarchies succeeds.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -441,7 +441,7 @@ artifacts:
     description: >
       Verifies that has_modes() returns false when the instance has
       no system operation modes.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/modal.rs
@@ -458,7 +458,7 @@ artifacts:
     description: >
       Verifies that has_modes() returns true and mode_names() returns
       the correct list when the instance has SOMs.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/modal.rs
@@ -475,7 +475,7 @@ artifacts:
     description: >
       Verifies that SchedulingAnalysis emits an Info diagnostic
       mentioning "system operation mode" when the instance has SOMs.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -492,7 +492,7 @@ artifacts:
     description: >
       Verifies that scheduling analysis does not emit the SOM awareness
       diagnostic when the instance has no system operation modes.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -515,7 +515,7 @@ artifacts:
       Intentionally_Unconnected does not produce a connectivity warning.
       Tests cover single feature, "all" variant, parenthesized list,
       and case-insensitive matching.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/connectivity.rs
@@ -533,7 +533,7 @@ artifacts:
       Regression guard verifying that ports without the
       Intentionally_Unconnected property still produce connectivity
       warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/connectivity.rs
@@ -550,7 +550,7 @@ artifacts:
     description: >
       Verifies that AnalysisRunner::register_all() registers exactly
       21 analysis passes and that the count matches expectations.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/lib.rs
@@ -569,7 +569,7 @@ artifacts:
       ms, sec, min, hr) against AS5506 Appendix A values. Includes
       forward/reverse conversions, adjacent ratio verification, and
       raw factor validation.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -587,7 +587,7 @@ artifacts:
       Tests validate size unit conversions (bits, Bytes, KByte, MByte,
       GByte, TByte) with factor verification (8x for bits/Bytes, 1024x
       for powers).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -604,7 +604,7 @@ artifacts:
     description: >
       Verifies that unit names are matched case-insensitively (e.g.,
       "MS", "Ms", "ms" all work).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -622,7 +622,7 @@ artifacts:
       Verifies that shared property accessors (get_timing_property,
       get_execution_time, get_size_property, get_processor_binding,
       extract_reference_target) parse property values correctly.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/property_accessors.rs
@@ -640,7 +640,7 @@ artifacts:
       Verifies that scheduling, latency, resource_budget, arinc653,
       binding_check, and binding_rules all import from
       property_accessors instead of defining private helpers.
-    status: passing
+    status: implemented
     fields:
       method: code-review
       evidence: >
@@ -659,7 +659,7 @@ artifacts:
       24 tests serialize each spar-hir public type to JSON, deserialize
       back, and assert structural equality. Covers all 16 serializable
       types plus all enum variants.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir/src/lib.rs
@@ -677,7 +677,7 @@ artifacts:
       Verifies that a complex InstanceNode tree (system > process >
       thread) with features, connections, array indices, and diagnostics
       survives JSON serialization round-trip.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir/src/lib.rs
@@ -699,7 +699,7 @@ artifacts:
       Verifies that when processor utilization exceeds the RMA bound
       but remains below 100%, the scheduling analysis emits an info
       diagnostic suggesting EDF scheduling as an alternative.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -714,7 +714,7 @@ artifacts:
     description: >
       Verifies that when utilization is within the RMA bound, no
       RMA/EDF cross-check diagnostic is emitted (not needed).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -729,7 +729,7 @@ artifacts:
     description: >
       Verifies that a +10% perturbation that crosses a schedulability
       bound produces a warning about thin timing margins.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -744,7 +744,7 @@ artifacts:
     description: >
       Verifies that systems with comfortable timing margins do not
       produce sensitivity warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -759,7 +759,7 @@ artifacts:
     description: >
       Verifies that a thread with Period but no Deadline emits an
       info diagnostic about implicit deadline equaling period.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -774,7 +774,7 @@ artifacts:
     description: >
       Verifies that a thread with both Period and Deadline does not
       emit the implicit-deadline info diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -789,7 +789,7 @@ artifacts:
     description: >
       Verifies that Compute_Execution_Time with min > max (e.g.,
       "5 ms .. 1 ms") produces an error diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -804,7 +804,7 @@ artifacts:
     description: >
       Verifies that worst-case execution time greater than period
       produces an error diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -819,7 +819,7 @@ artifacts:
     description: >
       Regression guard verifying that a valid range (min < max < period)
       does not produce execution time range errors.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -835,7 +835,7 @@ artifacts:
       Verifies that an end-to-end flow crossing processor boundaries
       without a Transmission_Time or Inter_Processor_Overhead property
       emits an info diagnostic about underestimated latency.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -850,7 +850,7 @@ artifacts:
     description: >
       Verifies that flows on the same processor do not trigger the
       inter-processor communication overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -865,7 +865,7 @@ artifacts:
     description: >
       Verifies that setting Transmission_Time on the flow owner
       suppresses the inter-processor overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -880,7 +880,7 @@ artifacts:
     description: >
       Verifies that processor utilization above 80% triggers a clock
       drift advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -895,7 +895,7 @@ artifacts:
     description: >
       Verifies that processor utilization below 80% does not trigger
       the clock drift advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -910,7 +910,7 @@ artifacts:
     description: >
       Verifies that threads without Context_Switch_Time or
       Interrupt_Overhead trigger an advisory diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -925,7 +925,7 @@ artifacts:
     description: >
       Verifies that setting Context_Switch_Time suppresses the
       interrupt overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -941,7 +941,7 @@ artifacts:
       Verifies that multiple threads on the same processor without
       Priority or Concurrency_Control_Protocol trigger a priority
       inversion advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -956,7 +956,7 @@ artifacts:
     description: >
       Verifies that setting Priority on threads suppresses the
       priority inversion advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -972,7 +972,7 @@ artifacts:
       Verifies get_execution_time_range returns correct (min, max)
       pairs for both range format ("1 ms .. 5 ms") and single
       values ("3 ms").
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/property_accessors.rs
@@ -992,7 +992,7 @@ artifacts:
       All tests in the spar workspace pass after batch 3 implementation
       (timing and scheduling safety requirements).
       cargo clippy --workspace reports no warnings.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       command: cargo test --workspace
@@ -1056,7 +1056,7 @@ artifacts:
       port defs, connections, attributes, states, constraints, and
       specialization, then compares the produced AADL ItemTree against
       expected output.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       test-location: crates/spar-sysml2/tests/
@@ -1076,7 +1076,7 @@ artifacts:
       item_def, enum_def, interface_def, requirement_def, constraint_def,
       calc_def, allocation_def, connection_usage) produces the expected
       AADL construct with correct category and structure.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1094,7 +1094,7 @@ artifacts:
       Will verify that unrecognized SysML v2 SyntaxKind variants
       produce a warning diagnostic instead of being silently dropped.
       Blocked on STPA-REQ-032 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1113,7 +1113,7 @@ artifacts:
       classified as process/thread (not system), and that subcomponent
       categories are propagated from referenced type definitions.
       Blocked on STPA-REQ-033 and STPA-REQ-034 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1134,7 +1134,7 @@ artifacts:
       produce typed PropertyExpr values (not Opaque), enabling downstream
       scheduling and timing analysis.
       Blocked on STPA-REQ-035 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1156,7 +1156,7 @@ artifacts:
       Will verify that verus_verify and lean_verify rules fail with
       a clear error when the tool binary is not found.
       Blocked on STPA-REQ-037 implementation.
-    status: planned
+    status: proposed
     fields:
       method: integration-test
       test-location: tools/bazel/rules_verus/defs.bzl
@@ -1174,7 +1174,7 @@ artifacts:
       Will verify that workspace_gen.rs produces verus_verify and/or
       lean_verify targets in per-crate BUILD.bazel files.
       Blocked on STPA-REQ-038 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-codegen/src/workspace_gen.rs
@@ -1192,7 +1192,7 @@ artifacts:
       Will verify that verus_verify and lean_verify rules validate
       proof log content and reject empty or error-only logs.
       Blocked on STPA-REQ-039 implementation.
-    status: planned
+    status: proposed
     fields:
       method: integration-test
       test-location: tools/bazel/rules_verus/defs.bzl


### PR DESCRIPTION
Closes #371.

Stacked on #368 (base is `fix/360-rivet-source-dedup`); GitHub will retarget to `main` when that merges. The two touch `artifacts/requirements.yaml` and so does #373 — whichever lands last needs a rebase.

## What this is

spar carried a private status vocabulary on **276 artifacts**. None of the four words is in the schema's allowed set, so every one was a `status-allowed-values` error and `rivet validate` could not run clean.

| from | to | n | lossy? |
|---|---|---|---|
| `passing` | `implemented` | 177 | no |
| `planned` | `proposed` | 40 | no |
| `not-implemented` | `proposed` | 51 | no |
| `partial` | `approved` | 8 | **yes** |

`passing` is the group worth naming. It is a verification **verdict** sitting in a lifecycle field, and a hand-edited YAML file cannot honestly assert that a test passes — only that the measure exists. That is what `implemented` says.

## The lossy eight

`partial` sits strictly between `approved` and `implemented`, and the vocabulary has no such rung. `approved` is the **conservative floor** — the strongest claim certainly true — rather than `implemented`, which would overstate.

Two of the eight (`RENDER-REQ-003`, `COVERAGE-GAPS`) already itemized their residue in prose and were left alone. The other five now say the residue is **not** itemized. That wording is deliberate and I want it reviewed as a choice, not skimmed as boilerplate: `lower.rs` has 54 `#[test]` functions, but STPA-REQ-036 requires *one test per lowering rule* — a mapping question a count cannot answer. Writing "54 tests exist" would be the necessary-but-not-sufficient trap. An explicit "not measured" is falsifiable; an invented figure is not, and inventing one is the exact failure #294 was reopened for.

## No new guard ships here — on purpose

rivet already enforces `status-allowed-values` at **ERROR** severity and `rivet validate` is already a required check, so the regression is mechanically blocked the moment this lands. A bespoke checker would add a weaker second oracle beside a working one.

This is the **opposite** of #370 / #373, which needed `tools/check_release_plane.py` precisely because rivet was *blind* to that defect.

## Verification — three planes that agree

1. **The migration proves its own edit.** Per file it asserts the artifact-id set is unchanged, every record is byte-identical outside `status`, and the text-rewrite count equals the semantic-move count. That last assertion is the load-bearing one: *"N lines rewritten"* is equally consistent with having rewritten N **prose** lines inside `description:` blocks while leaving N real statuses alone. Block scalars are tracked and skipped rather than `sed`'d through.
2. **The oracle flips.** `rivet validate` → exit 0, **0** error-severity diagnostics under `common@0.3.0 (embedded)`, down from 276. The diff is `276+/276-` on the status lines — a strict 1:1 swap, no structural change.
3. **The gate is live, not vacuous.** Re-introducing one off-vocabulary status reproduces **exactly one** `status-allowed-values` error; restoring it returns exit 0 with a byte-identical file. Distinct inputs → distinct verdicts. This is the property #327's withdrawn certificate did *not* have, so I no longer report an exit-0 without it.

## Reconciliation: why 303 raw hits but 276 errors

| | count | why |
|---|---|---|
| raw `status:` text matches, 9 committed files | 303 | |
| − `safety/requirements.yaml` | −21 | rivet **never loads it** — it is under no path in `rivet.yaml`'s `sources:` |
| − `safety/stpa/architecture.yaml` | −6 | nested in the `fields:` extension bag, where rivet cannot see them |
| **= rivet's error count** | **276** | ✅ exact |

Both remainders are **left in place and named** in `REQ-GUARD-STATUS-VOCAB-001` rather than silently absorbed into the total. The second one is the #370 defect one field over — `status:` instead of `release:` — and `tools/check_release_plane.py` from #373 would catch it by changing a single module-level constant (`FIELD = "release"`). That generalization is a follow-up, not this PR: doing it here would stack this branch three-deep and break the "vocabulary only" scope I posted to #371.

## Deliberately NOT in scope

Re-typing the 198 `TEST-*`/`VAL-*` measures to `unit-verification` and re-pointing `satisfies` → `verifies`. As measured on #371, those are ASPICE types requiring `sw-detail-design`/`sw-req`, of which spar has **zero** across 883 artifacts — adopting them would drag in SWE.1/SWE.2/SWE.3 and take feature-stage coverage from 194 requirements to 22. Separately scoped; the root friction is filed as pulseengine/rivet#748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
