### PR TITLE
fix(msrv): declare the Rust floor and gate it against the dependency closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,19 @@ jobs:
             --artifacts-dir artifacts \
             --artifacts-dir safety/stpa
 
+      # Closure MSRV drift (#369). Here rather than in a code-gated job for the
+      # same reason as above, and it matters more here than anywhere: the PR
+      # that raises the real floor is a `cargo update`, which touches only
+      # Cargo.lock. Behind `needs.changes.outputs.code` that is exactly the PR
+      # most likely to be filtered out.
+      #
+      # Cheap despite needing cargo: `cargo metadata` resolves, it does not
+      # compile, and this job already installs a toolchain for the rivet CLI.
+      - name: MSRV guardrail self-test
+        run: tools/check_msrv.py --self-test
+      - name: MSRV guardrail
+        run: tools/check_msrv.py
+
   # ── Bazel test sweep ───────────────────────────────────────────────
   # Issue #135 acceptance: `bazel test //...` to pick up Rust + Lean
   # targets via tools/bazel/rules_lean and rules_wasm_component.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,17 @@ members = [
 [workspace.package]
 version = "0.35.0"
 edition = "2024"
+# The floor is NOT a free choice — it is the maximum `rust-version` over the
+# whole resolved dependency closure, which cargo enforces whether or not it is
+# written down here. Declaring it makes that number a reviewable repo fact
+# instead of an emergent property of Cargo.lock that moves on every
+# `cargo update` with no diff anywhere in this repo.
+#
+# Currently set by smol_str@0.3.6 (1.89); the next tier down is 1.87.0
+# (wit-bindgen, wasip3). Do not hand-edit this to match a local toolchain —
+# tools/check_msrv.py re-derives the closure maximum and fails if this is
+# below it.
+rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"
 

--- a/crates/spar-analysis/Cargo.toml
+++ b/crates/spar-analysis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-analysis"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Pluggable analysis framework for AADL models"

--- a/crates/spar-annex/Cargo.toml
+++ b/crates/spar-annex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-annex"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Pluggable annex parser framework for AADL annexes (EMV2, BA, etc.)"

--- a/crates/spar-base-db/Cargo.toml
+++ b/crates/spar-base-db/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-base-db"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Salsa incremental computation database for AADL analysis"

--- a/crates/spar-cli/Cargo.toml
+++ b/crates/spar-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL toolchain CLI"

--- a/crates/spar-codegen/Cargo.toml
+++ b/crates/spar-codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-codegen"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Code generation from AADL instance models (Rust, WIT, Lean4, Kani, Bazel)"

--- a/crates/spar-dbc/Cargo.toml
+++ b/crates/spar-dbc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-dbc"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CAN .dbc ingest: parse a DBC network and emit AADL v2.3 source text"

--- a/crates/spar-hir-def/Cargo.toml
+++ b/crates/spar-hir-def/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-hir-def"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "HIR definitions and name resolution for AADL analysis"

--- a/crates/spar-hir/Cargo.toml
+++ b/crates/spar-hir/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-hir"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Public semantic API facade for AADL models"

--- a/crates/spar-insight/Cargo.toml
+++ b/crates/spar-insight/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-insight"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Statistical-discrepancy assistant: compares observed CTF timing traces to spar's Expected_BCET/WCET/Mean model predictions"

--- a/crates/spar-mcp/Cargo.toml
+++ b/crates/spar-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-mcp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MCP server exposing spar's verification oracles (read-only) for AI agent integration"

--- a/crates/spar-mermaid/Cargo.toml
+++ b/crates/spar-mermaid/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-mermaid"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Mermaid diagram emission for spar AADL instance models"

--- a/crates/spar-network/Cargo.toml
+++ b/crates/spar-network/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-network"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Network Calculus primitives for AADL WCTT analysis (TSN/Ethernet, Track D)"

--- a/crates/spar-parser/Cargo.toml
+++ b/crates/spar-parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-parser"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL parser — tree-agnostic recursive descent with error recovery"

--- a/crates/spar-render/Cargo.toml
+++ b/crates/spar-render/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-render"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SVG architecture visualization for AADL models"

--- a/crates/spar-solver/Cargo.toml
+++ b/crates/spar-solver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-solver"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Deployment solver for AADL models"

--- a/crates/spar-syntax/Cargo.toml
+++ b/crates/spar-syntax/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-syntax"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL syntax tree — lossless CST with typed AST layer"

--- a/crates/spar-sysml2/Cargo.toml
+++ b/crates/spar-sysml2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-sysml2"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SysML v2 parser, AADL lowering, and requirements extraction"

--- a/crates/spar-trace-topology/Cargo.toml
+++ b/crates/spar-trace-topology/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-trace-topology"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Runtime/declared topology reconciliation for spar (PCAPNG + LLDP + Qcc + AADL)"

--- a/crates/spar-transform/Cargo.toml
+++ b/crates/spar-transform/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-transform"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Bidirectional transforms between AADL and external formats (WIT, etc.)"

--- a/crates/spar-variants/Cargo.toml
+++ b/crates/spar-variants/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-variants"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Consumer-side adapter for rivet's variant context blob (v1) — filters spar HIR by binding rules"

--- a/crates/spar-verify-macros/Cargo.toml
+++ b/crates/spar-verify-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-verify-macros"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Proc macros for AADL configuration verification"

--- a/crates/spar-verify/Cargo.toml
+++ b/crates/spar-verify/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-verify"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL configuration verification attributes"

--- a/crates/spar-wasm/Cargo.toml
+++ b/crates/spar-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-wasm"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "WASM component for AADL parsing, analysis, and SVG rendering"

--- a/tools/check_msrv.py
+++ b/tools/check_msrv.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Gate the declared MSRV against the resolved dependency closure (#369).
+
+THE FAILURE
+-----------
+spar has a minimum supported Rust version whether or not anyone writes it
+down, because cargo enforces one: a build fails if the toolchain is below the
+maximum `rust-version` over the entire *resolved dependency closure*. Before
+this gate, `[workspace.package]` declared no `rust-version` and there was no
+`rust-toolchain.toml`, so the real floor was
+
+    max(rust-version) over every package in Cargo.lock
+
+— an emergent property of the lockfile. It moves on any `cargo update` with no
+diff anywhere in this repo, and it was discovered at build time by whichever
+consumer happened to have the oldest toolchain.
+
+WHY IT IS WORTH A GATE RATHER THAN A DECLARATION
+------------------------------------------------
+It already caused a defect. In #364 the tools/fixture-vm nixpkgs pin was moved
+24.05 -> 25.05 and recorded as "cannot compile -> can compile". The reasoning
+was: edition 2024 needs rustc >= 1.85, 25.05 ships 1.86.0, 1.86 >= 1.85, done.
+Every step of that is true. The conclusion was still wrong:
+
+    error: rustc 1.86.0 is not supported by the following package:
+      smol_str@0.3.6 requires rustc 1.89
+
+The edition floor is a *necessary* condition that got mistaken for *the*
+condition. The failure mode worth naming, because it is not "forgot to check":
+the probe genuinely ran and genuinely returned true. A one-variable check that
+comes back green is the most convincing way to not verify something — it
+produces the feeling of verification while silently scoping the claim to the
+one variable you happened to think of.
+
+A bare `rust-version = "..."` line does not fix that. A declaration is just
+another number that can go stale against the closure. So the declaration is the
+subject of this check, not the answer to it.
+
+WHAT IT CHECKS
+--------------
+1. Every workspace member has an effective `rust-version`.  A new crate that
+   forgets `rust-version.workspace = true` is silently exempt from the floor,
+   and would publish to crates.io claiming to build on toolchains it cannot.
+2. All members agree.  A per-crate override that diverges from the workspace
+   makes "the MSRV" ambiguous.
+3. **The closure maximum does not exceed the declared floor.**  This is the
+   drift gate: the `cargo update` that raises the real floor goes red on the PR
+   that introduces it, naming the package responsible, instead of surfacing two
+   months later inside a nix derivation.
+
+WHY IT READS `cargo metadata` RATHER THAN PARSING Cargo.toml
+------------------------------------------------------------
+`rust-version.workspace = true` means the value a member actually carries is
+computed by cargo, not written in its manifest. Re-parsing TOML would check
+what the files say; `cargo metadata` reports what cargo resolved, which is what
+is actually enforced. It also makes guard 1 fall out for free — a member that
+failed to inherit simply has no `rust_version` in the metadata.
+
+`--locked` is deliberate: the check must describe the committed lockfile, not
+whatever a resolver would pick today.
+
+THE DELIBERATE ASYMMETRY
+------------------------
+declared < closure  -> FAIL.  Consumers on the declared floor cannot build.
+declared > closure  -> report, do not fail.  An inflated floor excludes
+consumers unnecessarily, but it can also be a legitimate choice: spar's own
+source may use a feature newer than anything its dependencies require, and
+nothing here can tell those two cases apart. Failing would block the
+legitimate one. It is printed so it stays visible rather than silently drifting.
+
+WHAT THIS DOES NOT CLAIM
+------------------------
+- It does NOT verify that spar's own source compiles on the declared floor.
+  That needs a CI job pinned to that toolchain, which this is not. The claim
+  here is narrower and exact: the declared floor is not below what the
+  dependency closure demands.
+- It does not check the nix channel's rustc. That comparison lives in the
+  fixture-vm workflow, where a nix evaluation is already paid for, and is what
+  turns a 14-minute build failure into a several-second one.
+
+Stdlib only, matching the constraint documented above the human-scoped
+guardrail in ci.yml: no workflow here installs a Python package, so importing
+one would make a *required* check depend on an unverified runner package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_CANNOT_CHECK = 2
+
+
+def parse_version(text):
+    """`1.89` -> (1, 89, 0). Zero-padded so `1.89` and `1.89.0` compare equal.
+
+    Numeric, never lexicographic. The trap this avoids is real: as strings,
+    "1.100" < "1.99", so a naive comparison would pass a closure floor that is
+    actually higher than the declared one. `sort -V` gets this right but is a
+    GNU extension; this does not depend on which sort is installed.
+    """
+    parts = text.strip().split(".")
+    out = []
+    for p in parts[:3]:
+        digits = ""
+        for ch in p:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            raise ValueError(f"not a version: {text!r}")
+        out.append(int(digits))
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out)
+
+
+def load_metadata():
+    """Run `cargo metadata`, or exit 2. A gate that cannot run is not a pass."""
+    try:
+        proc = subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--locked"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("::error::cargo not found; cannot derive the closure MSRV.", file=sys.stderr)
+        sys.exit(EXIT_CANNOT_CHECK)
+    if proc.returncode != 0:
+        print("::error::`cargo metadata --locked` failed. If this is a lockfile", file=sys.stderr)
+        print("::error::mismatch, commit the updated Cargo.lock.", file=sys.stderr)
+        sys.stderr.write(proc.stderr[-2000:])
+        sys.exit(EXIT_CANNOT_CHECK)
+    return json.loads(proc.stdout)
+
+
+def analyse(meta):
+    """Split the resolved graph into workspace members and everything else.
+
+    Returns (members, closure) as lists of (name, version, rust_version|None).
+    """
+    member_ids = set(meta.get("workspace_members", []))
+    members, closure = [], []
+    for p in meta.get("packages", []):
+        row = (p.get("name"), p.get("version"), p.get("rust_version"))
+        (members if p.get("id") in member_ids else closure).append(row)
+    return members, closure
+
+
+def run_check(meta, verbose=True):
+    members, closure = analyse(meta)
+    problems = []
+
+    if not members:
+        print("::error::no workspace members in cargo metadata — refusing to", file=sys.stderr)
+        print("::error::report a floor derived from nothing.", file=sys.stderr)
+        return EXIT_CANNOT_CHECK
+
+    # Guard 1: a member with no effective rust-version is exempt from the floor.
+    missing = [f"{n}@{v}" for n, v, rv in members if not rv]
+    if missing:
+        problems.append(
+            "::error::%d workspace member(s) declare no rust-version:\n%s\n"
+            "::error::Add `rust-version.workspace = true` to each, next to\n"
+            "::error::`edition.workspace = true`. Without it the crate publishes\n"
+            "::error::claiming to build on toolchains the workspace does not support."
+            % (len(missing), "\n".join("::error::  " + m for m in missing))
+        )
+
+    # Guard 2: members must agree, or "the MSRV" has no referent.
+    declared_set = {rv for _, _, rv in members if rv}
+    if len(declared_set) > 1:
+        problems.append(
+            "::error::workspace members declare conflicting rust-versions: %s\n"
+            "::error::Set it once in [workspace.package] and inherit it."
+            % ", ".join(sorted(declared_set))
+        )
+
+    if problems:
+        for p in problems:
+            print(p, file=sys.stderr)
+        return EXIT_VIOLATION
+
+    declared_text = next(iter(declared_set))
+    declared = parse_version(declared_text)
+
+    # Guard 3: the drift gate.
+    rated = [(parse_version(rv), n, v, rv) for n, v, rv in closure if rv]
+    if not rated:
+        print("::error::no dependency in the closure declares a rust-version.", file=sys.stderr)
+        print("::error::That is implausible for this lockfile — refusing to pass", file=sys.stderr)
+        print("::error::on a comparison against an empty set.", file=sys.stderr)
+        return EXIT_CANNOT_CHECK
+
+    top = max(rated)
+    closure_max, top_name, top_ver, top_text = top
+    raisers = sorted({f"{n}@{v}" for pv, n, v, _ in rated if pv == closure_max})
+
+    if verbose:
+        print(
+            f"declared floor : {declared_text}  ([workspace.package] rust-version, "
+            f"inherited by {len(members)} member(s))"
+        )
+        print(
+            f"closure maximum: {top_text}  (set by {', '.join(raisers)}; "
+            f"{len(rated)} of {len(closure)} dependencies declare one)"
+        )
+
+    if closure_max > declared:
+        print(
+            "::error::the dependency closure requires rustc %s, but "
+            "[workspace.package] rust-version declares %s." % (top_text, declared_text),
+            file=sys.stderr,
+        )
+        for r in raisers:
+            print(f"::error::  raised by: {r}", file=sys.stderr)
+        print(
+            "::error::Anything built against the declared floor will fail with\n"
+            "::error::`rustc %s is not supported by the following package`.\n"
+            "::error::Either raise rust-version to %s, or pin the dependency back."
+            % (declared_text, top_text),
+            file=sys.stderr,
+        )
+        return EXIT_VIOLATION
+
+    if closure_max < declared and verbose:
+        print(
+            f"note: the declared floor is above the closure maximum "
+            f"({declared_text} > {top_text}). Not an error — spar's own source may "
+            f"need it — but nothing here verifies that, so it is reported rather "
+            f"than assumed."
+        )
+
+    if verbose:
+        print(f"PASS: declared floor {declared_text} covers the closure.")
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Self-tests. Fixtures are cargo-metadata-shaped dicts, so they run without a
+# toolchain and without a lockfile. Each records the failure it proves is still
+# caught; a test whose `proves` string does not name a real failure is a test
+# that will survive the deletion of the logic it claims to cover.
+# ---------------------------------------------------------------------------
+
+
+def _meta(members, deps):
+    """members/deps: list of (name, version, rust_version|None)."""
+    pkgs, ids = [], []
+    for i, (n, v, rv) in enumerate(members):
+        pid = f"member {i}"
+        ids.append(pid)
+        pkgs.append({"id": pid, "name": n, "version": v, "rust_version": rv})
+    for i, (n, v, rv) in enumerate(deps):
+        pkgs.append({"id": f"dep {i}", "name": n, "version": v, "rust_version": rv})
+    return {"workspace_members": ids, "packages": pkgs}
+
+
+SELF_TESTS = [
+    (
+        "clean: declared equals closure max",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_OK,
+        "the checker can return 0 at all — without this the rest is consistent "
+        "with a script that always fails",
+    ),
+    (
+        "closure above declared (the #364 defect shape)",
+        _meta([("spar-cli", "0.35.0", "1.86")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_VIOLATION,
+        "the exact drift that broke the fixture-vm build: a dependency demands "
+        "more than the declared floor",
+    ),
+    (
+        "member missing rust-version",
+        _meta(
+            [("spar-cli", "0.35.0", "1.89"), ("spar-new", "0.35.0", None)],
+            [("smol_str", "0.3.6", "1.89")],
+        ),
+        EXIT_VIOLATION,
+        "a new crate that forgets `rust-version.workspace = true` is exempt from "
+        "the floor and would publish a claim it cannot honour",
+    ),
+    (
+        "members disagree",
+        _meta(
+            [("spar-cli", "0.35.0", "1.89"), ("spar-core", "0.35.0", "1.85")],
+            [("smol_str", "0.3.6", "1.85")],
+        ),
+        EXIT_VIOLATION,
+        "with two different floors declared, 'the MSRV' has no referent and the "
+        "comparison in guard 3 would be against an arbitrary one of them",
+    ),
+    (
+        "declared above closure max is allowed",
+        _meta([("spar-cli", "0.35.0", "1.90")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_OK,
+        "the asymmetry is deliberate: spar's own source may need more than its "
+        "dependencies, and failing here would block that legitimate case",
+    ),
+    (
+        "1.89 vs 1.89.0 are the same floor",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("dep", "1.0.0", "1.89.0")]),
+        EXIT_OK,
+        "crates.io mixes both spellings (this lockfile has '1.89' and '1.87.0'); "
+        "treating them as different would red the build over formatting",
+    ),
+    (
+        "1.100 is above 1.99, not below it",
+        _meta([("spar-cli", "0.35.0", "1.99")], [("dep", "1.0.0", "1.100")]),
+        EXIT_VIOLATION,
+        "as strings '1.100' < '1.99', so a lexicographic compare passes a floor "
+        "that is actually too low — the comparison must be numeric",
+    ),
+    (
+        "no dependency declares a rust-version",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("dep", "1.0.0", None)]),
+        EXIT_CANNOT_CHECK,
+        "an empty closure means the metadata was not what we think it is; "
+        "passing on a comparison against nothing reads as coverage",
+    ),
+    (
+        "no workspace members",
+        _meta([], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_CANNOT_CHECK,
+        "same fail-closed rule at the other end: no members means no declared "
+        "floor to compare against",
+    ),
+]
+
+
+def self_test():
+    failures = 0
+    for name, meta, want, proves in SELF_TESTS:
+        # Capture the fixtures' stderr rather than letting it through. Six of
+        # these cases are *supposed* to fail, and their messages are
+        # `::error::` lines — which are GitHub Actions workflow commands, not
+        # plain text. Emitted from a passing self-test they would stamp eight
+        # red annotations onto the PR's diff view while the step exits 0. That
+        # is the same defect this whole gate exists to prevent: output that
+        # renders as a claim it does not support. The captured text is printed
+        # only when a case actually fails, where it is the debugging evidence.
+        buf, real = io.StringIO(), sys.stderr
+        sys.stderr = buf
+        try:
+            got = run_check(meta, verbose=False)
+        finally:
+            sys.stderr = real
+        ok = got == want
+        failures += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}: exit {got} (want {want})")
+        print(f"       proves: {proves}")
+        if not ok:
+            for line in buf.getvalue().splitlines():
+                print(f"       | {line.replace('::error::', '')}")
+    print()
+    if failures:
+        print(f"{failures} self-test(s) FAILED.", file=sys.stderr)
+        return EXIT_VIOLATION
+    print(f"{len(SELF_TESTS)} self-test(s) passed.")
+    return EXIT_OK
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the inline fixtures; no cargo or lockfile needed",
+    )
+    ap.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="print the derived floors and exit 0 regardless of the verdict",
+    )
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
+    meta = load_metadata()
+    rc = run_check(meta)
+    sys.exit(EXIT_OK if args.print_only else rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Addresses #369 (the closure-vs-declared half; see **Deliberately not in this PR** below).

## The gap

spar has a minimum supported Rust version whether or not anyone writes it down,
because cargo enforces one. Nothing in the repo stated it — `[workspace.package]`
declared no `rust-version`, and there is no `rust-toolchain.toml`. So the
effective floor was

```
max(rust-version) over the entire RESOLVED DEPENDENCY CLOSURE
```

an emergent property of `Cargo.lock` that **moves on any `cargo update` with no
diff anywhere in this repo**, discovered at build time by whichever consumer
happened to have the oldest toolchain.

Measured on the committed lock: **152 of 212** dependencies declare a
`rust-version`; the maximum is **1.89**, from `smol_str@0.3.6`, one tier above
the 1.87.0 cluster (`wit-bindgen`, `wasip3`).

## Why a gate and not just a line

It already caused a defect. In #364 the fixture-vm nixpkgs pin moved 24.05 →
25.05, recorded as *"cannot compile → can compile"*. The reasoning: edition 2024
needs rustc ≥ 1.85, 25.05 ships 1.86.0, 1.86 ≥ 1.85, done. **Every step true.
Conclusion wrong:**

```
error: rustc 1.86.0 is not supported by the following package:
  smol_str@0.3.6 requires rustc 1.89
```

The edition floor is a *necessary* condition mistaken for *the* condition. Worth
naming precisely because it isn't "forgot to check": **the probe genuinely ran
and genuinely returned true.** A one-variable check that comes back green is the
most convincing way to not verify something — it produces the feeling of
verification while silently scoping the claim to the one variable you thought of.

A bare `rust-version` line doesn't fix that; a declaration is just another number
that can go stale. So the declaration is the **subject** of the check, not the
answer to it.

## What landed

- `[workspace.package] rust-version = "1.89"`, inherited by all 23 members via
  `rust-version.workspace = true` — the same way they already inherit
  `version`/`edition`/`license`/`repository`. **`Cargo.lock` is unchanged**: this
  is a declaration, not a dependency change.
- `tools/check_msrv.py` re-derives the closure maximum from
  `cargo metadata --locked` and fails if it exceeds the declared floor, naming
  the package responsible.

It reads `cargo metadata` rather than parsing `Cargo.toml` because
`rust-version.workspace = true` means the effective value is *computed by cargo*,
not written in the member manifest. Metadata reports what cargo actually
enforces — and a member that failed to inherit simply has no `rust_version`, so
that guard falls out for free.

**The asymmetry is deliberate.** `declared < closure` → fail (consumers cannot
build). `declared > closure` → reported, not failed: spar's own source may
legitimately need more than its dependencies, and nothing here can tell that
apart from staleness. Failing would block the legitimate case.

## Verified two-sidedly, against the real workspace

A gate that cannot fire is worse than none, because it reads as coverage. So the
negative case is run against the actual lockfile, not a fixture:

```
POSITIVE  declared 1.89, committed lock
  declared floor : 1.89  (inherited by 23 member(s))
  closure maximum: 1.89  (set by smol_str@0.3.6; 152 of 212 deps declare one)
  PASS: declared floor 1.89 covers the closure.                        rc=0

NEGATIVE  declared 1.86 — the exact 25.05 rustc that broke #364
  ::error::the dependency closure requires rustc 1.89, but
  ::error::[workspace.package] rust-version declares 1.86.
  ::error::  raised by: smol_str@0.3.6                                 rc=1
```

That is what #369 asked for: the negative case fails **and names
`smol_str@0.3.6`**.

## Nine self-tests

Each records the failure it proves is still caught. Two are about the comparison
itself:

- **`1.89` and `1.89.0` must be the same floor** — crates.io mixes both
  spellings and this very lockfile contains both. Treating them as different
  would red the build over formatting.
- **`1.100` must be ABOVE `1.99`** — as strings it is *below*, so a lexicographic
  compare would pass a floor that is actually too low. The issue's sketch used
  `sort -V | tail -1`, which is correct but a GNU extension; this doesn't depend
  on which `sort` is installed.

The self-test **captures its fixtures' stderr** rather than letting it through.
Six cases are supposed to fail, and their messages are `::error::` lines —
GitHub Actions *workflow commands*, not plain text. Emitted from a passing
self-test they would stamp **eight red annotations onto the PR diff while the
step exits 0**. That's the same defect class this gate exists to prevent, so it
would have been an unusually poor thing to ship here.

## Wiring

Into `rivet-validate`, not a code-gated job. The PR that raises the real floor is
a `cargo update` touching only `Cargo.lock` — exactly the PR most likely to be
filtered out by a path filter. Same reasoning already documented above the
human-scoped guardrail. `cargo metadata` resolves, it does not compile, and that
job already installs a toolchain.

## What this does NOT claim

It does **not** verify that spar's own source compiles on 1.89. That needs a job
pinned to that toolchain. The claim here is narrower and exact: *the declared
floor is not below what the dependency closure demands.*

## Deliberately not in this PR

The channel-rustc half of #369 — compare nixpkgs' `rustc` against this floor at
nix **evaluation** time, turning a 14-minute build failure into a seconds-long
one — is not here, for two reasons, the second being the real one:

1. I cannot verify the `nix eval` expression locally, and shipping an unverified
   probe is precisely the failure this issue is about.
2. It lands in `trace-fixtures.yml`, which **#364 is currently trying to get
   green for the first time in that workflow's history**. Injecting a new
   unverified step into that file now would confound the run in flight.

Follow-up once #364 lands. #369 stays open until then.

## Conflict note

Touches `.github/workflows/ci.yml`'s `rivet-validate` job, as does #377.
Whichever merges second needs a rebase.

## Scope

CI plumbing + manifest declarations, no rivet artifact — matching the
#353/#363/#364/#366/#372 precedent; this repo carries no `REQ-CI-*` ids. Flagged
so the omission reads as a choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)