### PR TITLE
ci: six reviewed guardrail PRs as one branch, plus two gate repairs (#381, #383)

### DIFF
--- a/.github/required-contexts.txt
+++ b/.github/required-contexts.txt
@@ -1,0 +1,44 @@
+# Required status checks on `main` — the expected set (issue #372).
+#
+# This file is the committed half of a reconciliation that has three moving
+# parts and only ever had two of them written down:
+#
+#   .github/workflows/*   what actually runs
+#   THIS FILE             what we intend to enforce
+#   branch protection     what GitHub enforces
+#
+# `tools/check_required_contexts.py` reconciles the first two on every PR. It
+# cannot reconcile the third: reading branch protection needs an ADMIN token and
+# the Actions GITHUB_TOKEN is not one. Run
+# `tools/check_required_contexts.py --against-api` with admin credentials to
+# close that leg. Regenerate this file with `--print`.
+#
+# A context belongs here if and only if its job runs on every PR against main
+# and cannot fail open. Two kinds of job must NOT be listed:
+#
+#   * `continue-on-error` jobs — they report success whatever happened, so
+#     requiring one enforces nothing.
+#   * jobs in workflows with a workflow-level `on.pull_request.paths` filter —
+#     a workflow that does not trigger reports NOTHING, so the context sits at
+#     "Expected — waiting for status" and the PR deadlocks. Move the filter to a
+#     job-level `if:` first; an if:-skipped job reports "skipped", which
+#     satisfies a required context.
+#
+Bench compile smoke
+Cargo Deny
+Clippy
+Code Coverage
+Codegen compile oracle
+Detect changed paths
+Detect changed paths (proofs)
+Format
+Fuzz smoke (60s/target)
+Lean proof typecheck (lake build)
+Miri
+Mutation Testing
+Proptest (extended)
+Rivet validate (artifacts)
+Security Audit (RustSec)
+Supply Chain (cargo-vet)
+Test
+Verification Gate (rivet-driven)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,18 @@ jobs:
         run: tools/check_required_contexts.py --self-test
       - name: Required-context guardrail
         run: tools/check_required_contexts.py
+      # Closure MSRV drift (#369). Here rather than in a code-gated job for the
+      # same reason as above, and it matters more here than anywhere: the PR
+      # that raises the real floor is a `cargo update`, which touches only
+      # Cargo.lock. Behind `needs.changes.outputs.code` that is exactly the PR
+      # most likely to be filtered out.
+      #
+      # Cheap despite needing cargo: `cargo metadata` resolves, it does not
+      # compile, and this job already installs a toolchain for the rivet CLI.
+      - name: MSRV guardrail self-test
+        run: tools/check_msrv.py --self-test
+      - name: MSRV guardrail
+        run: tools/check_msrv.py
 
   # ── Bazel test sweep ───────────────────────────────────────────────
   # Issue #135 acceptance: `bazel test //...` to pick up Rust + Lean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,18 @@ jobs:
           # both artifacts and Rust must still run the full suite.
           # Counted explicitly rather than relying on `grep -q` exit semantics,
           # so the gate's decision is readable in the job log.
-          allow='^(artifacts/.*\.ya?ml|safety/.*|docs/.*|[^/]*\.md|.*/.*\.md)$'
+          #
+          # `rivet.yaml` is on the list (#379) because it is a rivet artifact by
+          # every other statement in this file — the header above says "rivet
+          # artifacts", and the rivet-validate job says it catches regressions
+          # "in artifacts/, safety/stpa/, and rivet.yaml" — but it lives at the
+          # repo root, so `artifacts/.*` never matched it and a rivet.yaml-only
+          # PR ran the entire heavy suite. Safe to skip those jobs for it:
+          # nothing that compiles reads the file (no .rs, no build script, no
+          # Cargo.toml references it; only AGENTS.md, docs/, this workflow, and
+          # artifacts themselves), and it stays gated regardless because
+          # rivet-validate has no `changes` gate at all.
+          allow='^(artifacts/.*\.ya?ml|safety/.*|docs/.*|rivet\.yaml|[^/]*\.md|.*/.*\.md)$'
           n_code=$(printf '%s\n' "$changed" | grep -cvE "$allow" || true)
           echo "code-ish files in diff: $n_code"
           if [ "$n_code" -gt 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      # `cargo fmt --all` means "all members of THIS workspace", not "all
+      # crates in the repo". fuzz/, codegen-exec-oracle/ and
+      # codegen-kiln-oracle/ each carry their own `[workspace]` table, so the
+      # root's --all never opened them — and this required check reported green
+      # on main over an unformatted fuzz_codegen_roundtrip.rs (#383). A gate
+      # that prints nothing on success cannot distinguish "checked everything"
+      # from "checked a subset"; the replacement always prints the count.
+      #
+      # Self-test first, as with the other guardrails: the decision table
+      # carries the #383 regression itself (root clean + fuzz/ dirty must exit
+      # 1), so the gate proves it can still fail before it may pass.
+      - name: Format guardrail self-test
+        run: tools/check_fmt_workspaces.py --self-test
+      - name: Format (every workspace in the repo)
+        # Discovers the workspace set rather than listing it, and floors the
+        # count at 4. A hard-coded list would fix today's bug and re-open it
+        # the day someone adds a fifth workspace.
+        run: tools/check_fmt_workspaces.py
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,14 +362,33 @@ jobs:
         # (2026-03-22) to #381 without anyone able to run it against a report.
         # The script's docstring carries the mechanism and the evidence.
         #
-        # 210 is the measured survivor count on main @ cd4d429 (run
-        # 30563879100). The previous 142 was a real hand-measurement — recorded
-        # in 5d6d98a, "down from 220" — but was never enforced, so raising it
-        # relaxes nothing that was ever in force; it is the first value this
-        # gate has actually checked against. The 142 → 210 drift over four
-        # blind months is exactly what a ratchet exists to prevent. Walking it
-        # back down is #382. Lower this number; do not raise it.
-        run: tools/check_mutants_report.py --output-dir mutants-out --max-missed 210
+        # 292 is the survivor count from the only run of this gate that has
+        # ever FINISHED: run 30586785648, "1737 mutants tested in 87m: 292
+        # missed, 708 caught, 735 unviable, 2 timeouts", outcomes.json carrying
+        # a populated end_time.
+        #
+        # It is not a relaxation of 210, because 210 was never a measurement of
+        # this codebase. Run 30563879100 died 3h02m in — cargo-mutants' worker
+        # temp trees were deleted underneath it ("does not exist, refusing to
+        # create it") — after testing 1608 of the 1737 mutants it had found.
+        # `|| true` swallowed the crash. Its artifact therefore records
+        # total_mutants 1608 and end_time null: a partial run, whose 210 is the
+        # survivor count of the 92% that ran. Both runs used cargo-mutants
+        # 27.1.0 against byte-identical spar-analysis/src, so 210 → 292 is
+        # entirely the 129 mutants the crashed run never reached.
+        #
+        # The earlier 142 (5d6d98a, "down from 220") was a real hand
+        # measurement, but the gate was misreading its report for the whole
+        # four months it stood, so no number here has yet been enforced
+        # against a complete run. 292 is the first.
+        #
+        # Lower this number as tests improve; target 0. Raise it only against a
+        # run whose outcomes.json has an end_time — a partial run reports FEWER
+        # survivors than the truth, so a threshold taken from one is a ceiling
+        # set below the floor. Nothing here yet fails a truncated run: that
+        # detector, and the runner disk-pressure fault behind it, are #389.
+        # Walking the number back down is #382.
+        run: tools/check_mutants_report.py --output-dir mutants-out --max-missed 292
       - name: Upload mutants report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,11 @@ jobs:
     # The full-workspace exhaustive run lives in mutants-weekly.yml; this
     # gating job stays narrow (spar-analysis) with a survivor ratchet.
     runs-on: [self-hosted, linux, x64, lean-mem]
+    # The only run of this job to reach `success` in the last 25 CI runs took
+    # 182.3 minutes; the other 16 were cancelled by a later push. With no
+    # timeout it inherits GitHub's 6-hour default, so a wedged run holds a
+    # lean-mem runner for a shift. 240 gives the measured duration ~30% headroom.
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -320,23 +325,34 @@ jobs:
         with:
           tool: cargo-mutants
       - name: Run cargo-mutants on spar-analysis
+        # `|| true` because cargo-mutants exits non-zero whenever ANY mutant
+        # survives and the ratchet below tolerates a bounded number. That makes
+        # this step incapable of reporting failure — so the next step has to
+        # prove the run happened rather than infer it from a missing file.
         run: cargo mutants -p spar-analysis --timeout 120 --jobs 4 --output mutants-out -- --lib || true
+      # Runs FIRST, for the same reason as the other guardrail self-tests: the
+      # decision table includes the #381 regression itself (outcome files at the
+      # shallow path must FAIL, not read as zero survivors), so a refactor that
+      # reintroduced the misread would fail here rather than pass vacuously
+      # below. This gate spent four months unable to fail; it now has to prove
+      # it still can before it is allowed to judge anything.
+      - name: Mutants-report guardrail self-test
+        run: tools/check_mutants_report.py --self-test
       - name: Check surviving mutants
-        run: |
-          MISSED=$(grep -c '^MISSED' mutants-out/caught.txt 2>/dev/null || echo 0)
-          if [ -f mutants-out/missed.txt ]; then
-            MISSED=$(wc -l < mutants-out/missed.txt | tr -d ' ')
-          fi
-          echo "Surviving mutants: $MISSED"
-          # Ratchet gate: fail if more mutants survive than the threshold.
-          # Lower this number as tests improve. Target: 0.
-          MAX_MISSED=142
-          if [ "$MISSED" -gt "$MAX_MISSED" ]; then
-            echo "::error::$MISSED mutant(s) survived (threshold: $MAX_MISSED) — add tests to kill them"
-            cat mutants-out/missed.txt 2>/dev/null | head -30
-            exit 1
-          fi
-          echo "Mutant survivors ($MISSED) within threshold ($MAX_MISSED). Target: 0."
+        # The logic lives in tools/check_mutants_report.py rather than inline
+        # here because inline shell in a workflow is only testable by pushing —
+        # which is precisely how the original misread survived from 563eb8c
+        # (2026-03-22) to #381 without anyone able to run it against a report.
+        # The script's docstring carries the mechanism and the evidence.
+        #
+        # 210 is the measured survivor count on main @ cd4d429 (run
+        # 30563879100). The previous 142 was a real hand-measurement — recorded
+        # in 5d6d98a, "down from 220" — but was never enforced, so raising it
+        # relaxes nothing that was ever in force; it is the first value this
+        # gate has actually checked against. The 142 → 210 drift over four
+        # blind months is exactly what a ratchet exists to prevent. Walking it
+        # back down is #382. Lower this number; do not raise it.
+        run: tools/check_mutants_report.py --output-dir mutants-out --max-missed 210
       - name: Upload mutants report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,19 @@ jobs:
             --artifacts-dir artifacts \
             --artifacts-dir safety/stpa
 
+      # Required-context drift (#372). Same stdlib-only, fail-closed rules as
+      # above, and here for the same reason: it must run on the PR that edits a
+      # workflow, and that PR need not touch anything a path filter selects.
+      #
+      # Deliberately steps of *this* job rather than a job of its own. A new job
+      # would itself be gateable, so it would have to be added to
+      # .github/required-contexts.txt — and syncing branch protection to match
+      # needs an admin token CI does not have. It would ship permanently red.
+      - name: Required-context guardrail self-test
+        run: tools/check_required_contexts.py --self-test
+      - name: Required-context guardrail
+        run: tools/check_required_contexts.py
+
   # ── Bazel test sweep ───────────────────────────────────────────────
   # Issue #135 acceptance: `bazel test //...` to pick up Rust + Lean
   # targets via tools/bazel/rules_lean and rules_wasm_component.
@@ -478,7 +491,11 @@ jobs:
   #
   # Time budget: cold cache ≤30 min, warm ≤5 min (per #135).
   bazel-test:
-    name: Bazel test (//...)
+    # "(advisory)" is in the NAME, not just the comment above, because the name
+    # is the only thing a PR reader sees. `continue-on-error` makes the tick
+    # green whatever happened — without the marker the check-run renders a claim
+    # the run does not support. Enforced by tools/check_required_contexts.py.
+    name: Bazel test (//...) (advisory)
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     # Stays on ubuntu-latest until Bazel is installed on the smithy host.
@@ -529,7 +546,12 @@ jobs:
   #      continue-on-error to false and add to the required-checks list.
   #   3. At that point, extend MAX_TASKS from 4 to 8 and re-tune unwinds.
   kani:
-    name: Kani Bounded Model Checking
+    # "(advisory)" belongs in the name for as long as step 2 above is pending:
+    # `continue-on-error` greens the tick regardless, and "Kani Bounded Model
+    # Checking ✓" is exactly the claim a reader should not draw from that.
+    # Drop the marker in the same commit that flips continue-on-error to false
+    # and adds this to .github/required-contexts.txt — the gate will insist.
+    name: Kani Bounded Model Checking (advisory)
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     # Stays on ubuntu-latest because kani-verifier bundles CBMC (~100 MB)

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -26,10 +26,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - fuzz_aadl_parse
-          - fuzz_scheduler_solver
-          - fuzz_codegen_roundtrip
+        # `include` rather than a flat `target:` list because the input-length
+        # cap is a property of the individual harness, not of fuzzing here
+        # (#361). Only fuzz_scheduler_solver fails: across the last 97 runs
+        # the other two legs concluded `success` every time. They consume
+        # arbitrarily long AADL/WIT source text, so a shared -max_len would
+        # shrink the reachable input space of two HEALTHY fuzzers to fix a
+        # third — a silent regression paid for by an unrelated leg's bug.
+        include:
+          - target: fuzz_aadl_parse
+            extra_args: ""
+          # This cap is lossless, not a coverage trade. The harness opens with
+          # `input.tasks.len().min(8)` / `input.processors.len().min(4)`, and
+          # `Arbitrary` grows those Vecs to consume whatever buffer it is
+          # given — so every byte past the ~120 the capped domain can encode
+          # produces a `Task` that is allocated and then discarded unread.
+          # Capping removes allocation churn, not reachable states.
+          - target: fuzz_scheduler_solver
+            extra_args: "-max_len=128"
+          - target: fuzz_codegen_roundtrip
+            extra_args: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -56,10 +72,38 @@ jobs:
       - name: Run fuzz target for 1h
         env:
           TARGET: ${{ matrix.target }}
+          EXTRA_ARGS: ${{ matrix.extra_args }}
+          # This leg has OOMed on every nightly since at least 2026-04-25
+          # (#361). It is NOT a leak in the code under test — ASan's own
+          # accounting at the moment of death says so (run 30516991027):
+          #
+          #   used: 2056Mb; limit: 2048Mb
+          #   Live Heap:    27.7 MB in     8,340 chunks
+          #   quarantined: 155.7 MB in 2,104,213 chunks
+          #   total chunks:              4,345,508
+          #
+          # Live plus quarantined CONTENTS are 183 MB of 2056 MB. The missing
+          # ~1.87 GB is ASan's per-chunk bookkeeping over 4.3M chunks, so the
+          # two knobs below attack the two terms of that product:
+          #   * quarantine_size_mb (default 256) bounds the chunk COUNT — the
+          #     2.1M quarantined chunks are retained solely to catch
+          #     use-after-free, which is not the bug class this harness hunts.
+          #   * malloc_context_size (default 30) bounds the per-chunk COST;
+          #     each chunk stores alloc/free stack traces of that depth.
+          #
+          # 10 frames still names the allocation site, so crash triage keeps
+          # working. Do not cut this to 2 — it saves little and turns a report
+          # into an unactionable address.
+          ASAN_OPTIONS: malloc_context_size=10:quarantine_size_mb=64
         # `--target x86_64-unknown-linux-gnu` avoids the cargo-fuzz default
         # musl target whose statically-linked libc is incompatible with
         # AddressSanitizer. Same fix as the PR-time fuzz smoke (PR #142).
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu "$TARGET" -- -max_total_time=3600 -timeout=10
+        #
+        # $EXTRA_ARGS is deliberately unquoted: it is a workflow-authored flag
+        # list that must word-split. -rss_limit_mb raises libFuzzer's 2048 MB
+        # default, which the measures above should now keep us under; it is
+        # headroom, not the fix.
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu "$TARGET" -- -max_total_time=3600 -timeout=10 -rss_limit_mb=4096 $EXTRA_ARGS
 
       - name: Upload corpus
         if: always()

--- a/.github/workflows/mutants-weekly.yml
+++ b/.github/workflows/mutants-weekly.yml
@@ -103,36 +103,25 @@ jobs:
 
       - name: Summarise to job summary
         if: always()
+        # Shares tools/check_mutants_report.py with the gating job in ci.yml so
+        # that "cargo-mutants nests its report under mutants.out/" is stated in
+        # exactly ONE place. Both this summary and that gate read the shallow
+        # path for four months (#381); here it rendered a table of 0/0/0/0,
+        # which is not merely wrong but impossible — zero caught AND zero
+        # unviable would mean cargo-mutants found nothing to test at all. It
+        # still looked like a plausible table. Two copies of a path is how one
+        # of them gets fixed and the other does not.
+        #
+        # Advisory: --summary-file never fails the job, it only refuses to
+        # render absence as zeros. `echo` the runner separately since the
+        # script has no business knowing about smithy classes.
         run: |
-          MISSED=0
-          [ -f mutants-out/missed.txt ] && MISSED=$(wc -l < mutants-out/missed.txt | tr -d ' ')
-          CAUGHT=0
-          [ -f mutants-out/caught.txt ] && CAUGHT=$(wc -l < mutants-out/caught.txt | tr -d ' ')
-          UNVIABLE=0
-          [ -f mutants-out/unviable.txt ] && UNVIABLE=$(wc -l < mutants-out/unviable.txt | tr -d ' ')
-          TIMEOUT=0
-          [ -f mutants-out/timeout.txt ] && TIMEOUT=$(wc -l < mutants-out/timeout.txt | tr -d ' ')
-          {
-            echo "## cargo-mutants weekly — ${{ steps.cfg.outputs.shard }}"
-            echo
-            echo "Runner: \`$(hostname)\` (${SMITHY_RUNNER_CLASS:-unknown class})"
-            echo
-            echo "| Outcome | Count |"
-            echo "|---------|------:|"
-            echo "| 🟥 Missed  (test suite did not catch) | $MISSED |"
-            echo "| 🟩 Caught  (test suite caught)        | $CAUGHT |"
-            echo "| ⏱  Timeout                           | $TIMEOUT |"
-            echo "| ⚪ Unviable (build failed)           | $UNVIABLE |"
-            echo
-            if [ "$MISSED" -gt 0 ] && [ -f mutants-out/missed.txt ]; then
-              echo "<details><summary>First 50 missed mutants</summary>"
-              echo
-              echo '```'
-              head -50 mutants-out/missed.txt
-              echo '```'
-              echo "</details>"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Runner: \`$(hostname)\` (${SMITHY_RUNNER_CLASS:-unknown class})" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          tools/check_mutants_report.py \
+            --output-dir mutants-out \
+            --shard "${{ steps.cfg.outputs.shard }}" \
+            --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Upload mutants report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,34 @@ jobs:
           fi
           echo "All versions match: $TAG_VERSION"
 
+  # ── Tag-point check (issue #366) ──────────────────────────────────────
+  #
+  # `check-versions` above cannot catch a tag placed BEHIND main: it measures
+  # the version *window* (Cargo.toml reads X.Y.Z from the bump commit until the
+  # next bump), and that window spans both the commits a tag included and the
+  # ones it silently left out. v0.31.0 missed a parser fix by 5m06s and v0.33.0
+  # excluded two commits — both with check-versions green.
+  #
+  # This job gates the PUBLISH, not the builds: it is wired into
+  # `create-release`'s `needs`, so a red verdict stops anything outward-facing
+  # while the maintainer still gets full build feedback to act on. The logic —
+  # and the four things it deliberately does not claim to catch — live in the
+  # script.
+  tag-point:
+    name: Verify tag point
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 is load-bearing: the gate walks C..origin/main, and the
+      # default depth of 1 has no history to walk. fetch-tags makes the tag
+      # OBJECT (not just the commit) present, which is what carries the tagger
+      # date and the message the gate reads.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Check the tag does not silently exclude finished work
+        run: tools/ci/check-tag-point.sh
+
   # ── Cross-platform binary builds ──────────────────────────────────────
   build-binaries:
     name: Build ${{ matrix.target }}
@@ -401,7 +429,7 @@ jobs:
   # the compliance-report archive, both folded into SHA256SUMS.txt.
   create-release:
     name: Create GitHub Release
-    needs: [build-binaries, build-compliance, build-test-evidence, build-vsix, build-sbom, build-wasm]
+    needs: [tag-point, build-binaries, build-compliance, build-test-evidence, build-vsix, build-sbom, build-wasm]
     runs-on: ubuntu-latest
     # Restated at job-level: actions/attest-build-provenance + cosign
     # keyless OIDC need both `id-token: write` and `attestations: write`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,17 @@ members = [
 [workspace.package]
 version = "0.35.0"
 edition = "2024"
+# The floor is NOT a free choice — it is the maximum `rust-version` over the
+# whole resolved dependency closure, which cargo enforces whether or not it is
+# written down here. Declaring it makes that number a reviewable repo fact
+# instead of an emergent property of Cargo.lock that moves on every
+# `cargo update` with no diff anywhere in this repo.
+#
+# Currently set by smol_str@0.3.6 (1.89); the next tier down is 1.87.0
+# (wit-bindgen, wasip3). Do not hand-edit this to match a local toolchain —
+# tools/check_msrv.py re-derives the closure maximum and fails if this is
+# below it.
+rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/pulseengine/spar"
 

--- a/artifacts/architecture.yaml
+++ b/artifacts/architecture.yaml
@@ -456,7 +456,7 @@ artifacts:
 
   - id: ARCH-MCP-001
     type: design-decision
-    status: planned
+    status: proposed
     title: MCP server as CLI command with stdio JSON-RPC transport
     description: >
       The MCP server is a new spar CLI subcommand (spar mcp) that
@@ -503,7 +503,7 @@ artifacts:
 
   - id: ARCH-QUERY-001
     type: design-decision
-    status: planned
+    status: proposed
     title: "Path-expression query language: components.where().property() pattern"
     description: >
       Query expressions use a method-chain syntax over the instance model:
@@ -527,7 +527,7 @@ artifacts:
 
   - id: ARCH-KNOWLEDGE-001
     type: design-decision
-    status: planned
+    status: proposed
     title: Instance model is the knowledge base; query layer on top
     description: >
       The spar instance model (SystemInstance with its arena-allocated
@@ -555,7 +555,7 @@ artifacts:
 
   - id: ARCH-SOLVER-001
     type: design-decision
-    status: planned
+    status: proposed
     title: "NDS-layered hierarchical solving"
     description: >
       Deployment optimization uses 4 hierarchical layers analogous to NDS
@@ -659,7 +659,7 @@ artifacts:
 
   - id: ARCH-SOLVER-006
     type: design-decision
-    status: planned
+    status: proposed
     title: "Dual solver strategy (WASM heuristic + native exact)"
     description: >
       Two solver tiers. Tier 1 (WASM): pure Rust heuristics (FFD/BFD

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4705,10 +4705,18 @@ artifacts:
     title: A gate shall prove it measured something before it reports a pass
     description: >
       A check that reports success shall be able to demonstrate that it read a
-      measurement. Specifically, for the mutation-testing ratchet: absence of a
-      report shall fail; a report that caught nothing shall fail; and the count
-      the gate scores shall be cross-checked against an independent recording of
-      the same count, with disagreement failing.
+      measurement, and that the measurement covered everything the check's name
+      claims. Two obligations, one per instance found so far.
+
+      (a) THE MUTATION-TESTING RATCHET. Absence of a report shall fail; a report
+      that caught nothing shall fail; and the count the gate scores shall be
+      cross-checked against an independent recording of the same count, with
+      disagreement failing.
+
+      (b) THE FORMATTING SCOPE. The formatting gate shall discover the set of
+      workspaces in the repository rather than inheriting cargo's default scope,
+      shall fail when that set is smaller than a declared floor, and shall print
+      the number of workspaces it examined on every path — including success.
 
       WHY: `Mutation Testing` is a required status check that runs for roughly
       three hours, and from 563eb8c (2026-03-22) until #381 it never once read
@@ -4770,16 +4778,63 @@ artifacts:
       exactly what a ratchet exists to prevent. #382 tracks walking it to zero.
       Lower this number; do not raise it.
 
+      SECOND INSTANCE: SCOPE NARROWER THAN THE NAME (#383). Auditing the other
+      17 required contexts for the same property found `Format` green on main
+      over unformatted tracked Rust. `cargo fmt --all` means "all members of
+      THIS workspace", not "all crates in the repo", and this repo has four
+      workspaces — the 23-crate root plus fuzz/, codegen-exec-oracle/ and
+      codegen-kiln-oracle/, each carrying its own `[workspace]` table, none of
+      which the root's `--all` ever opens. Executed on the same tree:
+      `cargo fmt --all -- --check` exits 0 while
+      `cargo fmt --manifest-path fuzz/Cargo.toml --all -- --check` exits 1 with
+      13 diff lines, against fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs:32.
+      Two gates, one repository, opposite verdicts.
+
+      This is #381's property arriving by a different mechanism. #381's error
+      path produced the ideal reading; here there is no error path at all — the
+      narrow answer is simply byte-identical to the broad one, because cargo
+      prints nothing on success and 23-of-26 crates clean looks exactly like
+      26-of-26 clean. So the fix is not a corrected path but a mandated output:
+      tools/check_fmt_workspaces.py prints "N workspace(s) checked, M formatted"
+      on every path. A count is not producible by a broken scan.
+
+      DISCOVERY WITH A FLOOR, not a list. Four hard-coded manifests would fix
+      today's bug and re-open it the day someone adds a fifth workspace, so the
+      set is walked for `[workspace]` tables and floored at 4 — the floor being
+      what makes a discovery failure loud instead of green. The prune list is
+      load-bearing rather than cosmetic: `target/` fills with vendored crates.io
+      sources, many of which ship their own `[workspace]` table, so a naive walk
+      finds dozens, sails past the floor, and asks cargo to format other
+      people's build cache — a bug that PASSES, which is why it is a self-test
+      row and not a comment. The same 10-case table carries the #383 regression
+      itself (root clean + fuzz/ dirty must exit 1), and distinguishes
+      `[workspace.package]` from `[workspace]`, since counting inheriting
+      members would inflate the total past the floor and disarm it.
+
+      THREE-VALUED EXIT, as in check_msrv.py: 0 formatted, 1 violation, 2 could
+      not measure (cargo absent, root unreadable, discovery empty). Collapsing
+      "could not measure" into 0 is the shape that let #381 run four months.
+
       WHAT THIS DOES NOT CLAIM. It does not claim spar-analysis is well tested —
       210 survivors out of 1608 mutants is the opposite of that claim, and the
-      number is only visible now because the gate started working. It also does
-      not generalise: the property "an operation that can report nothing-happened
-      must render that differently from it-worked" is stated here, but nothing
-      mechanically enforces it across the other required contexts. There is no
-      checker that finds the next one. The working detectors are reading a job's
-      own uploaded ARTIFACT rather than its log, and diffing any gate-printed
-      number against an independent measurement of the same quantity — both
-      review practices, not tools.
+      number is only visible now because the gate started working. Nor does it
+      claim the repo is now formatted by policy rather than by accident: `Clippy`
+      has the identical `--workspace` scope gap and is not fixed here, so the
+      three nested crates remain unlinted.
+
+      Above all it does not claim the property is enforced generally. #386
+      audits all 18 required contexts against "can this report success without
+      having measured the thing its name claims?" and finds 11 with a path to
+      green; this requirement now covers two of them. Both were found by a human
+      question, not by a checker, and there is still no checker that finds the
+      next one — the recurring shapes (scope narrower than the name, the error
+      path being the permissive path, absence rendering as success, a gate with
+      no configured failure mode) are review vocabulary, not tooling. What did
+      generalise is the convention rather than the detection: put the logic in a
+      script with a `--self-test` decision table, run the self-test as a step
+      BEFORE the real check, carry the historical regression as a table row, and
+      print a positive count of what was examined. That is transferable to the
+      remaining nine; running it against them is #386's checklist, not this.
     status: implemented
     release: v0.36.0
-    tags: [process, guardrail, ci, tooling, mutation-testing]
+    tags: [process, guardrail, ci, tooling, mutation-testing, formatting]

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -121,7 +121,11 @@ artifacts:
     description: >
       Trace connections through the hierarchy resolving across, up,
       and down patterns to produce end-to-end connection instances.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      The unimplemented residue is deliberately not itemized here — see
+      REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [instance, as5506-ch14]
 
   - id: REQ-INST-004
@@ -226,7 +230,11 @@ artifacts:
       Enforce AADL naming rules, category restrictions, direction rules,
       connection rules, flow rules, binding rules, mode rules, and
       subcomponent rules. Target 50+ rules.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      How many rules are actually enforced against the 50+ target is
+      deliberately not asserted here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [analysis, legality]
 
   - id: REQ-ANALYSIS-008
@@ -309,7 +317,7 @@ artifacts:
     description: >
       Import cargo metadata to generate virtual AADL packages
       representing Rust crate architecture.
-    status: planned
+    status: proposed
     tags: [transform, rust]
 
   - id: REQ-TRANSFORM-003
@@ -318,7 +326,7 @@ artifacts:
     description: >
       Read WAC composition files and generate AADL system
       implementations with subcomponents and connections.
-    status: planned
+    status: proposed
     tags: [transform, wac]
 
   - id: REQ-TRANSFORM-004
@@ -327,7 +335,7 @@ artifacts:
     description: >
       Map wRPC transports (NATS, TCP, QUIC) to AADL bus components
       with deployment bindings.
-    status: planned
+    status: proposed
     tags: [transform, wrpc]
 
   - id: REQ-TRANSFORM-005
@@ -336,7 +344,7 @@ artifacts:
     description: >
       Map WASI P3 async functions, streams, and futures to AADL
       thread components with scheduling properties.
-    status: planned
+    status: proposed
     tags: [transform, wasi-p3]
 
   # ── STPA Analysis Coverage Records (STPA-REQ-022) ────────────────
@@ -428,7 +436,11 @@ artifacts:
     description: >
       modal.rs computes SOMs. Scheduling and latency analyses evaluate
       per-SOM when modal property associations exist.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which Ch.12 obligations remain open is deliberately not asserted
+      here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     links:
       - type: satisfies
         target: REQ-INST-004
@@ -466,7 +478,7 @@ artifacts:
       Not yet covered: Ch.7 (prototypes — parsed but not analyzed).
       Ch.6 type extensions now resolved via extends chain walking (v0.5.0).
       Property expression evaluation now covered by text fallback parser (v0.5.0).
-    status: partial
+    status: approved
     links:
       - type: satisfies
         target: REQ-MODEL-005
@@ -637,7 +649,7 @@ artifacts:
       Detect architectural conflicts in three-way merges where concurrent
       changes affect the same structural elements (components, connections,
       bindings) or produce incompatible analysis results.
-    status: planned
+    status: proposed
     tags: [diff, merge, v040]
     release: v0.23.0
     fields:
@@ -666,7 +678,7 @@ artifacts:
       category == thread).property(Period)) to select and filter instance
       model elements. Supports predicate filtering, property extraction,
       and aggregation.
-    status: planned
+    status: proposed
     tags: [query, instance, v040]
     release: v0.23.0
     fields:
@@ -717,7 +729,7 @@ artifacts:
       subsystems to hardware zones (topology + bandwidth + safety). Layer 3
       (Global) — optimize across all zones (E2E latency, safety decomposition,
       cost). Local solutions compose into globally valid configurations.
-    status: planned
+    status: proposed
     tags: [solver, optimization, v040]
     release: v0.23.0
   - id: REQ-SOLVER-005
@@ -728,7 +740,7 @@ artifacts:
       machine-checkable certificate proving it is globally optimal (for
       exact methods) or within a bounded optimality gap (for heuristics).
       Uses dual bounds from MILP or exhaustive search proofs from CP-SAT.
-    status: planned
+    status: proposed
     tags: [solver, verification, v040]
     release: v0.23.0
   - id: REQ-SOLVER-006
@@ -739,7 +751,7 @@ artifacts:
       maximize safety margins), compute the Pareto front of non-dominated
       solutions. Present to the engineer for interactive selection. Support
       both exact Pareto (small problems) and approximate (NSGA-II for large).
-    status: planned
+    status: proposed
     tags: [solver, optimization, v040]
     release: v0.23.0
   - id: REQ-SOLVER-007
@@ -762,7 +774,7 @@ artifacts:
       freedom from interference is ensured (spatial via MMU, temporal via
       scheduling, communication via controlled interfaces). Supports ISO 26262
       ASIL, DO-178C DAL, and IEC 61508 SIL.
-    status: planned
+    status: proposed
     tags: [solver, safety, v040]
     release: v0.23.0
   - id: REQ-SOLVER-009
@@ -773,7 +785,7 @@ artifacts:
       with security-level properties. Validate that cross-zone connections
       have appropriate protection (encryption, authentication). Account for
       security overhead (TLS latency, MAC computation) in timing analysis.
-    status: planned
+    status: proposed
     tags: [solver, security, v040]
     release: v0.23.0
     fields:
@@ -965,7 +977,7 @@ artifacts:
       margins. Cheddar and Ellidiss MARZHIN offer this — spar has static
       RMA/RTA but no temporal visualization. Output as SVG/HTML with
       interactive zoom.
-    status: planned
+    status: proposed
     tags: [visualization, scheduling, competitive-gap, v040]
     release: v0.23.0
   - id: REQ-SECURITY-001
@@ -977,7 +989,7 @@ artifacts:
       interfaces, secure boot chain verification, trust boundary validation.
       Ellidiss has a security rules checker; OSATE has none. Maps to
       IEC 62443 zones/conduits and ISO 21434 threat analysis.
-    status: planned
+    status: proposed
     tags: [security, competitive-gap, v040]
     links:
       - type: traces-to
@@ -991,7 +1003,7 @@ artifacts:
       claims: hierarchical claim decomposition, evidence linking, and
       reusable claim libraries. Currently spar verify has flat assertions;
       Resolute supports claim trees with sub-claims and computed evidence.
-    status: planned
+    status: proposed
     tags: [verification, competitive-gap, v040]
     release: v0.23.0
   - id: REQ-BIDIRECTIONAL-001
@@ -1003,7 +1015,7 @@ artifacts:
       to AADL source via rowan CST. Currently spar renders read-only
       diagrams. OSATE graphical editor and Ellidiss STOOD both support
       bidirectional editing.
-    status: planned
+    status: proposed
     tags: [rendering, editing, competitive-gap, v050]
 
   # ── Interoperability Requirements (v0.5.0+) ────────────────────────
@@ -1042,7 +1054,7 @@ artifacts:
       Import OMG ReqIF XML into rivet artifacts. Bridges enterprise ALM
       tools (DOORS, Jama, Polarion) with spar's architecture verification.
       Requirements flow into rivet, trace to AADL components via spar verify.
-    status: planned
+    status: proposed
     tags: [interop, requirements, v040]
     release: v0.23.0
   - id: REQ-INTEROP-003
@@ -1053,7 +1065,7 @@ artifacts:
       implementations, Functional Chains → end-to-end flows, Components →
       AADL components. Lighter than the N7 Space Capella-to-TASTE bridge
       (no Eclipse dependency).
-    status: planned
+    status: proposed
     tags: [interop, capella, bridge, v050]
 
   - id: REQ-INTEROP-004
@@ -1064,7 +1076,7 @@ artifacts:
       → process/thread bindings, Service Instance Manifests → connections,
       Machine Manifests → processor configurations. Enables spar analysis
       on existing AUTOSAR models without manual AADL modeling.
-    status: planned
+    status: proposed
     tags: [interop, autosar, bridge, v050]
 
   # ── IRQ-aware RTA (Track A, v0.7.0) ────────────────────────────────
@@ -4629,3 +4641,61 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-GUARD-HUMAN-SCOPED-001
+
+  - id: REQ-GUARD-STATUS-VOCAB-001
+    type: requirement
+    title: "`status:` shall be a member of the schema's allowed set"
+    description: >
+      Every artifact's `status:` shall be one of the nine values the active
+      schema allows (draft, proposed, approved, implemented, verified, released,
+      accepted, deprecated, rejected). spar had 276 that were not: `passing`,
+      `planned`, `not-implemented` and `partial` — a private vocabulary that
+      read as meaningful and validated as nothing.
+
+      WHY IT MATTERS: `passing` was the largest group (177). It is a verification
+      VERDICT living in a lifecycle field, and a hand-edited YAML file cannot
+      honestly assert that a test passes — only that the measure exists. The
+      status plane records where an artifact sits in its lifecycle; it is not
+      a place to record the result of a run nobody re-derives.
+
+      THE MAPPING, and what it costs: passing -> implemented, planned ->
+      proposed, not-implemented -> proposed, partial -> approved. Only the last
+      is lossy. `partial` sits strictly between `approved` and `implemented`,
+      and the vocabulary has no such rung, so `approved` is chosen as the
+      CONSERVATIVE FLOOR — the strongest claim that is certainly true —
+      rather than `implemented`, which would overstate. The eight affected
+      requirements each say so in their own description. Two of them
+      (RENDER-REQ-003, COVERAGE-GAPS) already itemized their residue and were
+      left alone; the other five state that the residue is NOT itemized. That
+      wording is deliberate: an explicit "not measured" is falsifiable, whereas
+      a plausible invented figure ("32 of 50 rules") is not, and inventing one
+      is the precise failure #294 was reopened for.
+
+      THE GUARD IS NOT NEW CODE. rivet already ships `status-allowed-values` at
+      ERROR severity, and `rivet validate` is already a required check, so the
+      regression is mechanically blocked from the moment this lands. Writing a
+      bespoke checker here would have added a second, weaker oracle next to a
+      working one. This is the opposite of REQ-GUARD-RELEASE-PLANE-001, which
+      needed a tool precisely because rivet was BLIND to the defect.
+
+      TWO HOLES REMAIN OPEN, and neither is closed by this requirement:
+      (1) six `status:` values in safety/stpa/architecture.yaml sit inside the
+      `fields:` extension bag, where rivet cannot see them — the #370 defect one
+      field over, on `status:` instead of `release:`; (2) safety/requirements.yaml
+      holds 21 more, and rivet never loads that file at all because it is not
+      under any path in rivet.yaml's `sources:`. Both are invisible to the guard
+      above, which is exactly why they are named here rather than silently
+      absorbed into the 276.
+
+      RECONCILIATION (measured, not asserted): 303 raw `status:` text matches
+      across 9 committed files, minus 21 in the unloaded file, minus 6 in the
+      fields bag, equals the 276 errors rivet reports. The three planes agree.
+      NOTE ON THE MISSING LINK: this artifact deliberately carries no
+      `traces-to: REQ-GUARD-RELEASE-PLANE-001`, even though that is its natural
+      sibling. That artifact arrives in a different unmerged PR, and a `links:`
+      target is resolved at validate time — so the link would make this branch's
+      oracle pass or fail depending on which PR merges first. Add it once both
+      have landed; a flaky gate is not a traceability improvement.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, traceability, rivet, tooling]

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4690,15 +4690,20 @@ artifacts:
       RECONCILIATION (measured, not asserted): 303 raw `status:` text matches
       across 9 committed files, minus 21 in the unloaded file, minus 6 in the
       fields bag, equals the 276 errors rivet reports. The three planes agree.
-      NOTE ON THE MISSING LINK: this artifact deliberately carries no
-      `traces-to: REQ-GUARD-RELEASE-PLANE-001`, even though that is its natural
-      sibling. That artifact arrives in a different unmerged PR, and a `links:`
-      target is resolved at validate time — so the link would make this branch's
-      oracle pass or fail depending on which PR merges first. Add it once both
-      have landed; a flaky gate is not a traceability improvement.
+      NOTE ON THE LINK BELOW, and why it arrived a commit late: the
+      `traces-to: REQ-GUARD-RELEASE-PLANE-001` was deliberately withheld while
+      these two requirements sat in separate unmerged PRs. A `links:` target is
+      resolved at validate time, so the link would have made each branch's
+      oracle pass or fail depending on which PR merged first — and a gate whose
+      verdict depends on merge order is not a traceability improvement. The
+      target landed on main in #373; the link is now present and resolves
+      against the same tree that validates it.
     status: implemented
     release: v0.36.0
     tags: [process, guardrail, traceability, rivet, tooling]
+    links:
+      - type: traces-to
+        target: REQ-GUARD-RELEASE-PLANE-001
 
   - id: REQ-GUARD-GATE-EVIDENCE-001
     type: requirement

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4699,3 +4699,87 @@ artifacts:
     status: implemented
     release: v0.36.0
     tags: [process, guardrail, traceability, rivet, tooling]
+
+  - id: REQ-GUARD-GATE-EVIDENCE-001
+    type: requirement
+    title: A gate shall prove it measured something before it reports a pass
+    description: >
+      A check that reports success shall be able to demonstrate that it read a
+      measurement. Specifically, for the mutation-testing ratchet: absence of a
+      report shall fail; a report that caught nothing shall fail; and the count
+      the gate scores shall be cross-checked against an independent recording of
+      the same count, with disagreement failing.
+
+      WHY: `Mutation Testing` is a required status check that runs for roughly
+      three hours, and from 563eb8c (2026-03-22) until #381 it never once read
+      its own results. `cargo mutants --output DIR` creates `mutants.out` INSIDE
+      DIR, so the report lands at `mutants-out/mutants.out/`. The gate read
+      `mutants-out/missed.txt`, one level up — a path that has never existed.
+      `grep` failed into `|| echo 0`, the `-f` test was false, `0 -gt 142` was
+      false, exit 0. Four months of green on a check that was structurally
+      incapable of red.
+
+      THE PROPERTY THAT MADE IT INVISIBLE, and the reason this is a requirement
+      rather than a bug fix: the ERROR path produced the IDEAL reading. `|| true`,
+      `2>/dev/null` and `|| echo 0` convert "file not found" into `0`, and `0` is
+      the best possible score for survivor count. This gate did not fail silently;
+      it failed *flatteringly*. Any guard whose error path yields its ideal
+      reading is unfalsifiable by construction — no amount of watching it pass
+      distinguishes "clean" from "blind".
+
+      THE EVIDENCE (executed, not reasoned): run 30563879100 on main @ cd4d429 —
+      the one run of this job to reach `success` in its last 25 — uploads its
+      artifact with `path: mutants-out/`, so the artifact root IS a listing of
+      that directory, and it holds exactly one entry: `mutants.out/`. Inside:
+      210 missed, 603 caught, 793 unviable, 2 timeout, each `wc -l` agreeing with
+      `outcomes.json`. The old step body, extracted from origin/main with
+      `yaml.safe_load` rather than retyped and handed that exact directory,
+      prints "Surviving mutants: 0" and exits 0. It uploaded 210 survivors against
+      a threshold of 142 and reported green.
+
+      THE TELL WAS IN THE TREE. 5d6d98a, 58 minutes after the gate went hard:
+      "Current survivors: 142 (down from 220)." That measurement was real and
+      correct, and structurally impossible for CI to have produced, because CI
+      was printing 0. Someone measured by hand, wrote the number down, and
+      shipped a gate that could not see it. Two readings of one quantity sat in
+      the repository for four months and were never diffed. That diff is the only
+      detector that would have worked from day one — mutating the gate to a no-op
+      changes no observable behaviour, so no mutation test, coverage measure or
+      log review could have found it. It is now automated: the checker refuses to
+      score a report whose `.txt` line counts disagree with `outcomes.json`.
+
+      SINGLE SOURCE. `mutants-weekly.yml` had the same wrong path, where it
+      rendered `0 missed / 0 caught / 0 unviable / 0 timeout` — not merely wrong
+      but impossible, since zero caught AND zero unviable would mean cargo-mutants
+      found nothing to test at all. It still read as a plausible table. Both the
+      gate and the weekly summary now call tools/check_mutants_report.py, so the
+      nesting fact lives in one constant; two copies of a path is how one of them
+      gets fixed and the other does not.
+
+      THE LOGIC IS NOT IN THE WORKFLOW. Inline shell in a YAML file is only
+      testable by pushing, which is precisely how the misread survived four months
+      with nobody able to run it against a report. The checker ships a 19-case
+      decision table, and its self-test step runs BEFORE the real check, for the
+      same reason the sibling guardrails do — the table includes the #381
+      regression itself, so a refactor that reintroduced the shallow read fails
+      there instead of passing vacuously.
+
+      THE THRESHOLD. 142 was never enforced, so re-baselining to the measured 210
+      relaxes nothing that was ever in force; it is the first value this gate has
+      actually checked against. The 142 -> 210 drift over four blind months is
+      exactly what a ratchet exists to prevent. #382 tracks walking it to zero.
+      Lower this number; do not raise it.
+
+      WHAT THIS DOES NOT CLAIM. It does not claim spar-analysis is well tested —
+      210 survivors out of 1608 mutants is the opposite of that claim, and the
+      number is only visible now because the gate started working. It also does
+      not generalise: the property "an operation that can report nothing-happened
+      must render that differently from it-worked" is stated here, but nothing
+      mechanically enforces it across the other required contexts. There is no
+      checker that finds the next one. The working detectors are reading a job's
+      own uploaded ARTIFACT rather than its log, and diffing any gate-printed
+      number against an independent measurement of the same quantity — both
+      review practices, not tools.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling, mutation-testing]

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -260,54 +260,19 @@ artifacts:
     tags: [integration, serde]
 
   # ── Rendering (STPA-derived) ──────────────────────────────────────────
-
-  - id: RENDER-REQ-001
-    type: requirement
-    title: Orthogonal edge routing
-    description: >
-      Edges must use orthogonal routing to minimize visual crossings.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-002
-    type: requirement
-    title: Port visibility with directional indicators
-    description: >
-      Ports must be visible with directional indicators and type coloring.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-003
-    type: requirement
-    title: Interactive HTML with zoom/pan/minimap/search
-    description: >
-      Interactive HTML output must support zoom, pan, minimap, and search.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-004
-    type: requirement
-    title: Deterministic layout
-    description: >
-      Layout must be deterministic — same model always produces same layout.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-005
-    type: requirement
-    title: Selection and group highlighting
-    description: >
-      Selection and group highlighting must be supported in interactive mode.
-    status: implemented
-    tags: [rendering, stpa]
-
-  - id: RENDER-REQ-006
-    type: requirement
-    title: Semantic zoom for overview levels
-    description: >
-      Semantic zoom must reduce clutter at overview levels.
-    status: partial
-    tags: [rendering, stpa]
+  #
+  # RENDER-REQ-001..006 are NOT defined here. They live in
+  # safety/stpa/rendering-analysis.yaml, which is the canonical copy: it
+  # carries the hazards/satisfies/verified-by trace links that make them
+  # part of the STPA V, and the stubs that used to sit here carried none.
+  #
+  # Both files defined all six ids until #360. rivet silently kept ONE and
+  # dropped the other with no diagnostic, and which one won was load order,
+  # not a decision. The stubs were stale in BOTH directions -- they claimed
+  # RENDER-REQ-003 `implemented` (it is `partial`: minimap/search are
+  # Phase 3b, still `reserved` in etch) and RENDER-REQ-006 `partial` (it is
+  # `implemented`: etch/src/html.rs emits svg.zoom-low / svg.zoom-overview
+  # behind a wheel handler). Do not re-add them here.
 
   - id: REQ-WASM-001
     type: requirement

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -598,7 +598,7 @@ artifacts:
 
   - id: VAL-RTA-001
     type: feature
-    status: planned
+    status: proposed
     title: RTA response time analysis tests
     description: >
       Tests for Response Time Analysis covering deadline miss detection,
@@ -616,7 +616,7 @@ artifacts:
 
   - id: VAL-BUS-001
     type: feature
-    status: planned
+    status: proposed
     title: Bus bandwidth utilization tests
     description: >
       Tests for bus bandwidth analysis covering overload detection when
@@ -634,7 +634,7 @@ artifacts:
 
   - id: VAL-MEMBUD-001
     type: feature
-    status: planned
+    status: proposed
     title: Memory budget analysis tests
     description: >
       Tests for memory budget analysis covering budget violations when
@@ -652,7 +652,7 @@ artifacts:
 
   - id: VAL-WEIGHTPOWER-001
     type: feature
-    status: planned
+    status: proposed
     title: Weight/power aggregation tests
     description: >
       Tests for weight and power property aggregation up the component
@@ -670,7 +670,7 @@ artifacts:
 
   - id: VAL-VERIFY-001
     type: feature
-    status: planned
+    status: proposed
     title: Property assertion rule tests
     description: >
       Tests for the property assertion DSL covering passing assertions,
@@ -688,7 +688,7 @@ artifacts:
 
   - id: VAL-DIFF-001
     type: feature
-    status: planned
+    status: proposed
     title: Structural diff and analysis impact tests
     description: >
       Tests for git-aware structural diff covering component addition/
@@ -711,7 +711,7 @@ artifacts:
 
   - id: VAL-MCP-001
     type: feature
-    status: planned
+    status: proposed
     title: MCP server JSON-RPC request/response tests
     description: >
       Tests for the MCP server covering JSON-RPC initialize handshake,
@@ -732,7 +732,7 @@ artifacts:
 
   - id: VAL-CODEGEN-001
     type: feature
-    status: passing
+    status: implemented
     title: Golden model integration tests for codegen
     description: >
       19 golden model integration tests validating end-to-end code generation
@@ -754,7 +754,7 @@ artifacts:
 
   - id: VAL-CODEGEN-002
     type: feature
-    status: passing
+    status: implemented
     title: WIT/Rust/Config/Test/Proof generation output validation
     description: >
       Tests validating each codegen output layer independently: WIT interface
@@ -795,7 +795,7 @@ artifacts:
 
   - id: VAL-SYSML2-LOWER-001
     type: feature
-    status: passing
+    status: implemented
     title: SysML v2 lowering tests
     description: >
       Tests for SysML v2 to AADL lowering covering diagnostic handling for
@@ -814,7 +814,7 @@ artifacts:
 
   - id: VAL-VERIFY-MACROS-001
     type: feature
-    status: passing
+    status: implemented
     title: Verify macro proc-macro tests
     description: >
       Tests for spar-verify-macros proc-macro crate covering #[aadl(...)]
@@ -837,7 +837,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-001
     type: feature
-    status: planned
+    status: proposed
     title: Kani — solver output implies no deadline miss
     description: >
       kani_schedule_implies_no_deadline_miss harness: for any TaskSet of
@@ -861,7 +861,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-002
     type: feature
-    status: planned
+    status: proposed
     title: Kani — priority ordering is monotone and antisymmetric
     description: >
       kani_priority_monotonicity harness: for any two tasks in a ≤4-task
@@ -885,7 +885,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-003
     type: feature
-    status: planned
+    status: proposed
     title: Kani — EDF accepts U=1 at n=2, RM rejects
     description: >
       kani_zero_laxity_handled harness: a 2-task implicit-deadline set
@@ -909,7 +909,7 @@ artifacts:
 
   - id: VAL-KANI-CODEGEN-001
     type: feature
-    status: planned
+    status: proposed
     title: Kani — codegen emission preserves schedule task IDs
     description: >
       kani_emit_preserves_schedule harness: for any Schedule of size
@@ -931,7 +931,7 @@ artifacts:
 
   - id: TEST-KANI-CODEGEN
     type: feature
-    status: passing
+    status: implemented
     title: Kani — AADL contract preservation harnesses for codegen
     description: >
       The #[kani::proof] harnesses in crates/spar-codegen/tests/kani_contracts.rs
@@ -980,7 +980,7 @@ artifacts:
 
   - id: VAL-MUTATION-001
     type: feature
-    status: passing
+    status: implemented
     title: Mutation testing for analysis passes
     description: >
       Mutation testing campaign covering 674 analysis tests. Validates that
@@ -1003,7 +1003,7 @@ artifacts:
     description: >
       Features, subcomponents, connections, and properties are inherited
       through extends chains with cycle detection and deduplication.
-    status: passing
+    status: implemented
     tags: [v0.5.0, instance-model]
     links:
       - type: satisfies
@@ -1015,7 +1015,7 @@ artifacts:
     description: >
       Salsa-memoized file_item_tree, CST-aware completion, rename safety,
       LineIndex O(1) positions, duplicate package detection, DidClose handler.
-    status: passing
+    status: implemented
     tags: [v0.5.0, lsp]
     links:
       - type: satisfies
@@ -1027,7 +1027,7 @@ artifacts:
     description: >
       6 analysis checks for AI/ML components: inference deadline, fallback
       coverage/timing, OOD coverage, model deployment, redundancy.
-    status: passing
+    status: implemented
     tags: [v0.5.0, analysis, ai-ml]
     links:
       - type: satisfies
@@ -1039,7 +1039,7 @@ artifacts:
     description: >
       Maps EMV2 fault tree analysis to STPA hazard artifacts. Composite
       error states to hazards, propagation paths to loss scenarios.
-    status: passing
+    status: implemented
     tags: [v0.5.0, safety]
     links:
       - type: satisfies
@@ -1052,7 +1052,7 @@ artifacts:
       Rowan-based SysML v2 parser handles full KerML grammar including
       part, port, connection, requirement, constraint, action, and state
       definitions with lossless CST and error recovery.
-    status: passing
+    status: implemented
     tags: [v0.5.0, sysml2]
     links:
       - type: satisfies
@@ -1064,7 +1064,7 @@ artifacts:
     description: >
       Extract requirements with satisfy/verify/refine/allocate/derive
       relationships, architecture context, and roundtrip generation.
-    status: passing
+    status: implemented
     tags: [v0.5.0, sysml2]
     links:
       - type: satisfies
@@ -1078,7 +1078,7 @@ artifacts:
     description: >
       requires_modes flag stored in ItemTree. Modal filtering utility
       for connectivity and scheduling analysis passes.
-    status: passing
+    status: implemented
     tags: [v0.5.0, modes]
     links:
       - type: satisfies
@@ -1090,7 +1090,7 @@ artifacts:
     description: >
       Text-based fallback parser handles booleans, references, classifiers,
       ranges, lists, numerics with units, and enums when CST lowering fails.
-    status: passing
+    status: implemented
     tags: [v0.5.0, properties]
     links:
       - type: satisfies
@@ -1102,7 +1102,7 @@ artifacts:
     description: >
       XSS prevention in SVG rendering, YAML/TOML injection prevention,
       path traversal protection, UTF-8 safe percent decoding, arena bounds checks.
-    status: passing
+    status: implemented
     tags: [v0.5.0, security]
     links:
       - type: satisfies
@@ -1115,7 +1115,7 @@ artifacts:
       WebviewPanel integration renders architecture diagrams live in
       VS Code. Automatic refresh on file save, theme-aware styling,
       pan/zoom controls in the webview.
-    status: passing
+    status: implemented
     tags: [v0.5.0, tooling, vscode]
     links:
       - type: satisfies
@@ -1134,7 +1134,7 @@ artifacts:
       scheduling, connectivity, ARINC 653, resource budget, memory budget,
       weight/power, bus bandwidth, binding check. Diagnostics prefixed
       with [mode: <name>] for per-SOM results.
-    status: passing
+    status: implemented
     tags: [v0.6.0, analysis, modes]
     links:
       - type: satisfies
@@ -1153,7 +1153,7 @@ artifacts:
       GlobalScope follows package renames, classifier renames, and feature
       group renames declarations. Aliases stored in resolver and resolved
       during name lookup. Enables cross-package aliasing per AS5506 Ch.4.
-    status: passing
+    status: implemented
     tags: [v0.6.0, resolution]
     links:
       - type: satisfies
@@ -1169,7 +1169,7 @@ artifacts:
       OneToOne (element i to element i, requires same array size) and
       AllToAll (cartesian product, default). Property parsed from nested
       list format or simple identifier, case-insensitive matching.
-    status: passing
+    status: implemented
     tags: [v0.6.0, instance-model, connections]
     links:
       - type: satisfies
@@ -1189,7 +1189,7 @@ artifacts:
       PropertyMap to analysis passes. get_typed() on PropertyMap returns
       typed property values. All 7 instance.rs construction sites propagate
       typed_value. Extends chain survival tested.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties]
     links:
       - type: satisfies
@@ -1207,7 +1207,7 @@ artifacts:
       to try get_typed() before falling back to text parsing. Covers
       timing properties, scheduling, bus bandwidth, memory, weight/power,
       and binding properties. Reduces text-parsing fragility.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties, analysis]
     links:
       - type: satisfies
@@ -1224,7 +1224,7 @@ artifacts:
       MAX_RENDER_DEPTH=5 constant prevents stack overflow on deeply nested
       hierarchies. Components beyond the depth limit are reparented to the
       nearest visible ancestor. 5 new tests covering deep nesting scenarios.
-    status: passing
+    status: implemented
     tags: [v0.6.0, rendering, bugfix]
     links:
       - type: satisfies
@@ -1240,7 +1240,7 @@ artifacts:
       statements (satisfy, verify, refine, allocate, derive) from rivet
       artifacts. Supports action/state/connection keywords via tags.
       Sanitizes identifiers for SysML v2 compliance.
-    status: passing
+    status: implemented
     tags: [v0.6.0, sysml2]
     links:
       - type: satisfies
@@ -1256,7 +1256,7 @@ artifacts:
       nested list values. PropertyExpr::Record variant added. 670+ lines
       of lowering enhancements in item_tree/lower.rs covering record
       fields, nested lists, and complex property expression combinations.
-    status: passing
+    status: implemented
     tags: [v0.6.0, properties]
     links:
       - type: satisfies
@@ -1277,7 +1277,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_timing test_spar_property_sets_resolved_via_global_scope
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, properties]
     links:
       - type: satisfies
@@ -1300,7 +1300,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_trace test_spar_property_sets_resolved_via_global_scope
-    status: passing
+    status: implemented
     tags: [v0.8.0, trace, verification, properties]
     links:
       - type: satisfies
@@ -1394,7 +1394,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests scheduling_verified
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, rta]
     links:
       - type: satisfies
@@ -1419,7 +1419,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --test rta_fixtures
-    status: passing
+    status: implemented
     tags: [v0.7.0, timing, irq, rta, fixtures]
     links:
       - type: satisfies
@@ -1446,7 +1446,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def -- test_standard_properties_in_spar_network test_spar_network_property_set_resolved_via_global_scope test_spar_network_unknown_property_returns_none
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn, properties]
     links:
       - type: satisfies
@@ -1477,7 +1477,7 @@ artifacts:
             standard_properties::tests::test_standard_properties_in_spar_migration
             standard_properties::tests::test_spar_migration_property_set_resolved_via_global_scope
             standard_properties::tests::test_spar_migration_unknown_property_returns_none
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1502,7 +1502,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib -- migration::tests
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1535,7 +1535,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib -- overlay::tests
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080]
     links:
       - type: satisfies
@@ -1577,7 +1577,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_verify
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli]
     links:
       - type: satisfies
@@ -1622,7 +1622,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_enumerate
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli]
     links:
       - type: satisfies
@@ -1678,7 +1678,7 @@ artifacts:
         - run: cargo test -p spar --test moves_enumerate_objectives
         - run: "cargo test -p spar-solver enumerate::"
         - run: "cargo test -p spar moves::enumerate_tests"
-    status: passing
+    status: implemented
     tags: [migration, track-e, v080, cli, solver]
     links:
       - type: satisfies
@@ -1725,7 +1725,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test moves_variant
-    status: passing
+    status: implemented
     tags: [migration, variants, track-e, track-b, v080, cli]
     links:
       - type: satisfies
@@ -1756,7 +1756,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn, extract]
     links:
       - type: satisfies
@@ -1788,7 +1788,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- curves::tests
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, network-calculus]
     links:
       - type: satisfies
@@ -1818,7 +1818,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --test nc_validation
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, validation, oracle]
     links:
       - type: satisfies
@@ -1864,7 +1864,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_xval"
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, plp, validation, oracle]
     links:
       - type: satisfies
@@ -1905,7 +1905,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_xval::panco_converge"
-    status: passing
+    status: implemented
     tags: [v0.19.0, network, network-calculus, plp, converging, validation, oracle]
     links:
       - type: satisfies
@@ -1937,7 +1937,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-analysis --lib --features milp-solver network_wide_authoritative_bound"
         - run: "cargo test -p spar-analysis --lib --no-default-features network_wide_authoritative_bound"
-    status: passing
+    status: implemented
     tags: [v0.22.0, network, network-calculus, plp, tfa, bridge, oracle]
     links:
       - type: satisfies
@@ -1977,7 +1977,7 @@ artifacts:
       steps:
         - run: "cargo test -p spar-network --lib plp::"
         - run: "cargo test -p spar-network --test nc_validation plp_str_xval"
-    status: passing
+    status: implemented
     tags: [v0.19.0, network, network-calculus, plp, validation, oracle]
     links:
       - type: satisfies
@@ -2031,7 +2031,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib wctt::tests::network_wide"
-    status: passing
+    status: implemented
     tags: [v0.18.0, network, network-calculus, bridge, tsn, tfa, plp]
     links:
       - type: satisfies
@@ -2062,7 +2062,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- wctt::tests
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, tsn]
     links:
       - type: satisfies
@@ -2106,7 +2106,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- latency::tests
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, latency]
     links:
       - type: satisfies
@@ -2140,7 +2140,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-variants
-    status: passing
+    status: implemented
     tags: [variants, track-b, v07x]
     links:
       - type: satisfies
@@ -2166,7 +2166,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests scheduling_verified property_accessors
-    status: passing
+    status: implemented
     tags: [v0.7.1, timing, irq, rta, pip, pcp, blocking]
     links:
       - type: satisfies
@@ -2194,7 +2194,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cd proofs && lake build
-    status: passing
+    status: implemented
     tags: [v0.8.0, network, wctt, network-calculus, lean, proofs]
     links:
       - type: satisfies
@@ -2224,7 +2224,7 @@ artifacts:
       method: formal-proof
       steps:
         - run: cd proofs && lake build
-    status: passing
+    status: implemented
     tags: [v0.15.0, scheduling, lean, proofs, rta, edf]
     links:
       - type: satisfies
@@ -2253,7 +2253,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, properties]
     links:
       - type: satisfies
@@ -2290,7 +2290,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, wctt, tas]
     links:
       - type: satisfies
@@ -2326,7 +2326,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- tas_sound"
-    status: passing
+    status: implemented
     tags: [network, tsn, wctt, tas, soundness, oracle]
     links:
       - type: satisfies
@@ -2363,7 +2363,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- synth"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, synthesis, qbv, oracle]
     links:
       - type: satisfies
@@ -2392,7 +2392,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- split_"
-    status: passing
+    status: implemented
     tags: [v0.21.0, network, tsn, synthesis, qbv, oracle]
     links:
       - type: satisfies
@@ -2433,7 +2433,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- guard"
-    status: passing
+    status: implemented
     tags: [v0.22.0, network, tsn, synthesis, qbv, guard-band, oracle]
     links:
       - type: satisfies
@@ -2468,7 +2468,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- yang"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, export, yang, netconf, oracle]
     links:
       - type: satisfies
@@ -2505,7 +2505,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- cqf"
-    status: passing
+    status: implemented
     tags: [v0.20.0, network, tsn, synthesis, cqf, oracle]
     links:
       - type: satisfies
@@ -2549,7 +2549,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-network --lib -- cqf"
-    status: passing
+    status: implemented
     tags: [v0.23.0, network, tsn, synthesis, cqf, longlink, oracle]
     links:
       - type: satisfies
@@ -2586,7 +2586,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- cqf_synth"
-    status: passing
+    status: implemented
     tags: [v0.20.0, analysis, tsn, synthesis, cqf, bridge, oracle]
     links:
       - type: satisfies
@@ -2627,7 +2627,7 @@ artifacts:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn::tests::cbs
         - run: cargo test -p spar-analysis --lib -- wctt::tests::cbs
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, cbs, qav, wctt]
     links:
       - type: satisfies
@@ -2665,7 +2665,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.8.1, network, tsn, preemption, qbu, wctt]
     links:
       - type: satisfies
@@ -2701,7 +2701,7 @@ artifacts:
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.9.1, network, wctt, soundness, gptp, quantization]
     links:
       - type: satisfies
@@ -2750,7 +2750,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- curves::piecewise
-    status: passing
+    status: implemented
     tags: [v0.9.3, network, wctt, network-calculus, piecewise]
     links:
       - type: satisfies
@@ -2777,7 +2777,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- rta::tests::stop_for_lock
         - run: cargo test -p spar-analysis --lib -- arinc653
-    status: passing
+    status: implemented
     tags: [v0.9.2, analysis, rta, arinc653, soundness]
     links:
       - type: satisfies
@@ -2804,7 +2804,7 @@ artifacts:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-network --lib -- tsn
         - run: cargo test -p spar-analysis --lib -- wctt
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, tsn, cbs, wctt]
     links:
       - type: satisfies
@@ -2825,7 +2825,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- context_switch
-    status: passing
+    status: implemented
     tags: [v0.9.2, analysis, rta, soundness, scheduling]
     links:
       - type: satisfies
@@ -2849,7 +2849,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- wctt
         - run: cargo test -p spar-analysis --test wctt_fixtures
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, wctt, sensitivity]
     links:
       - type: satisfies
@@ -2872,7 +2872,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-analysis --lib -- rta_wctt
         - run: cargo test -p spar-analysis --lib -- no_dispatch_jitter
-    status: passing
+    status: implemented
     tags: [v0.9.2, network, wctt, rta, coupling]
     links:
       - type: satisfies
@@ -2903,7 +2903,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-network --lib -- pmoo
         - run: cargo test -p spar-analysis --lib -- pmoo_flag
-    status: passing
+    status: implemented
     tags: [v0.9.3, network, wctt, pmoo, ludb, lp]
     links:
       - type: satisfies
@@ -2930,7 +2930,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-insight
-    status: passing
+    status: implemented
     tags: [v0.9.0, insight, trace, ctf, tier1]
     links:
       - type: satisfies
@@ -2973,7 +2973,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-mcp
-    status: passing
+    status: implemented
     tags: [mcp, migration, track-e, v090, integration]
     links:
       # v0.14.0 link-and-promote: the tool-surface tests exercise the MCP
@@ -3017,7 +3017,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def --lib -- standard_properties
         - run: cargo test -p spar-trace-topology
-    status: passing
+    status: implemented
     tags: [v0.10.0, trace-topology, track-g, properties]
     links:
       - type: satisfies
@@ -3041,7 +3041,7 @@ artifacts:
         - run: cargo test -p spar-analysis rta::tests::interrupt_overhead_inflates_isr_wcet
         - run: cargo test -p spar-analysis rta::tests::no_interrupt_overhead_byte_identical_to_pre_c1
         - run: cargo test -p spar-analysis rta::tests::interrupt_overhead_combined_with_context_switch_for_handler
-    status: passing
+    status: implemented
     tags: [rta, isr, v093]
     links:
       - type: satisfies
@@ -3060,7 +3060,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, lldp, v0100]
     links:
       - type: satisfies
@@ -3080,7 +3080,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, pcapng, v0100]
     links:
       - type: satisfies
@@ -3099,7 +3099,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, qcc, yang, v0100]
     links:
       - type: satisfies
@@ -3118,7 +3118,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- ingest::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, ingest, gptp, v0100]
     links:
       - type: satisfies
@@ -3136,7 +3136,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology --lib -- identity::tests
-    status: passing
+    status: implemented
     tags: [trace-topology, properties, identity, ip, v0100]
     links:
       - type: satisfies
@@ -3161,7 +3161,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-trace-topology --lib -- engine::tests
         - run: cargo test -p spar-trace-topology --test identity_reconcile
-    status: passing
+    status: implemented
     tags: [trace-topology, reconcile, engine, v0110, track-g]
     links:
       - type: satisfies
@@ -3189,7 +3189,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-trace-topology --lib -- engine::tests::gptp_
         - run: cargo test -p spar-trace-topology --test gptp_out_of_budget
-    status: passing
+    status: implemented
     tags: [trace-topology, reconcile, engine, gptp, v0110, track-g]
     links:
       - type: satisfies
@@ -3209,7 +3209,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-hir-def overlay
         - run: cargo test -p spar --test applies_to_nested
-    status: passing
+    status: implemented
     tags: [binding, hir-def, v093]
     links:
       - type: satisfies
@@ -3235,7 +3235,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib -- binding_rules::tests
-    status: passing
+    status: implemented
     tags: [binding, analysis, v0111]
     links:
       - type: satisfies
@@ -3254,7 +3254,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis classifier_match
-    status: passing
+    status: implemented
     tags: [classifier-match, connections, v093]
     links:
       - type: satisfies
@@ -3274,7 +3274,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --bin spar -- assertion::tests::eval_count
-    status: passing
+    status: implemented
     tags: [assertions, eval, v093]
     links:
       - type: satisfies
@@ -3294,7 +3294,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --bin spar -- assertion::tests::has
-    status: passing
+    status: implemented
     tags: [assertions, v093]
     links:
       - type: satisfies
@@ -3314,7 +3314,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test applies_to_feature_path
-    status: passing
+    status: implemented
     tags: [hir-def, properties, v093]
     links:
       - type: satisfies
@@ -3343,7 +3343,7 @@ artifacts:
       steps:
         - run: "test -f proofs/Proofs/Scheduling/Latency.lean"
         - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Latency.lean"
-    status: passing
+    status: implemented
     tags: [proof, latency, lean, v0100]
     links:
       - type: satisfies
@@ -3366,7 +3366,7 @@ artifacts:
       steps:
         - run: "test -f proofs/Proofs/Scheduling/Arinc653Isolation.lean"
         - run: "! grep -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/Scheduling/Arinc653Isolation.lean"
-    status: passing
+    status: implemented
     tags: [proof, arinc653, lean, v0100]
     links:
       - type: satisfies
@@ -3387,7 +3387,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-mermaid
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3407,7 +3407,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test emit_mermaid
-    status: passing
+    status: implemented
     tags: [mermaid, cli, v0100]
     links:
       - type: satisfies
@@ -3431,7 +3431,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis emv2_propagation
-    status: passing
+    status: implemented
     tags: [emv2, analysis, v0100, safety]
     links:
       - type: satisfies
@@ -3462,7 +3462,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-annex --lib model
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, annex]
     links:
       - type: verifies
@@ -3492,7 +3492,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib emv2
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, hir-def]
     links:
       - type: verifies
@@ -3526,7 +3526,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-hir-def --lib emv2_
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, hir-def]
     links:
       - type: verifies
@@ -3565,7 +3565,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --test emv2_chain
-    status: passing
+    status: implemented
     tags: [emv2, analysis, safety, v0.23.0, capability]
     links:
       - type: verifies
@@ -3588,7 +3588,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- wrpc_binding"
-    status: passing
+    status: implemented
     tags: [wrpc, binding, analysis, bug]
     links:
       - type: satisfies
@@ -3615,7 +3615,7 @@ artifacts:
       method: automated-test
       steps:
         - run: "cargo test -p spar-analysis --lib -- wrpc_binding"
-    status: passing
+    status: implemented
     tags: [wrpc, binding, analysis]
     links:
       - type: satisfies
@@ -3637,7 +3637,7 @@ artifacts:
       steps:
         - run: "tools/run_verification.py --filter '(and (= type \"feature\") (has-tag \"classifier-match\"))' --results-json /tmp/verify-smoke.json"
         - run: "python3 -c 'import json,sys; d=json.load(open(\"/tmp/verify-smoke.json\")); sys.exit(0 if d[\"passed_count\"]==1 and d[\"failed_count\"]==0 else 1)'"
-    status: passing
+    status: implemented
     tags: [ci, rivet, verification, v0100]
     links:
       - type: satisfies
@@ -3661,7 +3661,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-mermaid
         - run: cargo test -p spar --test emit_mermaid emit_mermaid_class_happy_path
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3683,7 +3683,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-mermaid
         - run: cargo test -p spar --test emit_mermaid emit_mermaid_req_happy_path
-    status: passing
+    status: implemented
     tags: [mermaid, emission, v0100]
     links:
       - type: satisfies
@@ -3705,7 +3705,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --test golden_test
-    status: passing
+    status: implemented
     tags: [codegen, wit, cli, v0100]
     links:
       - type: satisfies
@@ -3732,7 +3732,7 @@ artifacts:
         - run: cargo run -q -p spar -- codegen --root Threads::Sys.impl --output /tmp/threads-out /tmp/threads.aadl
         - run: cargo run -q -p spar -- codegen --root Proc::Sys.impl --format wit --output /tmp/proc-out /tmp/proc.aadl
         - run: cargo run -q -p spar -- codegen --root Threads::Sys.impl --format rust --output /tmp/threads-rust-out /tmp/threads.aadl
-    status: passing
+    status: implemented
     tags: [codegen, wit, cli, diagnostics, v0110]
     links:
       - type: satisfies
@@ -3763,7 +3763,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-trace-topology fixtures::transform
-    status: passing
+    status: implemented
     tags: [trace-topology, fixtures, v0110]
     links:
       - type: satisfies
@@ -3784,7 +3784,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo build -p spar-trace-topology --bin fixture-vm
-    status: passing
+    status: implemented
     tags: [trace-topology, fixtures, ci, v0110]
     links:
       - type: satisfies
@@ -3822,7 +3822,7 @@ artifacts:
         - run: "grep -q \"cosign-release: 'v2.4.1'\" .github/workflows/release.yml"
         - run: grep -q 'cosign sign-blob' .github/workflows/release.yml
         - run: grep -q 'build-env.txt' .github/workflows/release.yml
-    status: passing
+    status: implemented
     tags: [release, supply-chain, cosign, slsa, sbom, v0110]
     links:
       - type: satisfies
@@ -3847,7 +3847,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar --test osate_corpus -- --nocapture
-    status: passing
+    status: implemented
     tags: [interop, plugfest, aadl, parser, osate, v0120]
     links:
       - type: satisfies
@@ -3871,7 +3871,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, interop, v0130]
     links:
       - type: satisfies
@@ -3894,7 +3894,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, interop, v0140]
     links:
       - type: satisfies
@@ -3918,7 +3918,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-codegen --lib -- wit_gen
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, interop, v0240]
     links:
       - type: satisfies
@@ -3950,7 +3950,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-codegen --test lifecycle_bindings
         - run: cargo test -p spar-codegen --test lifecycle_bindings -- --ignored
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, wit-bindgen, interop, v0240]
     links:
       - type: satisfies
@@ -3983,7 +3983,7 @@ artifacts:
       steps:
         - run: cargo test -p spar-codegen --test lifecycle_bindings
         - run: cargo test -p spar-codegen --test lifecycle_bindings -- --ignored
-    status: passing
+    status: implemented
     tags: [codegen, wit, rust, wit-bindgen, no-alloc, v0240]
     links:
       - type: satisfies
@@ -4013,7 +4013,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-network --lib -- tfa
-    status: passing
+    status: implemented
     tags: [network-calculus, tfa, substrate, tier1, v0170]
     links:
       - type: satisfies
@@ -4040,7 +4040,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-dbc
-    status: passing
+    status: implemented
     tags: [ingest, dbc, can, tier1, v0170]
     links:
       - type: satisfies
@@ -4067,7 +4067,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-dbc --test roundtrip sample_dbc_emits_message_flows
-    status: passing
+    status: implemented
     tags: [ingest, dbc, can, flows, tier1, v0200]
     links:
       - type: satisfies
@@ -4119,7 +4119,7 @@ artifacts:
       steps:
         - run: tools/check_human_scoped.py --self-test
         - run: tools/check_human_scoped.py --artifacts-dir artifacts --artifacts-dir safety/stpa
-    status: passing
+    status: implemented
     tags: [process, guardrail, autonomy, ci, tooling, v0360]
     links:
       - type: satisfies
@@ -4162,7 +4162,7 @@ artifacts:
       method: automated-test
       steps:
         - run: cargo test -p spar-analysis --lib bus_bandwidth
-    status: passing
+    status: implemented
     tags: [network-calculus, bus, honesty, analysis, oracle, v0350]
     links:
       - type: satisfies

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -732,7 +732,7 @@ artifacts:
 
   - id: VAL-CODEGEN-001
     type: feature
-    status: pass
+    status: passing
     title: Golden model integration tests for codegen
     description: >
       19 golden model integration tests validating end-to-end code generation
@@ -754,7 +754,7 @@ artifacts:
 
   - id: VAL-CODEGEN-002
     type: feature
-    status: pass
+    status: passing
     title: WIT/Rust/Config/Test/Proof generation output validation
     description: >
       Tests validating each codegen output layer independently: WIT interface
@@ -795,7 +795,7 @@ artifacts:
 
   - id: VAL-SYSML2-LOWER-001
     type: feature
-    status: pass
+    status: passing
     title: SysML v2 lowering tests
     description: >
       Tests for SysML v2 to AADL lowering covering diagnostic handling for
@@ -814,7 +814,7 @@ artifacts:
 
   - id: VAL-VERIFY-MACROS-001
     type: feature
-    status: pass
+    status: passing
     title: Verify macro proc-macro tests
     description: >
       Tests for spar-verify-macros proc-macro crate covering #[aadl(...)]
@@ -837,7 +837,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — solver output implies no deadline miss
     description: >
       kani_schedule_implies_no_deadline_miss harness: for any TaskSet of
@@ -861,7 +861,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-002
     type: feature
-    status: pending
+    status: planned
     title: Kani — priority ordering is monotone and antisymmetric
     description: >
       kani_priority_monotonicity harness: for any two tasks in a ≤4-task
@@ -885,7 +885,7 @@ artifacts:
 
   - id: VAL-KANI-SOLVER-003
     type: feature
-    status: pending
+    status: planned
     title: Kani — EDF accepts U=1 at n=2, RM rejects
     description: >
       kani_zero_laxity_handled harness: a 2-task implicit-deadline set
@@ -909,7 +909,7 @@ artifacts:
 
   - id: VAL-KANI-CODEGEN-001
     type: feature
-    status: pending
+    status: planned
     title: Kani — codegen emission preserves schedule task IDs
     description: >
       kani_emit_preserves_schedule harness: for any Schedule of size
@@ -980,7 +980,7 @@ artifacts:
 
   - id: VAL-MUTATION-001
     type: feature
-    status: pass
+    status: passing
     title: Mutation testing for analysis passes
     description: >
       Mutation testing campaign covering 674 analysis tests. Validates that

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4127,6 +4127,62 @@ artifacts:
       - type: verifies
         target: REQ-GUARD-HUMAN-SCOPED-001
 
+  - id: TEST-GUARD-GATE-EVIDENCE
+    type: feature
+    title: The mutation gate fails on absence, on a report that measured nothing, and on self-disagreement
+    description: >
+      Verifies REQ-GUARD-GATE-EVIDENCE-001 through the 19-case decision table in
+      tools/check_mutants_report.py --self-test, which runs as its own CI step
+      BEFORE the gate it protects.
+
+      THE LOAD-BEARING CASE is "REGRESSION #381: outcome files ONLY at the
+      shallow path" — a fixture with a full, valid set of outcome files placed
+      where the old gate LOOKED rather than where cargo-mutants writes them. It
+      must exit 1. Against the shipped implementation before this change, that
+      same fixture exits 0 and reports zero survivors, which is why the case is
+      written as a fixture rather than as prose.
+
+      The table also covers: no output directory at all (a crashed or OOM'd run,
+      which is a real state because the run step ends in `|| true` and the job is
+      on lean-mem precisely because it is RAM-hungry); an empty output directory;
+      a report with 0 caught (the suite never ran, which also scores zero
+      survivors); the impossible 0-caught-and-0-unviable report; missed.txt and
+      caught.txt individually removed; survivors exactly at and one over the
+      threshold; and four `outcomes.json` cross-check cases — agreeing,
+      disagreeing, unparseable, and absent. Absent passes but says "counts NOT
+      cross-checked" out loud rather than passing silently, because losing the
+      cross-check is losing the only detector that would have caught #381.
+
+      Four further cases assert on the weekly summary's RENDERED MARKDOWN rather
+      than an exit code: for an advisory report that never gates, the text is the
+      entire product, so "renders no table when there is no report" and "the
+      shallow layout must not render 0/0/0/0" are the properties that matter.
+
+      MEASURED AGAINST THE REAL ARTIFACT, not only fixtures: run 30563879100's
+      uploaded report (15 MB, downloaded) scores 210 missed / 603 caught / 793
+      unviable / 2 timeout with the counts agreeing with outcomes.json; exit 0 at
+      the 210 threshold, exit 1 at 209, and exit 1 at 142 — the threshold that was
+      nominally in force for four months while the same report scored green.
+
+      HONEST CEILING: this verifies the checker's decision table, and that the
+      checker is reachable — a PR touching tools/*.py is classified `code` by the
+      change filter, so the self-test runs. It does NOT verify that cargo-mutants
+      itself measured the workspace correctly, and it cannot verify the gate's
+      behaviour on a real three-hour CI run until one completes; the first such
+      run is the PR that lands this.
+    fields:
+      method: automated-test
+      steps:
+        - run: tools/check_mutants_report.py --self-test
+        - run: tools/check_mutants_report.py --output-dir mutants-out --max-missed 210
+    status: implemented
+    tags: [process, guardrail, ci, tooling, mutation-testing, v0360]
+    links:
+      - type: satisfies
+        target: REQ-GUARD-GATE-EVIDENCE-001
+      - type: verifies
+        target: REQ-GUARD-GATE-EVIDENCE-001
+
   - id: TEST-NC-BUS-PAYLOAD
     type: feature
     title: Bus bandwidth reports unmeasurable connections instead of scoring them zero

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4183,6 +4183,75 @@ artifacts:
       - type: verifies
         target: REQ-GUARD-GATE-EVIDENCE-001
 
+  - id: TEST-GUARD-FMT-WORKSPACES
+    type: feature
+    title: The format gate fails on a dirty nested workspace and on a discovery that came up short
+    description: >
+      Verifies obligation (b) of REQ-GUARD-GATE-EVIDENCE-001 through the 10-case
+      decision table in tools/check_fmt_workspaces.py --self-test, which runs as
+      its own CI step BEFORE the gate it protects.
+
+      THE LOAD-BEARING CASE is "REGRESSION #383: a dirty NON-ROOT workspace fails
+      the gate" — a four-workspace tree where the root is clean and fuzz/ is
+      dirty. It must exit 1 and print "4 workspace(s) checked, 3 formatted".
+      That is the live state of main, on which `cargo fmt --all -- --check`
+      exits 0. The case is a fixture rather than prose because the two gates
+      disagree about the same tree, and only executing both shows it.
+
+      TWO PRUNE CASES GUARD A BUG THAT PASSES. A vendored `[workspace]` under
+      target/, and one under a nested fuzz/target/, must not be discovered.
+      Without the prune list a walk on any machine that has built once finds
+      dozens of crates.io manifests, clears the floor comfortably, and hands
+      cargo other people's cached sources to format — green, and wrong. The
+      second case exists separately because it fails if pruning is applied only
+      at the top level rather than at every depth.
+
+      THE FLOOR IS TESTED IN BOTH DIRECTIONS: a tree with three workspaces exits
+      1 (a workspace that vanishes from discovery is silently exempt, which is
+      #383 returning by a different route), and a tree with none exits 2 — an
+      empty scan must not render as "everything is formatted". A member crate
+      with no `[workspace]` table, and one carrying `[workspace.package]`, are
+      both excluded, since counting inheriting members would inflate the total
+      past the floor and disarm it. Cargo being absent (OSError from the runner)
+      exits 2, not 0.
+
+      MEASURED AGAINST THE REAL TREE, not only fixtures. On main's version of
+      fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs the checker exits 1 with
+      "4 workspace(s) checked, 3 formatted" and reproduces the 13-line rustfmt
+      diff; with the file reformatted it exits 0 with "4 workspace(s) checked,
+      4 formatted". The four discovered manifests are the root, fuzz/,
+      codegen-exec-oracle/ and codegen-kiln-oracle/.
+
+      REACHABILITY is unconditional, and stronger than the mutation checker's.
+      The `fmt` job declares no `needs` and no `if`, so unlike `clippy`, `test`
+      and `mutants` — all three gated on `needs.changes.outputs.code == 'true'` —
+      it runs on every pull request including documentation-only ones. Both
+      steps therefore execute on every PR, which is also why the runner-class
+      assumption below is exercised immediately rather than eventually.
+
+      HONEST CEILING: the decision table fakes the cargo runner, so it verifies
+      discovery, the floor, pruning and reporting — NOT the argument vector
+      handed to cargo. That is covered only by the real-tree run above, which is
+      a manual measurement rather than a CI assertion. It does not cover
+      `Clippy`, which has the identical `--workspace` scope gap and is untouched
+      here. And it does not establish that python3 exists on the `light` runner
+      class the fmt job runs on; the sibling guardrails have been observed on
+      rust-cpu and lean-mem hosts only. The failure mode is fail-closed — exit
+      127 turns the required check red — so the PR that lands this is the
+      measurement, and if it 127s the job moves to rust-cpu.
+    fields:
+      method: automated-test
+      steps:
+        - run: tools/check_fmt_workspaces.py --self-test
+        - run: tools/check_fmt_workspaces.py
+    status: implemented
+    tags: [process, guardrail, ci, tooling, formatting, v0360]
+    links:
+      - type: satisfies
+        target: REQ-GUARD-GATE-EVIDENCE-001
+      - type: verifies
+        target: REQ-GUARD-GATE-EVIDENCE-001
+
   - id: TEST-NC-BUS-PAYLOAD
     type: feature
     title: Bus bandwidth reports unmeasurable connections instead of scoring them zero

--- a/crates/spar-analysis/Cargo.toml
+++ b/crates/spar-analysis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-analysis"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Pluggable analysis framework for AADL models"

--- a/crates/spar-annex/Cargo.toml
+++ b/crates/spar-annex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-annex"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Pluggable annex parser framework for AADL annexes (EMV2, BA, etc.)"

--- a/crates/spar-base-db/Cargo.toml
+++ b/crates/spar-base-db/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-base-db"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Salsa incremental computation database for AADL analysis"

--- a/crates/spar-cli/Cargo.toml
+++ b/crates/spar-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL toolchain CLI"

--- a/crates/spar-codegen/Cargo.toml
+++ b/crates/spar-codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-codegen"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Code generation from AADL instance models (Rust, WIT, Lean4, Kani, Bazel)"

--- a/crates/spar-dbc/Cargo.toml
+++ b/crates/spar-dbc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-dbc"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "CAN .dbc ingest: parse a DBC network and emit AADL v2.3 source text"

--- a/crates/spar-hir-def/Cargo.toml
+++ b/crates/spar-hir-def/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-hir-def"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "HIR definitions and name resolution for AADL analysis"

--- a/crates/spar-hir/Cargo.toml
+++ b/crates/spar-hir/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-hir"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Public semantic API facade for AADL models"

--- a/crates/spar-insight/Cargo.toml
+++ b/crates/spar-insight/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-insight"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Statistical-discrepancy assistant: compares observed CTF timing traces to spar's Expected_BCET/WCET/Mean model predictions"

--- a/crates/spar-mcp/Cargo.toml
+++ b/crates/spar-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-mcp"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "MCP server exposing spar's verification oracles (read-only) for AI agent integration"

--- a/crates/spar-mermaid/Cargo.toml
+++ b/crates/spar-mermaid/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-mermaid"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Mermaid diagram emission for spar AADL instance models"

--- a/crates/spar-network/Cargo.toml
+++ b/crates/spar-network/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-network"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Network Calculus primitives for AADL WCTT analysis (TSN/Ethernet, Track D)"

--- a/crates/spar-parser/Cargo.toml
+++ b/crates/spar-parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-parser"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL parser — tree-agnostic recursive descent with error recovery"

--- a/crates/spar-render/Cargo.toml
+++ b/crates/spar-render/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-render"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SVG architecture visualization for AADL models"

--- a/crates/spar-solver/Cargo.toml
+++ b/crates/spar-solver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-solver"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Deployment solver for AADL models"

--- a/crates/spar-syntax/Cargo.toml
+++ b/crates/spar-syntax/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-syntax"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL syntax tree — lossless CST with typed AST layer"

--- a/crates/spar-sysml2/Cargo.toml
+++ b/crates/spar-sysml2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-sysml2"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "SysML v2 parser, AADL lowering, and requirements extraction"

--- a/crates/spar-trace-topology/Cargo.toml
+++ b/crates/spar-trace-topology/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-trace-topology"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Runtime/declared topology reconciliation for spar (PCAPNG + LLDP + Qcc + AADL)"

--- a/crates/spar-transform/Cargo.toml
+++ b/crates/spar-transform/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-transform"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Bidirectional transforms between AADL and external formats (WIT, etc.)"

--- a/crates/spar-variants/Cargo.toml
+++ b/crates/spar-variants/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-variants"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Consumer-side adapter for rivet's variant context blob (v1) — filters spar HIR by binding rules"

--- a/crates/spar-verify-macros/Cargo.toml
+++ b/crates/spar-verify-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-verify-macros"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Proc macros for AADL configuration verification"

--- a/crates/spar-verify/Cargo.toml
+++ b/crates/spar-verify/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-verify"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "AADL configuration verification attributes"

--- a/crates/spar-wasm/Cargo.toml
+++ b/crates/spar-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spar-wasm"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "WASM component for AADL parsing, analysis, and SVG rendering"

--- a/fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs
@@ -32,11 +32,7 @@ struct Knobs {
 
 fn build_seed_instance() -> (GlobalScope, SystemInstance) {
     let db = spar_hir_def::HirDefDatabase::default();
-    let sf = spar_base_db::SourceFile::new(
-        &db,
-        "fuzz.aadl".to_string(),
-        SEED_AADL.to_string(),
-    );
+    let sf = spar_base_db::SourceFile::new(&db, "fuzz.aadl".to_string(), SEED_AADL.to_string());
     let tree = spar_hir_def::file_item_tree(&db, sf);
     let scope = GlobalScope::from_trees(vec![tree]);
     let inst = SystemInstance::instantiate(

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -18,16 +18,16 @@ project:
 sources:
   - path: artifacts
     format: generic-yaml
+  # The directory scan below already loads every *.yaml under safety/stpa.
+  # Four of those files used to ALSO be listed individually, to force
+  # `format: generic-yaml` on them — which loaded each one twice and made
+  # every id in it collide with itself: 184 phantom "declared more than
+  # once" errors, one per id, with the same path on both sides of the
+  # message (#360). The explicit entries are removed; see the measurement
+  # in the PR for the artifact-set equivalence check that says the
+  # directory scan alone loses nothing.
   - path: safety/stpa
     format: stpa-yaml
-  - path: safety/stpa/requirements.yaml
-    format: generic-yaml
-  - path: safety/stpa/architecture.yaml
-    format: generic-yaml
-  - path: safety/stpa/validation.yaml
-    format: generic-yaml
-  - path: safety/stpa/solver-requirements.yaml
-    format: generic-yaml
 
 docs:
   - docs

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -23,9 +23,28 @@ sources:
   # `format: generic-yaml` on them — which loaded each one twice and made
   # every id in it collide with itself: 184 phantom "declared more than
   # once" errors, one per id, with the same path on both sides of the
-  # message (#360). The explicit entries are removed; see the measurement
-  # in the PR for the artifact-set equivalence check that says the
-  # directory scan alone loses nothing.
+  # message (#360). The explicit entries are removed.
+  #
+  # This is NOT free, and the PR's first measurement said it was — wrongly.
+  # `rivet list --format json` WITHOUT `--full` emits only the summary view
+  # (`--help`: it omits `description`, `tags`, and `fields`), so the
+  # "byte-identical, loses nothing" equivalence check was run on a view
+  # structurally incapable of seeing field-level loss — the exact class of
+  # change a `format:` switch produces. Re-measured with `--full`:
+  #
+  #   +86 artifacts GAIN `mitigates` and `traces-to` (stpa-yaml really is
+  #       broadly a superset — but the original measurement didn't show that
+  #       either, it showed nothing)
+  #    -5 artifacts LOSE half of `test-name`: VAL-010/011/014/015/021 are
+  #       exactly the five whose on-disk value is a comma-separated pair, and
+  #       the stpa-yaml parser keeps only the first element.
+  #
+  #       on disk: tests::boolean_matches_aadl_boolean, tests::boolean_mismatches_aadl_string
+  #       rivet:   tests::boolean_matches_aadl_boolean
+  #
+  # Accepted deliberately — five truncated evidence pointers against 190
+  # phantom duplicate-id errors — and filed upstream as pulseengine/rivet#747
+  # rather than silently absorbed. Revert this trade if #747 lands a fix.
   - path: safety/stpa
     format: stpa-yaml
 

--- a/safety/stpa/rendering-analysis.yaml
+++ b/safety/stpa/rendering-analysis.yaml
@@ -159,7 +159,7 @@ artifacts:
   - id: RENDER-REQ-003
     type: requirement
     title: Interactive HTML with zoom/pan/minimap/search
-    status: partial
+    status: approved
     description: >
       The interactive HTML output must support zoom, pan, a minimap
       for orientation in large models, and text search to locate

--- a/safety/stpa/requirements.yaml
+++ b/safety/stpa/requirements.yaml
@@ -458,7 +458,7 @@ artifacts:
       with explicit arms for known non-semantic kinds and a catch-all that
       emits a warning diagnostic "unhandled SysML v2 construct: {kind}".
       This mirrors the AADL lowering exhaustiveness (STPA-REQ-004).
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, lowering, stpa]
     traces-to: [CC-15]
     mitigates: [H-7]
@@ -473,7 +473,7 @@ artifacts:
       it must not be classified as system. A test suite must cover all
       category inference paths with at least one test per SysML v2
       construct type (part def, action def, state def, etc.).
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, category, stpa]
     traces-to: [CC-16]
     mitigates: [H-7, H-1]
@@ -487,7 +487,7 @@ artifacts:
       the referenced type definition's category, not hardcoded to
       ComponentCategory::System. When the referenced type is not
       available, a warning diagnostic must be emitted.
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, category, stpa]
     traces-to: [CC-16]
     mitigates: [H-7, H-3]
@@ -501,7 +501,7 @@ artifacts:
       produce typed PropertyExpr values (IntegerLit/RealLit with unit
       annotation), not Opaque strings. Only expressions that genuinely
       cannot be parsed should use PropertyExpr::Opaque.
-    status: not-implemented
+    status: proposed
     tags: [safety, sysml2, properties, stpa]
     traces-to: [CC-17]
     mitigates: [H-7, H-6]
@@ -515,7 +515,12 @@ artifacts:
       AADL ItemTree has the correct category, features, subcomponents,
       connections, and property associations. A golden model test must
       verify end-to-end lowering of a non-trivial SysML v2 model.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Tests exist, but which of the 14+ lowering rules each one covers
+      has not been mapped, so per-rule coverage is deliberately not
+      asserted here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [safety, sysml2, testing, stpa]
     traces-to: [CC-15, CC-16]
     mitigates: [H-7]
@@ -534,7 +539,7 @@ artifacts:
       the rule must fail with a clear error message, not produce a
       cached success artifact. The check must use `which` or equivalent
       and verify the tool version meets minimum requirements.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-18]
     mitigates: [H-8]
@@ -548,7 +553,7 @@ artifacts:
       generating code that includes verification annotations. An
       integration test must verify that generated BUILD.bazel files
       contain at least one verification target per generated crate.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-19]
     mitigates: [H-8]
@@ -563,7 +568,7 @@ artifacts:
       "verification results" summary line. The lean_verify rule must
       check that the log contains "All proofs verified." A log that
       contains only error messages must cause the rule to fail.
-    status: not-implemented
+    status: proposed
     tags: [safety, codegen, verification, bazel, stpa]
     traces-to: [CC-18]
     mitigates: [H-8]
@@ -601,7 +606,7 @@ artifacts:
       diagnostics and halt code generation. Default value substitution
       (the current 10ms/1ms fallback) must emit a warning diagnostic
       rather than proceeding silently.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, stpa-sec]
     traces-to: [CC-SEC-2]
     mitigates: [H-SEC-2]
@@ -616,7 +621,7 @@ artifacts:
       (via .., symlinks, or absolute paths), codegen must emit an error
       and skip that file. This check must occur after all path component
       construction, including process name and thread name interpolation.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, filesystem, stpa-sec]
     traces-to: [CC-SEC-3]
     mitigates: [H-SEC-6]
@@ -631,7 +636,12 @@ artifacts:
       SyntaxKind name, source offset, and parent context. A golden-file
       test must verify that all semantic SysML v2 constructs produce
       either a lowered AADL item or a diagnostic.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which half is outstanding — the diagnostic itself or the
+      golden-file test that would prove it exhaustive — is deliberately
+      not asserted here; see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [security, sysml2, lowering, stpa-sec]
     traces-to: [CC-SEC-4]
     mitigates: [H-SEC-3]
@@ -647,7 +657,7 @@ artifacts:
       workspace Cargo.toml. Process names must be checked against a
       reserved list of common crate names (serde, tokio, rand, etc.)
       and must be prefixed with "aadl_" if they collide.
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, supply-chain, stpa-sec]
     traces-to: [CC-SEC-5]
     mitigates: [H-SEC-4]
@@ -664,7 +674,7 @@ artifacts:
       (e.g., verify_{name}_no_deadline_miss_base_case). The codegen
       must also generate a coverage_manifest.json listing each
       verification artifact and its scope.
-    status: not-implemented
+    status: proposed
     tags: [security, verification, stpa-sec]
     traces-to: [CC-SEC-6]
     mitigates: [H-SEC-5]
@@ -679,7 +689,7 @@ artifacts:
       paths must never be concatenated into shell command strings. If
       run_shell is unavoidable (e.g., for piping), all interpolated paths
       must be shell-quoted using shlex or equivalent escaping.
-    status: not-implemented
+    status: proposed
     tags: [security, build, bazel, stpa-sec]
     traces-to: [CC-SEC-7]
     mitigates: [H-SEC-1, H-SEC-4]
@@ -695,7 +705,7 @@ artifacts:
       current build invocation (via Bazel's action dependency graph,
       not filesystem timestamps). Content hashing of the core module
       should be logged for audit.
-    status: not-implemented
+    status: proposed
     tags: [security, build, wasm, stpa-sec]
     traces-to: [CC-SEC-8]
     mitigates: [H-SEC-1, H-SEC-2]
@@ -710,7 +720,7 @@ artifacts:
       100,000). When a limit is exceeded, codegen must emit an error
       diagnostic and halt. These limits must be configurable via CLI
       flags (--max-files, --max-output-size, --max-components).
-    status: not-implemented
+    status: proposed
     tags: [security, codegen, resource-limits, stpa-sec]
     traces-to: [SC-SEC-6]
     mitigates: [H-SEC-7]
@@ -725,7 +735,11 @@ artifacts:
       clippy). This test verifies that generated code is syntactically
       valid Rust. A second test must verify that generated WIT files
       pass wasm-tools component wit validation.
-    status: partial
+      Partially implemented: `partial` has no lifecycle equivalent, so
+      `approved` is the conservative floor, not an accurate position.
+      Which of the two tests is in place is deliberately not asserted
+      here — see REQ-GUARD-STATUS-VOCAB-001.
+    status: approved
     tags: [security, codegen, testing, stpa-sec]
     traces-to: [CC-SEC-1, CC-SEC-2]
     mitigates: [H-SEC-1, H-SEC-2]
@@ -740,7 +754,7 @@ artifacts:
       as system: no action/state usages found"). Engineers must be
       able to override the inference via a SysML v2 annotation or
       comment convention (e.g., `/* @aadl-category: thread */`).
-    status: not-implemented
+    status: proposed
     tags: [security, sysml2, lowering, stpa-sec]
     traces-to: [CC-SEC-4]
     mitigates: [H-SEC-3]
@@ -756,7 +770,7 @@ artifacts:
       proof uses default 10ms) must be reported as an error. This
       cross-reference should be implemented as a post-codegen
       validation step.
-    status: not-implemented
+    status: proposed
     tags: [security, verification, consistency, stpa-sec]
     traces-to: [CC-SEC-2, CC-SEC-6]
     mitigates: [H-SEC-2, H-SEC-5]

--- a/safety/stpa/solver-requirements.yaml
+++ b/safety/stpa/solver-requirements.yaml
@@ -25,7 +25,7 @@ artifacts:
       for LP relaxations), the final feasibility check must use
       conservative integer rounding (ceiling for utilization, floor
       for available time).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, numeric, stpa]
     traces-to: [CC-S1, CC-S20]
     mitigates: [H-S2, H-S12]
@@ -40,7 +40,7 @@ artifacts:
       When a single value is specified, it is treated as both best-case
       and worst-case. The RTA must emit a diagnostic if only a single
       value is provided, advising the engineer to specify a range.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, stpa]
     traces-to: [CC-S1]
     mitigates: [H-S2]
@@ -55,7 +55,7 @@ artifacts:
       are not specified in the model, the RTA must emit a warning that
       overhead is not accounted for and that the schedulability result
       is optimistic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, overhead, stpa]
     traces-to: [CC-S1]
     mitigates: [H-S2]
@@ -70,7 +70,7 @@ artifacts:
       (whose thread sets have changed) and re-run RTA for each dirty
       processor before reporting feasibility. An integration test must
       verify that no populated processor is skipped.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, completeness, stpa]
     traces-to: [CC-S2]
     mitigates: [H-S2]
@@ -85,7 +85,7 @@ artifacts:
       The quick utilization test may be used as a pre-filter to reject
       obviously infeasible allocations, but the full RTA must confirm
       feasibility before the allocation is committed.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, scheduling, incremental, stpa]
     traces-to: [CC-S2]
     mitigates: [H-S2, H-S9]
@@ -105,7 +105,7 @@ artifacts:
       processor they reside on, not once per process that accesses them.
       An integration test must verify resource sums against hand-calculated
       values for a reference model.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, resources, stpa]
     traces-to: [CC-S3]
     mitigates: [H-S10]
@@ -120,7 +120,7 @@ artifacts:
       as soft constraints. When an allocation violates an affinity
       constraint, the diagnostic must name the constraint, the component,
       and the conflicting binding.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, constraints, stpa]
     traces-to: [CC-S4]
     mitigates: [H-S3]
@@ -135,7 +135,7 @@ artifacts:
       different processors, different buses, and (when specified)
       different cabinets. The solver must detect redundancy annotations
       and apply anti-affinity automatically.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, allocation, redundancy, stpa]
     traces-to: [CC-S4]
     mitigates: [H-S3]
@@ -155,7 +155,7 @@ artifacts:
       utilization exceeds capacity, the assignment must be rejected.
       The bandwidth check must account for protocol overhead (framing,
       headers, retransmission).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, bandwidth, stpa]
     traces-to: [CC-S5]
     mitigates: [H-S4]
@@ -170,7 +170,7 @@ artifacts:
       check). The virtual bus library must declare security properties.
       Connections without a matching secure protocol must produce an
       error diagnostic, not be silently assigned to an insecure protocol.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, security, stpa]
     traces-to: [CC-S6]
     mitigates: [H-S4]
@@ -186,7 +186,7 @@ artifacts:
       cross-processor connection must receive a bus binding. A
       completeness check must verify that no cross-processor connection
       is unbound after Layer 2 completes.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, completeness, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S4]
@@ -201,7 +201,7 @@ artifacts:
       Nominal values may be used only for optimization objective
       evaluation (not for constraint satisfaction). Library entries
       without worst-case values must produce a warning diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, bus-binding, protocol-library, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -221,7 +221,7 @@ artifacts:
       context-switch time, and queuing delay. Each segment must be
       individually reported in the latency breakdown. Missing segments
       must produce a diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, e2e-latency, stpa]
     traces-to: [CC-S8]
     mitigates: [H-S1, H-S9]
@@ -237,7 +237,7 @@ artifacts:
       stop), (c) time and space partitioning is specified. If any
       containment mechanism is missing, the co-location must be rejected
       with an error diagnostic identifying the missing mechanism.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, mixed-criticality, containment, stpa]
     traces-to: [CC-S9]
     mitigates: [H-S3]
@@ -255,7 +255,7 @@ artifacts:
       schedulability. The global validation must use the composed
       solution (not individual layer results) and must report all
       violations, not just the first one found.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, global-validation, composition, stpa]
     traces-to: [CC-S10]
     mitigates: [H-S9]
@@ -272,7 +272,7 @@ artifacts:
       processes X and Y"). Full automated backtracking is desirable
       but manual-with-guidance is acceptable for the initial
       implementation.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, backtracking, global-validation, stpa]
     traces-to: [CC-S10]
     mitigates: [H-S9]
@@ -292,7 +292,7 @@ artifacts:
       by text search on the CST). When the path does not resolve to
       exactly one CST node, the rewriter must emit an error and skip
       the rewrite for that component.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, targeting, stpa]
     traces-to: [CC-S11]
     mitigates: [H-S5]
@@ -308,7 +308,7 @@ artifacts:
       none exists. Before insertion, the rewriter must check whether the
       property already exists; if so, it must update the value in place
       rather than inserting a duplicate.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, preservation, stpa]
     traces-to: [CC-S12]
     mitigates: [H-S5]
@@ -323,7 +323,7 @@ artifacts:
       back (original files restored) and an error diagnostic must
       identify which file has the syntax error and the approximate
       insertion location.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, validation, stpa]
     traces-to: [CC-S13]
     mitigates: [H-S5]
@@ -338,7 +338,7 @@ artifacts:
       If any file cannot be written (permissions, disk error), no files
       must be modified. The rewriter should write to temporary files
       first, then rename all atomically.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, atomicity, stpa]
     traces-to: [CC-S14]
     mitigates: [H-S5]
@@ -353,7 +353,7 @@ artifacts:
       as a workspace edit). The engineer must have the option to accept
       or reject the changes. No source modification without explicit
       engineer approval.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, rewriter, review, stpa]
     traces-to: [CC-S14]
     mitigates: [H-S5, H-S4]
@@ -374,7 +374,7 @@ artifacts:
       certificate must contain sufficient data for an independent
       verifier to reproduce the gap calculation without running the
       solver.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, verification, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -389,7 +389,7 @@ artifacts:
       solution satisfies all constraints by re-evaluating constraints
       against the reported binding, (c) flag any inconsistency. The
       verifier must be included in the CI test suite.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, independent-check, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -405,7 +405,7 @@ artifacts:
       results (certificate must include the infeasibility proof or
       state which constraint set is unsatisfiable). Solutions without
       certificates must not be reported to the user.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, completeness, stpa]
     traces-to: [CC-S16]
     mitigates: [H-S6]
@@ -420,7 +420,7 @@ artifacts:
       hash matches the solver's objective function hash. Mismatched
       objectives must produce an internal error, not a misleading
       certificate.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, certificate, consistency, stpa]
     traces-to: [CC-S15]
     mitigates: [H-S6]
@@ -439,7 +439,7 @@ artifacts:
       analysis must use the rewritten model (not the pre-solve model).
       Any analysis diagnostic at error severity must cause the solver to
       report failure, even if the solver's internal validation passed.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, validation, post-solve, stpa]
     traces-to: [CC-S17]
     mitigates: [H-S1, H-S8]
@@ -456,7 +456,7 @@ artifacts:
       rewritten property values (not stale pre-rewrite values) by
       checking that a solver-inserted binding property appears in the
       post-solve analysis output.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, validation, cache-coherence, stpa]
     traces-to: [CC-S17]
     mitigates: [H-S8]
@@ -478,7 +478,7 @@ artifacts:
       produce error diagnostics. The solver must refuse to run until
       all required properties are present or the engineer explicitly
       acknowledges the gaps.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, completeness, pre-solve, stpa]
     traces-to: [CC-S18]
     mitigates: [H-S11]
@@ -495,7 +495,7 @@ artifacts:
       must produce an explicit diagnostic. If the engineer provides an
       explicit default via a solver configuration flag, the solver must
       emit a warning listing all properties using the override default.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, completeness, defaults, stpa]
     traces-to: [CC-S18]
     mitigates: [H-S11]
@@ -515,7 +515,7 @@ artifacts:
       criterion (lexicographic ordering of component names). A CI test
       must run the solver 10 times on the same input and verify
       identical output.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, determinism, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S7]
@@ -531,7 +531,7 @@ artifacts:
       utilization for each processor/bus/memory, and a hash of the
       input model. Re-running the solver with the same input hash
       must produce the same binding or report a divergence diagnostic.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, reproducibility, persistence, stpa]
     traces-to: [CC-S7]
     mitigates: [H-S7]
@@ -551,7 +551,7 @@ artifacts:
       check that declared properties (bandwidth, latency, frame size)
       are within the ranges specified by the referenced standard.
       Library entries without standard references must produce a warning.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, protocol-library, validation, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -567,7 +567,7 @@ artifacts:
       emit a warning identifying the sensitive flows and the margin.
       This accounts for virtual bus library inaccuracies and real-world
       protocol variability.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, sensitivity, protocol-library, stpa]
     traces-to: [CC-S19]
     mitigates: [H-S4]
@@ -586,7 +586,7 @@ artifacts:
       each layer, and what properties the virtual bus library must
       provide. This documentation must be updated when the constraint
       model changes and must be reviewable by safety engineers.
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, documentation, stpa]
     traces-to: [SC-S1]
     mitigates: [H-S1]
@@ -602,7 +602,7 @@ artifacts:
       pass/fail status, (e) the optimality certificate, (f) list of
       all diagnostics by severity. The report must be both human-readable
       (text) and machine-parseable (JSON).
-    status: not-implemented
+    status: proposed
     tags: [safety, solver, reporting, stpa]
     traces-to: [SC-S1]
     mitigates: [H-S1, H-S5, H-S6]

--- a/safety/stpa/validation.yaml
+++ b/safety/stpa/validation.yaml
@@ -17,7 +17,7 @@ artifacts:
     description: >
       Verifies that parsing AADL with an annex library produces a
       LoweringDiagnostic containing "annex" with Warning severity.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -35,7 +35,7 @@ artifacts:
       Verifies that parsing a clean AADL package with a system type
       produces no "unhandled" warnings. This validates that the
       explicit no-op arms correctly cover all non-semantic SyntaxKinds.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -52,7 +52,7 @@ artifacts:
     description: >
       Verifies that a complete AADL package with types, implementations,
       features, and subcomponents produces zero lowering diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/item_tree/lower.rs
@@ -75,7 +75,7 @@ artifacts:
     description: >
       Verifies that an integer expression validates successfully against
       an AadlInteger property type definition.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -92,7 +92,7 @@ artifacts:
     description: >
       Verifies that a string expression against an integer type produces
       a type mismatch diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -109,7 +109,7 @@ artifacts:
     description: >
       Verifies that an enumeration value not in the declared variant
       list produces a diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -125,7 +125,7 @@ artifacts:
     title: Case-insensitive enum matching
     description: >
       Verifies that enumeration matching is case-insensitive per AADL spec.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -142,7 +142,7 @@ artifacts:
     description: >
       Verifies that list elements are individually checked against the
       list element type, and mismatched elements produce diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -159,7 +159,7 @@ artifacts:
     description: >
       Verifies that opaque (unparsed) property values do not produce
       false positive type mismatch diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -176,7 +176,7 @@ artifacts:
     description: >
       Verifies boolean expressions match AadlBoolean and mismatch
       AadlString with appropriate diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -193,7 +193,7 @@ artifacts:
     description: >
       Verifies that range min/max expressions are checked against the
       inner type, and mismatched bounds produce diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -210,7 +210,7 @@ artifacts:
     description: >
       Verifies that record field expressions are checked against the
       corresponding field type in the RecordType definition.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -227,7 +227,7 @@ artifacts:
     description: >
       Verifies that UnitValue delegates type checking to its inner
       expression.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -244,7 +244,7 @@ artifacts:
     description: >
       Verifies that classifier values match Classifier types and
       reference values match Reference types.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -261,7 +261,7 @@ artifacts:
     description: >
       Verifies that computed values and type references skip validation
       (cannot be checked statically).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_check.rs
@@ -279,7 +279,7 @@ artifacts:
       Verifies that when two imported packages both export a classifier
       with the same unqualified name, resolution produces an "ambiguous"
       warning listing the candidate packages.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -296,7 +296,7 @@ artifacts:
     description: >
       Verifies that fully qualified references (Pkg::Type) do not
       produce ambiguity warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -313,7 +313,7 @@ artifacts:
     description: >
       Verifies that references resolved within the same package do not
       produce ambiguity warnings even when imports have matching names.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/resolver.rs
@@ -335,7 +335,7 @@ artifacts:
       Verifies that a model with mutual containment (A.Impl contains
       B, B.Impl contains A) produces a diagnostic containing "circular"
       or "cycle".
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -352,7 +352,7 @@ artifacts:
     description: >
       Verifies that SystemInstance::instantiate produces a circular
       containment diagnostic when given a model with cycles.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -369,7 +369,7 @@ artifacts:
     description: >
       Verifies that a linear (non-circular) hierarchy does not produce
       spurious circular containment diagnostics.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -386,7 +386,7 @@ artifacts:
     description: >
       Verifies that an array with dimension 0 produces a diagnostic
       and the function returns 1 as fallback.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -403,7 +403,7 @@ artifacts:
     description: >
       Verifies that a valid positive array dimension produces no
       diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -420,7 +420,7 @@ artifacts:
     description: >
       Indirectly verifies that the Builder max_depth is 100 by testing
       that instantiation of deep hierarchies succeeds.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/instance.rs
@@ -441,7 +441,7 @@ artifacts:
     description: >
       Verifies that has_modes() returns false when the instance has
       no system operation modes.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/modal.rs
@@ -458,7 +458,7 @@ artifacts:
     description: >
       Verifies that has_modes() returns true and mode_names() returns
       the correct list when the instance has SOMs.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/modal.rs
@@ -475,7 +475,7 @@ artifacts:
     description: >
       Verifies that SchedulingAnalysis emits an Info diagnostic
       mentioning "system operation mode" when the instance has SOMs.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -492,7 +492,7 @@ artifacts:
     description: >
       Verifies that scheduling analysis does not emit the SOM awareness
       diagnostic when the instance has no system operation modes.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -515,7 +515,7 @@ artifacts:
       Intentionally_Unconnected does not produce a connectivity warning.
       Tests cover single feature, "all" variant, parenthesized list,
       and case-insensitive matching.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/connectivity.rs
@@ -533,7 +533,7 @@ artifacts:
       Regression guard verifying that ports without the
       Intentionally_Unconnected property still produce connectivity
       warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/connectivity.rs
@@ -550,7 +550,7 @@ artifacts:
     description: >
       Verifies that AnalysisRunner::register_all() registers exactly
       21 analysis passes and that the count matches expectations.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/lib.rs
@@ -569,7 +569,7 @@ artifacts:
       ms, sec, min, hr) against AS5506 Appendix A values. Includes
       forward/reverse conversions, adjacent ratio verification, and
       raw factor validation.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -587,7 +587,7 @@ artifacts:
       Tests validate size unit conversions (bits, Bytes, KByte, MByte,
       GByte, TByte) with factor verification (8x for bits/Bytes, 1024x
       for powers).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -604,7 +604,7 @@ artifacts:
     description: >
       Verifies that unit names are matched case-insensitively (e.g.,
       "MS", "Ms", "ms" all work).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir-def/src/property_value.rs
@@ -622,7 +622,7 @@ artifacts:
       Verifies that shared property accessors (get_timing_property,
       get_execution_time, get_size_property, get_processor_binding,
       extract_reference_target) parse property values correctly.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/property_accessors.rs
@@ -640,7 +640,7 @@ artifacts:
       Verifies that scheduling, latency, resource_budget, arinc653,
       binding_check, and binding_rules all import from
       property_accessors instead of defining private helpers.
-    status: passing
+    status: implemented
     fields:
       method: code-review
       evidence: >
@@ -659,7 +659,7 @@ artifacts:
       24 tests serialize each spar-hir public type to JSON, deserialize
       back, and assert structural equality. Covers all 16 serializable
       types plus all enum variants.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir/src/lib.rs
@@ -677,7 +677,7 @@ artifacts:
       Verifies that a complex InstanceNode tree (system > process >
       thread) with features, connections, array indices, and diagnostics
       survives JSON serialization round-trip.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-hir/src/lib.rs
@@ -699,7 +699,7 @@ artifacts:
       Verifies that when processor utilization exceeds the RMA bound
       but remains below 100%, the scheduling analysis emits an info
       diagnostic suggesting EDF scheduling as an alternative.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -714,7 +714,7 @@ artifacts:
     description: >
       Verifies that when utilization is within the RMA bound, no
       RMA/EDF cross-check diagnostic is emitted (not needed).
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -729,7 +729,7 @@ artifacts:
     description: >
       Verifies that a +10% perturbation that crosses a schedulability
       bound produces a warning about thin timing margins.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -744,7 +744,7 @@ artifacts:
     description: >
       Verifies that systems with comfortable timing margins do not
       produce sensitivity warnings.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -759,7 +759,7 @@ artifacts:
     description: >
       Verifies that a thread with Period but no Deadline emits an
       info diagnostic about implicit deadline equaling period.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -774,7 +774,7 @@ artifacts:
     description: >
       Verifies that a thread with both Period and Deadline does not
       emit the implicit-deadline info diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -789,7 +789,7 @@ artifacts:
     description: >
       Verifies that Compute_Execution_Time with min > max (e.g.,
       "5 ms .. 1 ms") produces an error diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -804,7 +804,7 @@ artifacts:
     description: >
       Verifies that worst-case execution time greater than period
       produces an error diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -819,7 +819,7 @@ artifacts:
     description: >
       Regression guard verifying that a valid range (min < max < period)
       does not produce execution time range errors.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -835,7 +835,7 @@ artifacts:
       Verifies that an end-to-end flow crossing processor boundaries
       without a Transmission_Time or Inter_Processor_Overhead property
       emits an info diagnostic about underestimated latency.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -850,7 +850,7 @@ artifacts:
     description: >
       Verifies that flows on the same processor do not trigger the
       inter-processor communication overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -865,7 +865,7 @@ artifacts:
     description: >
       Verifies that setting Transmission_Time on the flow owner
       suppresses the inter-processor overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/latency.rs
@@ -880,7 +880,7 @@ artifacts:
     description: >
       Verifies that processor utilization above 80% triggers a clock
       drift advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -895,7 +895,7 @@ artifacts:
     description: >
       Verifies that processor utilization below 80% does not trigger
       the clock drift advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -910,7 +910,7 @@ artifacts:
     description: >
       Verifies that threads without Context_Switch_Time or
       Interrupt_Overhead trigger an advisory diagnostic.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -925,7 +925,7 @@ artifacts:
     description: >
       Verifies that setting Context_Switch_Time suppresses the
       interrupt overhead advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -941,7 +941,7 @@ artifacts:
       Verifies that multiple threads on the same processor without
       Priority or Concurrency_Control_Protocol trigger a priority
       inversion advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -956,7 +956,7 @@ artifacts:
     description: >
       Verifies that setting Priority on threads suppresses the
       priority inversion advisory.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/scheduling.rs
@@ -972,7 +972,7 @@ artifacts:
       Verifies get_execution_time_range returns correct (min, max)
       pairs for both range format ("1 ms .. 5 ms") and single
       values ("3 ms").
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-analysis/src/property_accessors.rs
@@ -992,7 +992,7 @@ artifacts:
       All tests in the spar workspace pass after batch 3 implementation
       (timing and scheduling safety requirements).
       cargo clippy --workspace reports no warnings.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       command: cargo test --workspace
@@ -1056,7 +1056,7 @@ artifacts:
       port defs, connections, attributes, states, constraints, and
       specialization, then compares the produced AADL ItemTree against
       expected output.
-    status: passing
+    status: implemented
     fields:
       method: integration-test
       test-location: crates/spar-sysml2/tests/
@@ -1076,7 +1076,7 @@ artifacts:
       item_def, enum_def, interface_def, requirement_def, constraint_def,
       calc_def, allocation_def, connection_usage) produces the expected
       AADL construct with correct category and structure.
-    status: passing
+    status: implemented
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1094,7 +1094,7 @@ artifacts:
       Will verify that unrecognized SysML v2 SyntaxKind variants
       produce a warning diagnostic instead of being silently dropped.
       Blocked on STPA-REQ-032 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1113,7 +1113,7 @@ artifacts:
       classified as process/thread (not system), and that subcomponent
       categories are propagated from referenced type definitions.
       Blocked on STPA-REQ-033 and STPA-REQ-034 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1134,7 +1134,7 @@ artifacts:
       produce typed PropertyExpr values (not Opaque), enabling downstream
       scheduling and timing analysis.
       Blocked on STPA-REQ-035 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-sysml2/src/lower.rs
@@ -1156,7 +1156,7 @@ artifacts:
       Will verify that verus_verify and lean_verify rules fail with
       a clear error when the tool binary is not found.
       Blocked on STPA-REQ-037 implementation.
-    status: planned
+    status: proposed
     fields:
       method: integration-test
       test-location: tools/bazel/rules_verus/defs.bzl
@@ -1174,7 +1174,7 @@ artifacts:
       Will verify that workspace_gen.rs produces verus_verify and/or
       lean_verify targets in per-crate BUILD.bazel files.
       Blocked on STPA-REQ-038 implementation.
-    status: planned
+    status: proposed
     fields:
       method: unit-test
       test-location: crates/spar-codegen/src/workspace_gen.rs
@@ -1192,7 +1192,7 @@ artifacts:
       Will verify that verus_verify and lean_verify rules validate
       proof log content and reject empty or error-only logs.
       Blocked on STPA-REQ-039 implementation.
-    status: planned
+    status: proposed
     fields:
       method: integration-test
       test-location: tools/bazel/rules_verus/defs.bzl

--- a/tools/check_fmt_workspaces.py
+++ b/tools/check_fmt_workspaces.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Format-check every workspace in the repo, not just the one cargo defaults to (#383).
+
+THE FAILURE
+-----------
+The required `Format` status check ran
+
+    cargo fmt --all -- --check
+
+and reported green while `fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs` was
+unformatted on main. `--all` does not mean "all crates in the repo". It means
+"all members of *this* workspace", and this repo has four workspaces:
+
+    Cargo.toml                      the 23-crate root
+    fuzz/Cargo.toml                 own [workspace] table
+    codegen-exec-oracle/Cargo.toml  own [workspace] table
+    codegen-kiln-oracle/Cargo.toml  own [workspace] table
+
+A nested crate with its own `[workspace]` table is a separate workspace, and
+the root's `--all` never opens it. Measured on main:
+
+    cargo fmt --all -- --check                            -> 0
+    cargo fmt --manifest-path fuzz/Cargo.toml -- --check  -> 1  (13 diff lines)
+
+WHY IT SURVIVED
+---------------
+The same property as #381: the narrow answer is byte-identical to the broad
+one. `cargo fmt --all --check` exiting 0 over 23 of 26 crates prints exactly
+what it prints over all 26 — nothing. A gate that says nothing on success
+cannot distinguish "checked everything" from "checked a subset". So this
+script's contract is that it always prints the count of what it examined:
+
+    4 workspaces checked, 4 formatted
+
+A count is not producible by a broken scan. That is the entire trick.
+
+DISCOVERY, NOT ENUMERATION
+--------------------------
+A hard-coded list of four manifests would fix today's bug and re-open it the
+day someone adds a fifth workspace. So the set is discovered by walking the
+tree for `Cargo.toml` files containing a `[workspace]` table, and the count is
+floored at --min-workspaces. Discovery that silently returns fewer manifests
+than expected is the failure mode that would restore the original bug, so it
+is the one thing checked before any formatting happens.
+
+THE PRUNE LIST IS LOAD-BEARING
+------------------------------
+`target/` fills up with vendored dependency sources, and plenty of crates.io
+packages ship a `[workspace]` table. A naive walk finds dozens of them on any
+machine that has built once, sails past a `>= 4` floor, and then asks cargo to
+format other people's code out of the build cache. The floor check would still
+be green, which is what makes this worth a self-test case rather than a
+comment: the bug it prevents is one that *passes*.
+
+EXIT CODES
+----------
+    0  every discovered workspace is formatted
+    1  at least one is not (or discovery came up short)
+    2  the check could not run at all (cargo missing, root unreadable)
+
+2 exists so that "I could not measure" is not spelled the same way as "I
+measured and it was fine". Collapsing those two into 0 is how #381 lasted four
+months.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_CANNOT_CHECK = 2
+
+# Four today. This is a floor, not an expectation: adding a fifth workspace
+# should not require touching this file, but losing one should be loud.
+MIN_WORKSPACES = 4
+
+# Directories never descended into. `target` is the one that matters (see the
+# module docstring); the rest are conventional build/VCS residue.
+PRUNE = {"target", ".git", "node_modules", ".direnv", "result"}
+
+# A `[workspace]` table header, alone on its line. Deliberately NOT matching
+# `[workspace.package]` / `[workspace.dependencies]`, which appear in the root
+# manifest and in members that inherit from it — those do not create a
+# workspace, and counting them would inflate the total past the floor.
+WORKSPACE_TABLE = re.compile(r"^\[workspace\]\s*$", re.MULTILINE)
+
+
+def discover(root):
+    """Return the sorted repo-relative manifests that declare a [workspace] table."""
+    found = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in PRUNE)
+        if "Cargo.toml" not in filenames:
+            continue
+        path = os.path.join(dirpath, "Cargo.toml")
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        if WORKSPACE_TABLE.search(text):
+            found.append(os.path.relpath(path, root))
+    return sorted(found)
+
+
+def _cargo_fmt(root, manifest):
+    """Real runner: (exit_code, combined_output). Raises OSError if cargo is absent."""
+    proc = subprocess.run(
+        ["cargo", "fmt", "--manifest-path", manifest, "--all", "--", "--check"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def check(root, *, min_workspaces=MIN_WORKSPACES, runner=None, out=None):
+    out = out or sys.stdout
+    runner = runner or _cargo_fmt
+
+    if not os.path.isdir(root):
+        print(f"::error::not a directory: {root}", file=sys.stderr)
+        return EXIT_CANNOT_CHECK
+
+    manifests = discover(root)
+
+    if not manifests:
+        # Distinct from the floor message below on purpose. Zero means the walk
+        # itself is broken (wrong root, prune list too greedy); fewer-than-N
+        # means a workspace was removed. Same exit code, different repair.
+        print(
+            "::error::discovered NO workspace manifests — the scan is broken, "
+            f"not the tree (root: {root})",
+            file=sys.stderr,
+        )
+        return EXIT_CANNOT_CHECK
+
+    if len(manifests) < min_workspaces:
+        print(
+            f"::error::discovered {len(manifests)} workspace(s), expected at least "
+            f"{min_workspaces}: {', '.join(manifests)}",
+            file=sys.stderr,
+        )
+        print(
+            "::error::a workspace that vanishes from discovery is silently exempt "
+            "from formatting — that is #383. Lower --min-workspaces only when a "
+            "workspace was deliberately removed.",
+            file=sys.stderr,
+        )
+        return EXIT_VIOLATION
+
+    dirty = []
+    for manifest in manifests:
+        try:
+            code, output = runner(root, manifest)
+        except OSError as exc:
+            print(f"::error::could not run cargo fmt for {manifest}: {exc}", file=sys.stderr)
+            return EXIT_CANNOT_CHECK
+        if code == 0:
+            print(f"  ok   {manifest}", file=out)
+        else:
+            dirty.append((manifest, output))
+            print(f"  DIRTY {manifest} (exit {code})", file=out)
+
+    # The positive count, always, on every path. This line is the fix.
+    print(
+        f"{len(manifests)} workspace(s) checked, {len(manifests) - len(dirty)} formatted.",
+        file=out,
+    )
+
+    if dirty:
+        for manifest, output in dirty:
+            print(f"::error::{manifest} is not formatted — run: cargo fmt --manifest-path {manifest} --all", file=sys.stderr)
+            for line in output.splitlines()[:40]:
+                print(f"  | {line}", file=sys.stderr)
+        return EXIT_VIOLATION
+
+    return EXIT_OK
+
+
+# ── self-test ────────────────────────────────────────────────────────────
+# Every case is a real directory tree under a temp root. The runner is faked so
+# the table exercises discovery and reporting without needing a toolchain; the
+# real cargo invocation is one subprocess.run and is not what broke.
+
+def _tree(root, spec):
+    """spec: {relative_dir: manifest_text}. Creates Cargo.toml files."""
+    for rel, text in spec.items():
+        d = os.path.join(root, rel) if rel else root
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "Cargo.toml"), "w", encoding="utf-8") as fh:
+            fh.write(text)
+
+
+WS = '[workspace]\nmembers = ["a"]\n'
+MEMBER = '[package]\nname = "a"\n'
+INHERIT = '[workspace.package]\nversion = "0.1.0"\n\n[package]\nname = "a"\n'
+
+FOUR = {"": WS, "fuzz": WS, "codegen-exec-oracle": WS, "codegen-kiln-oracle": WS}
+
+CASES = [
+    (
+        "the repo's four workspaces are all discovered",
+        FOUR,
+        lambda r, m: (0, ""),
+        4,
+        EXIT_OK,
+        ["4 workspace(s) checked, 4 formatted"],
+        [],
+        "discovery finds nested [workspace] tables, not just the root",
+    ),
+    (
+        "REGRESSION #383: a dirty NON-ROOT workspace fails the gate",
+        FOUR,
+        lambda r, m: (1, "Diff in x.rs") if m.startswith("fuzz") else (0, ""),
+        4,
+        EXIT_VIOLATION,
+        ["DIRTY fuzz/Cargo.toml", "4 workspace(s) checked, 3 formatted"],
+        [],
+        "the exact live bug: root clean, fuzz/ dirty, old gate said 0",
+    ),
+    (
+        "a dirty ROOT workspace still fails (no regression the other way)",
+        FOUR,
+        lambda r, m: (1, "Diff in y.rs") if m == "Cargo.toml" else (0, ""),
+        4,
+        EXIT_VIOLATION,
+        ["DIRTY Cargo.toml"],
+        [],
+        "widening scope did not lose the coverage that already worked",
+    ),
+    (
+        "PRUNE: vendored [workspace] under target/ is not discovered",
+        {**FOUR, "target/package/somecrate-1.0": WS},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_OK,
+        ["4 workspace(s) checked"],
+        ["target/"],
+        "a built machine does not format other people's cached sources",
+    ),
+    (
+        "PRUNE: nested crate's own target/ is skipped too",
+        {**FOUR, "fuzz/target/debug/build/dep-abc": WS},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_OK,
+        ["4 workspace(s) checked"],
+        ["fuzz/target/"],
+        "the walk prunes by directory name at every depth, not just the top",
+    ),
+    (
+        "[workspace.package] is NOT a workspace root",
+        {**FOUR, "crates/spar-hir": INHERIT},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_OK,
+        ["4 workspace(s) checked"],
+        ["crates/spar-hir"],
+        "inheriting members must not inflate the count past the floor",
+    ),
+    (
+        "a member crate with no [workspace] is not counted",
+        {**FOUR, "crates/spar-parser": MEMBER},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_OK,
+        ["4 workspace(s) checked"],
+        ["spar-parser"],
+        "the 23 root members are formatted BY the root, not counted separately",
+    ),
+    (
+        "a workspace going missing trips the floor",
+        {"": WS, "fuzz": WS, "codegen-exec-oracle": WS},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_VIOLATION,
+        [],
+        [],
+        "silently checking fewer workspaces than yesterday is #383 returning",
+    ),
+    (
+        "discovery finding nothing is CANNOT_CHECK, not a pass",
+        {"crates/spar-parser": MEMBER},
+        lambda r, m: (0, ""),
+        4,
+        EXIT_CANNOT_CHECK,
+        [],
+        [],
+        "an empty scan must not render as 'everything is formatted'",
+    ),
+    (
+        "cargo absent is CANNOT_CHECK, not a pass",
+        FOUR,
+        lambda r, m: (_ for _ in ()).throw(OSError("No such file or directory: 'cargo'")),
+        4,
+        EXIT_CANNOT_CHECK,
+        [],
+        [],
+        "the #381 lesson: a tool that never ran scores neither 0 nor green",
+    ),
+]
+
+
+def self_test():
+    failures = 0
+    print("check_fmt_workspaces self-test")
+    for name, spec, runner, floor, want_exit, want_in, want_not_in, proves in CASES:
+        with tempfile.TemporaryDirectory() as root:
+            _tree(root, spec)
+            buf, real = io.StringIO(), sys.stderr
+            sys.stderr = buf
+            try:
+                got = check(root, min_workspaces=floor, runner=runner, out=buf)
+            except Exception as exc:  # a crash is a failed case, not a crashed run
+                sys.stderr = real
+                print(f"  FAIL {name}: raised {exc!r}")
+                failures += 1
+                continue
+            finally:
+                sys.stderr = real
+            text = buf.getvalue()
+
+        ok = got == want_exit
+        for needle in want_in:
+            if needle not in text:
+                ok = False
+        for needle in want_not_in:
+            if needle in text:
+                ok = False
+        failures += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}: exit {got} (want {want_exit})")
+        print(f"       proves: {proves}")
+        if not ok:
+            for line in text.splitlines():
+                print(f"       | {line.replace('::error::', '')}")
+
+    print()
+    if failures:
+        print(f"{failures} self-test(s) FAILED.", file=sys.stderr)
+        return EXIT_VIOLATION
+    print(f"{len(CASES)} self-test(s) passed.")
+    return EXIT_OK
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", default=".", help="repository root (default: .)")
+    ap.add_argument(
+        "--min-workspaces",
+        type=int,
+        default=MIN_WORKSPACES,
+        help=f"fail if discovery finds fewer than this many (default: {MIN_WORKSPACES})",
+    )
+    ap.add_argument("--self-test", action="store_true", help="run the decision table and exit")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    return check(args.root, min_workspaces=args.min_workspaces)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_msrv.py
+++ b/tools/check_msrv.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Gate the declared MSRV against the resolved dependency closure (#369).
+
+THE FAILURE
+-----------
+spar has a minimum supported Rust version whether or not anyone writes it
+down, because cargo enforces one: a build fails if the toolchain is below the
+maximum `rust-version` over the entire *resolved dependency closure*. Before
+this gate, `[workspace.package]` declared no `rust-version` and there was no
+`rust-toolchain.toml`, so the real floor was
+
+    max(rust-version) over every package in Cargo.lock
+
+— an emergent property of the lockfile. It moves on any `cargo update` with no
+diff anywhere in this repo, and it was discovered at build time by whichever
+consumer happened to have the oldest toolchain.
+
+WHY IT IS WORTH A GATE RATHER THAN A DECLARATION
+------------------------------------------------
+It already caused a defect. In #364 the tools/fixture-vm nixpkgs pin was moved
+24.05 -> 25.05 and recorded as "cannot compile -> can compile". The reasoning
+was: edition 2024 needs rustc >= 1.85, 25.05 ships 1.86.0, 1.86 >= 1.85, done.
+Every step of that is true. The conclusion was still wrong:
+
+    error: rustc 1.86.0 is not supported by the following package:
+      smol_str@0.3.6 requires rustc 1.89
+
+The edition floor is a *necessary* condition that got mistaken for *the*
+condition. The failure mode worth naming, because it is not "forgot to check":
+the probe genuinely ran and genuinely returned true. A one-variable check that
+comes back green is the most convincing way to not verify something — it
+produces the feeling of verification while silently scoping the claim to the
+one variable you happened to think of.
+
+A bare `rust-version = "..."` line does not fix that. A declaration is just
+another number that can go stale against the closure. So the declaration is the
+subject of this check, not the answer to it.
+
+WHAT IT CHECKS
+--------------
+1. Every workspace member has an effective `rust-version`.  A new crate that
+   forgets `rust-version.workspace = true` is silently exempt from the floor,
+   and would publish to crates.io claiming to build on toolchains it cannot.
+2. All members agree.  A per-crate override that diverges from the workspace
+   makes "the MSRV" ambiguous.
+3. **The closure maximum does not exceed the declared floor.**  This is the
+   drift gate: the `cargo update` that raises the real floor goes red on the PR
+   that introduces it, naming the package responsible, instead of surfacing two
+   months later inside a nix derivation.
+
+WHY IT READS `cargo metadata` RATHER THAN PARSING Cargo.toml
+------------------------------------------------------------
+`rust-version.workspace = true` means the value a member actually carries is
+computed by cargo, not written in its manifest. Re-parsing TOML would check
+what the files say; `cargo metadata` reports what cargo resolved, which is what
+is actually enforced. It also makes guard 1 fall out for free — a member that
+failed to inherit simply has no `rust_version` in the metadata.
+
+`--locked` is deliberate: the check must describe the committed lockfile, not
+whatever a resolver would pick today.
+
+THE DELIBERATE ASYMMETRY
+------------------------
+declared < closure  -> FAIL.  Consumers on the declared floor cannot build.
+declared > closure  -> report, do not fail.  An inflated floor excludes
+consumers unnecessarily, but it can also be a legitimate choice: spar's own
+source may use a feature newer than anything its dependencies require, and
+nothing here can tell those two cases apart. Failing would block the
+legitimate one. It is printed so it stays visible rather than silently drifting.
+
+WHAT THIS DOES NOT CLAIM
+------------------------
+- It does NOT verify that spar's own source compiles on the declared floor.
+  That needs a CI job pinned to that toolchain, which this is not. The claim
+  here is narrower and exact: the declared floor is not below what the
+  dependency closure demands.
+- It does not check the nix channel's rustc. That comparison lives in the
+  fixture-vm workflow, where a nix evaluation is already paid for, and is what
+  turns a 14-minute build failure into a several-second one.
+
+Stdlib only, matching the constraint documented above the human-scoped
+guardrail in ci.yml: no workflow here installs a Python package, so importing
+one would make a *required* check depend on an unverified runner package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_CANNOT_CHECK = 2
+
+
+def parse_version(text):
+    """`1.89` -> (1, 89, 0). Zero-padded so `1.89` and `1.89.0` compare equal.
+
+    Numeric, never lexicographic. The trap this avoids is real: as strings,
+    "1.100" < "1.99", so a naive comparison would pass a closure floor that is
+    actually higher than the declared one. `sort -V` gets this right but is a
+    GNU extension; this does not depend on which sort is installed.
+    """
+    parts = text.strip().split(".")
+    out = []
+    for p in parts[:3]:
+        digits = ""
+        for ch in p:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            raise ValueError(f"not a version: {text!r}")
+        out.append(int(digits))
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out)
+
+
+def load_metadata():
+    """Run `cargo metadata`, or exit 2. A gate that cannot run is not a pass."""
+    try:
+        proc = subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--locked"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("::error::cargo not found; cannot derive the closure MSRV.", file=sys.stderr)
+        sys.exit(EXIT_CANNOT_CHECK)
+    if proc.returncode != 0:
+        print("::error::`cargo metadata --locked` failed. If this is a lockfile", file=sys.stderr)
+        print("::error::mismatch, commit the updated Cargo.lock.", file=sys.stderr)
+        sys.stderr.write(proc.stderr[-2000:])
+        sys.exit(EXIT_CANNOT_CHECK)
+    return json.loads(proc.stdout)
+
+
+def analyse(meta):
+    """Split the resolved graph into workspace members and everything else.
+
+    Returns (members, closure) as lists of (name, version, rust_version|None).
+    """
+    member_ids = set(meta.get("workspace_members", []))
+    members, closure = [], []
+    for p in meta.get("packages", []):
+        row = (p.get("name"), p.get("version"), p.get("rust_version"))
+        (members if p.get("id") in member_ids else closure).append(row)
+    return members, closure
+
+
+def run_check(meta, verbose=True):
+    members, closure = analyse(meta)
+    problems = []
+
+    if not members:
+        print("::error::no workspace members in cargo metadata — refusing to", file=sys.stderr)
+        print("::error::report a floor derived from nothing.", file=sys.stderr)
+        return EXIT_CANNOT_CHECK
+
+    # Guard 1: a member with no effective rust-version is exempt from the floor.
+    missing = [f"{n}@{v}" for n, v, rv in members if not rv]
+    if missing:
+        problems.append(
+            "::error::%d workspace member(s) declare no rust-version:\n%s\n"
+            "::error::Add `rust-version.workspace = true` to each, next to\n"
+            "::error::`edition.workspace = true`. Without it the crate publishes\n"
+            "::error::claiming to build on toolchains the workspace does not support."
+            % (len(missing), "\n".join("::error::  " + m for m in missing))
+        )
+
+    # Guard 2: members must agree, or "the MSRV" has no referent.
+    declared_set = {rv for _, _, rv in members if rv}
+    if len(declared_set) > 1:
+        problems.append(
+            "::error::workspace members declare conflicting rust-versions: %s\n"
+            "::error::Set it once in [workspace.package] and inherit it."
+            % ", ".join(sorted(declared_set))
+        )
+
+    if problems:
+        for p in problems:
+            print(p, file=sys.stderr)
+        return EXIT_VIOLATION
+
+    declared_text = next(iter(declared_set))
+    declared = parse_version(declared_text)
+
+    # Guard 3: the drift gate.
+    rated = [(parse_version(rv), n, v, rv) for n, v, rv in closure if rv]
+    if not rated:
+        print("::error::no dependency in the closure declares a rust-version.", file=sys.stderr)
+        print("::error::That is implausible for this lockfile — refusing to pass", file=sys.stderr)
+        print("::error::on a comparison against an empty set.", file=sys.stderr)
+        return EXIT_CANNOT_CHECK
+
+    top = max(rated)
+    closure_max, top_name, top_ver, top_text = top
+    raisers = sorted({f"{n}@{v}" for pv, n, v, _ in rated if pv == closure_max})
+
+    if verbose:
+        print(
+            f"declared floor : {declared_text}  ([workspace.package] rust-version, "
+            f"inherited by {len(members)} member(s))"
+        )
+        print(
+            f"closure maximum: {top_text}  (set by {', '.join(raisers)}; "
+            f"{len(rated)} of {len(closure)} dependencies declare one)"
+        )
+
+    if closure_max > declared:
+        print(
+            "::error::the dependency closure requires rustc %s, but "
+            "[workspace.package] rust-version declares %s." % (top_text, declared_text),
+            file=sys.stderr,
+        )
+        for r in raisers:
+            print(f"::error::  raised by: {r}", file=sys.stderr)
+        print(
+            "::error::Anything built against the declared floor will fail with\n"
+            "::error::`rustc %s is not supported by the following package`.\n"
+            "::error::Either raise rust-version to %s, or pin the dependency back."
+            % (declared_text, top_text),
+            file=sys.stderr,
+        )
+        return EXIT_VIOLATION
+
+    if closure_max < declared and verbose:
+        print(
+            f"note: the declared floor is above the closure maximum "
+            f"({declared_text} > {top_text}). Not an error — spar's own source may "
+            f"need it — but nothing here verifies that, so it is reported rather "
+            f"than assumed."
+        )
+
+    if verbose:
+        print(f"PASS: declared floor {declared_text} covers the closure.")
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Self-tests. Fixtures are cargo-metadata-shaped dicts, so they run without a
+# toolchain and without a lockfile. Each records the failure it proves is still
+# caught; a test whose `proves` string does not name a real failure is a test
+# that will survive the deletion of the logic it claims to cover.
+# ---------------------------------------------------------------------------
+
+
+def _meta(members, deps):
+    """members/deps: list of (name, version, rust_version|None)."""
+    pkgs, ids = [], []
+    for i, (n, v, rv) in enumerate(members):
+        pid = f"member {i}"
+        ids.append(pid)
+        pkgs.append({"id": pid, "name": n, "version": v, "rust_version": rv})
+    for i, (n, v, rv) in enumerate(deps):
+        pkgs.append({"id": f"dep {i}", "name": n, "version": v, "rust_version": rv})
+    return {"workspace_members": ids, "packages": pkgs}
+
+
+SELF_TESTS = [
+    (
+        "clean: declared equals closure max",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_OK,
+        "the checker can return 0 at all — without this the rest is consistent "
+        "with a script that always fails",
+    ),
+    (
+        "closure above declared (the #364 defect shape)",
+        _meta([("spar-cli", "0.35.0", "1.86")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_VIOLATION,
+        "the exact drift that broke the fixture-vm build: a dependency demands "
+        "more than the declared floor",
+    ),
+    (
+        "member missing rust-version",
+        _meta(
+            [("spar-cli", "0.35.0", "1.89"), ("spar-new", "0.35.0", None)],
+            [("smol_str", "0.3.6", "1.89")],
+        ),
+        EXIT_VIOLATION,
+        "a new crate that forgets `rust-version.workspace = true` is exempt from "
+        "the floor and would publish a claim it cannot honour",
+    ),
+    (
+        "members disagree",
+        _meta(
+            [("spar-cli", "0.35.0", "1.89"), ("spar-core", "0.35.0", "1.85")],
+            [("smol_str", "0.3.6", "1.85")],
+        ),
+        EXIT_VIOLATION,
+        "with two different floors declared, 'the MSRV' has no referent and the "
+        "comparison in guard 3 would be against an arbitrary one of them",
+    ),
+    (
+        "declared above closure max is allowed",
+        _meta([("spar-cli", "0.35.0", "1.90")], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_OK,
+        "the asymmetry is deliberate: spar's own source may need more than its "
+        "dependencies, and failing here would block that legitimate case",
+    ),
+    (
+        "1.89 vs 1.89.0 are the same floor",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("dep", "1.0.0", "1.89.0")]),
+        EXIT_OK,
+        "crates.io mixes both spellings (this lockfile has '1.89' and '1.87.0'); "
+        "treating them as different would red the build over formatting",
+    ),
+    (
+        "1.100 is above 1.99, not below it",
+        _meta([("spar-cli", "0.35.0", "1.99")], [("dep", "1.0.0", "1.100")]),
+        EXIT_VIOLATION,
+        "as strings '1.100' < '1.99', so a lexicographic compare passes a floor "
+        "that is actually too low — the comparison must be numeric",
+    ),
+    (
+        "no dependency declares a rust-version",
+        _meta([("spar-cli", "0.35.0", "1.89")], [("dep", "1.0.0", None)]),
+        EXIT_CANNOT_CHECK,
+        "an empty closure means the metadata was not what we think it is; "
+        "passing on a comparison against nothing reads as coverage",
+    ),
+    (
+        "no workspace members",
+        _meta([], [("smol_str", "0.3.6", "1.89")]),
+        EXIT_CANNOT_CHECK,
+        "same fail-closed rule at the other end: no members means no declared "
+        "floor to compare against",
+    ),
+]
+
+
+def self_test():
+    failures = 0
+    for name, meta, want, proves in SELF_TESTS:
+        # Capture the fixtures' stderr rather than letting it through. Six of
+        # these cases are *supposed* to fail, and their messages are
+        # `::error::` lines — which are GitHub Actions workflow commands, not
+        # plain text. Emitted from a passing self-test they would stamp eight
+        # red annotations onto the PR's diff view while the step exits 0. That
+        # is the same defect this whole gate exists to prevent: output that
+        # renders as a claim it does not support. The captured text is printed
+        # only when a case actually fails, where it is the debugging evidence.
+        buf, real = io.StringIO(), sys.stderr
+        sys.stderr = buf
+        try:
+            got = run_check(meta, verbose=False)
+        finally:
+            sys.stderr = real
+        ok = got == want
+        failures += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}: exit {got} (want {want})")
+        print(f"       proves: {proves}")
+        if not ok:
+            for line in buf.getvalue().splitlines():
+                print(f"       | {line.replace('::error::', '')}")
+    print()
+    if failures:
+        print(f"{failures} self-test(s) FAILED.", file=sys.stderr)
+        return EXIT_VIOLATION
+    print(f"{len(SELF_TESTS)} self-test(s) passed.")
+    return EXIT_OK
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the inline fixtures; no cargo or lockfile needed",
+    )
+    ap.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="print the derived floors and exit 0 regardless of the verdict",
+    )
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
+    meta = load_metadata()
+    rc = run_check(meta)
+    sys.exit(EXIT_OK if args.print_only else rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_mutants_report.py
+++ b/tools/check_mutants_report.py
@@ -57,12 +57,39 @@ entry:
         ├── missed.txt      210 lines
         ├── unviable.txt    793 lines
         ├── timeout.txt       2 lines
-        ├── outcomes.json   total_mutants 1608, missed 210, caught 603
+        ├── outcomes.json   total_mutants 1608, missed 210, caught 603,
+        │                   end_time null          <-- SEE BELOW
         ├── mutants.json
         ├── debug.log
         ├── lock.json
         ├── diff/
         └── log/
+
+The *shape* above is authoritative; its *numbers* are not, and the reason is
+the next defect in this same gate. That run did not finish. cargo-mutants had
+found 1737 mutants; 3h02m in, the per-worker temp trees it copies the source
+into were deleted underneath it —
+
+    ERROR Worker thread failed: ".../cargo-mutants-spar-2xA4rk.tmp/crates/
+    spar-analysis/src/weight_power.rs" does not exist, refusing to create it
+
+— four workers at once, on runner1, consistent with the runner's disk-pressure
+cleanup hook reaping `_tmp` during a live job. `|| true` swallowed the exit.
+So 1608 is how many mutants got tested, not how many exist, and 210 is the
+survivor count of the 92% that ran.
+
+That matters beyond bookkeeping: **a truncated run under-reports survivors**,
+so it fails safe in appearance and unsafe in fact — fewer survivors is a
+better score. The cross-check in `_cross_check` cannot see it either, because
+cargo-mutants writes `total_mutants` incrementally: 210+603+793+2 == 1608
+agrees with itself perfectly. The discriminator is `end_time`, which is null
+on the crashed run and populated on the completed one (30586785648: 1737
+tested, 292 missed).
+
+This script does NOT yet reject a truncated run — arming that against a job
+that demonstrably crashes on one runner would make a required context flap on
+infrastructure. The detector plus the runner fix are #389. Until then, treat
+any survivor count from a run without an `end_time` as a lower bound.
 
 Run `--self-test` to exercise the whole decision table against constructed
 fixtures, including a regression case that reproduces the original bug: a tree
@@ -332,7 +359,7 @@ def self_test() -> int:
 
     passed = failed = 0
 
-    def case(desc: str, want: int, build, max_missed: int = 210):
+    def case(desc: str, want: int, build, max_missed: int = 292):
         nonlocal passed, failed
         with tempfile.TemporaryDirectory() as tmp:
             out_dir = build(tmp)
@@ -363,9 +390,9 @@ def self_test() -> int:
     case("valid report, 0 survivors", 0,
          lambda t: _fixture(t, missed=0, caught=100))
     case("survivors exactly at the threshold", 0,
-         lambda t: _fixture(t, missed=210, caught=603))
+         lambda t: _fixture(t, missed=292, caught=708))
     case("survivors one over the threshold", 1,
-         lambda t: _fixture(t, missed=211, caught=603))
+         lambda t: _fixture(t, missed=293, caught=708))
 
     # Absence that scores as perfection.
     case("report present but 0 caught (suite never ran)", 1,

--- a/tools/check_mutants_report.py
+++ b/tools/check_mutants_report.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Gate a cargo-mutants run on its surviving-mutant count — and, first, on the
+run having actually happened.
+
+WHY THIS IS A SCRIPT AND NOT FOUR LINES OF SHELL
+================================================
+
+It was four lines of shell, and it was vacuous for four months (#381).
+
+`.github/workflows/ci.yml` ran `cargo mutants --output mutants-out` and then
+read `mutants-out/missed.txt`. But `--output DIR` names the directory in which
+to CREATE `mutants.out` — the report is at `mutants-out/mutants.out/`. The path
+the gate read has never existed. `grep` failed into `|| echo 0`, an `[ -f ]`
+test was false, `0 -gt 142` was false, exit 0. `Mutation Testing` is a required
+status check that runs for roughly three hours; run 30563879100 uploaded 210
+surviving mutants against a threshold of 142 and printed
+`Surviving mutants: 0`.
+
+What made it invisible is worth stating, because it is the property to design
+against: **the error path produced the ideal reading.** `|| true`, `2>/dev/null`
+and `|| echo 0` are each defensible in isolation; together they turn "the file
+is not there" into `0`, and `0` is the best possible score for this metric. No
+one reading the log approvingly could have noticed.
+
+Three consequences shape this file:
+
+1. **Absence fails.** Every path this script reads is required to exist, and a
+   missing one exits non-zero with a message naming the path. The cargo-mutants
+   invocation ends in `|| true` (it exits non-zero whenever ANY mutant survives,
+   and the ratchet tolerates a bounded number), so the run step cannot report
+   failure — which means this step must prove the run happened rather than infer
+   it from a quiet directory.
+
+2. **The nesting lives in exactly one place.** Callers pass `--output-dir`, the
+   same value handed to `cargo mutants --output`, and `_REPORT_SUBDIR` below
+   applies the nesting. Nobody has to remember it twice, which is how it came to
+   be remembered wrongly once.
+
+3. **The counts are cross-checked against cargo-mutants' own JSON.** This is the
+   detector that would have caught the original bug on day one and did not
+   exist. `outcomes.json` records `missed`/`caught` independently of the `.txt`
+   files; if the two disagree, our reading of the report is wrong and the run is
+   rejected rather than scored. A gate that prints a number should compare that
+   number against an independent measurement of the same number — the tell in
+   #381 sat in the repo for four months as exactly such a pair (a commit message
+   saying "Current survivors: 142" next to CI logs saying 0) and was never
+   diffed.
+
+The report layout is not guessed. It is transcribed from the `mutants-report`
+artifact of run 30563879100, uploaded with `path: mutants-out/` — so the
+artifact root is a listing of that directory, and its root contains exactly one
+entry:
+
+    mutants-out/
+    └── mutants.out/
+        ├── caught.txt      603 lines
+        ├── missed.txt      210 lines
+        ├── unviable.txt    793 lines
+        ├── timeout.txt       2 lines
+        ├── outcomes.json   total_mutants 1608, missed 210, caught 603
+        ├── mutants.json
+        ├── debug.log
+        ├── lock.json
+        ├── diff/
+        └── log/
+
+Run `--self-test` to exercise the whole decision table against constructed
+fixtures, including a regression case that reproduces the original bug: a tree
+where the `.txt` files exist ONLY at the shallow path must be rejected, not
+scored as zero survivors.
+
+stdlib-only, deliberately: no workflow in this repo installs a Python package,
+and a required check that depends on an unverified runner package is a check
+that can fail to run — which reads as approval. See REQ-GUARD-HUMAN-SCOPED-001
+for the same constraint stated as a requirement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+# cargo-mutants creates `mutants.out` INSIDE the directory given to `--output`.
+# This is the single fact whose duplication caused #381; it is stated here once.
+_REPORT_SUBDIR = "mutants.out"
+
+# The four per-outcome files cargo-mutants writes. `missed` and `caught` are
+# load-bearing for the verdict; the other two are reported for context only.
+_REQUIRED_FILES = ("missed.txt", "caught.txt")
+_CONTEXT_FILES = ("unviable.txt", "timeout.txt")
+
+
+def report_dir(output_dir: str) -> str:
+    """The directory cargo-mutants actually writes, given a `--output` value."""
+    return os.path.join(output_dir, _REPORT_SUBDIR)
+
+
+def _count_lines(path: str) -> int:
+    """Number of mutants listed in a cargo-mutants outcome file.
+
+    Counts non-blank lines rather than newlines, so a report whose final line
+    lacks a trailing newline is not silently undercounted by one. For the real
+    artifact both agree exactly (210/603/793/2), and any disagreement with
+    `outcomes.json` is caught by the cross-check below.
+    """
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        return sum(1 for line in fh if line.strip())
+
+
+class GateFailure(Exception):
+    """A condition under which the run must not be scored."""
+
+
+def _load_counts(rdir: str) -> dict[str, int]:
+    """Read the outcome counts, refusing anything that is not a complete run."""
+    if not os.path.isdir(rdir):
+        raise GateFailure(
+            f"no cargo-mutants report directory at {rdir} — the run did not "
+            f"complete. This is not zero survivors; it is no measurement. "
+            f"(cargo-mutants writes {_REPORT_SUBDIR!r} inside the --output "
+            f"directory; check that --output-dir here matches --output there.)"
+        )
+
+    counts = {}
+    for name in _REQUIRED_FILES:
+        path = os.path.join(rdir, name)
+        if not os.path.isfile(path):
+            raise GateFailure(
+                f"{path} is missing — the report is incomplete, so the run "
+                f"cannot be scored."
+            )
+        counts[name[: -len(".txt")]] = _count_lines(path)
+
+    for name in _CONTEXT_FILES:
+        path = os.path.join(rdir, name)
+        counts[name[: -len(".txt")]] = _count_lines(path) if os.path.isfile(path) else 0
+
+    return counts
+
+
+def _cross_check(rdir: str, counts: dict[str, int]) -> str:
+    """Diff our line counts against cargo-mutants' own JSON tally.
+
+    Returns a human-readable note. Raises GateFailure on disagreement: if the
+    two independent readings of the same quantity differ, we do not know which
+    is right, and scoring on the wrong one is precisely #381.
+    """
+    path = os.path.join(rdir, "outcomes.json")
+    if not os.path.isfile(path):
+        # Not fatal: older cargo-mutants releases may not write it. Say so out
+        # loud rather than passing silently, because losing this cross-check is
+        # losing the detector that catches a misread report.
+        return f"outcomes.json absent at {path} — counts NOT cross-checked"
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, ValueError) as exc:
+        raise GateFailure(f"{path} is present but unreadable ({exc}) — refusing to score a report we cannot verify")
+
+    mismatches = []
+    for key in ("missed", "caught"):
+        recorded = doc.get(key)
+        if recorded is None:
+            continue
+        if recorded != counts[key]:
+            mismatches.append(f"{key}: {counts[key]} line(s) in {key}.txt vs {recorded} in outcomes.json")
+
+    if mismatches:
+        raise GateFailure(
+            "the report disagrees with itself, so it is being misread: "
+            + "; ".join(mismatches)
+            + ". Do not adjust the threshold to match — find out which reading is wrong."
+        )
+
+    return "counts agree with outcomes.json"
+
+
+def check(output_dir: str, max_missed: int, out=None) -> int:
+    """Return 0 if the run happened and stayed within the ratchet, else 1."""
+    out = out or sys.stdout
+    rdir = report_dir(output_dir)
+
+    try:
+        counts = _load_counts(rdir)
+        note = _cross_check(rdir, counts)
+    except GateFailure as exc:
+        print(f"::error::{exc}", file=out)
+        if os.path.isdir(output_dir):
+            print(f"Tree under {output_dir}/:", file=out)
+            for root, dirs, files in os.walk(output_dir):
+                depth = root[len(output_dir) :].count(os.sep)
+                if depth > 1:
+                    dirs[:] = []
+                    continue
+                for name in sorted(files)[:12]:
+                    print(f"  {os.path.join(root, name)}", file=out)
+        else:
+            print(f"{output_dir}/ does not exist at all.", file=out)
+        return 1
+
+    missed, caught = counts["missed"], counts["caught"]
+    print(
+        f"Surviving mutants: {missed}  "
+        f"(caught {caught}, unviable {counts['unviable']}, timeout {counts['timeout']}; {note})",
+        file=out,
+    )
+
+    # A report that exists but caught nothing means the test suite never ran —
+    # every mutant unviable, or the package/target filter matched nothing. That
+    # also scores zero survivors, the best possible value, so it has to be
+    # rejected explicitly or it sails straight through the ratchet below.
+    if caught == 0:
+        print(
+            "::error::0 mutants caught — the test suite did not run. A 0 here is "
+            "absence, not success.",
+            file=out,
+        )
+        return 1
+
+    if missed > max_missed:
+        print(
+            f"::error::{missed} mutant(s) survived (threshold: {max_missed}) — add tests to kill them",
+            file=out,
+        )
+        missed_path = os.path.join(rdir, "missed.txt")
+        with open(missed_path, "r", encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= 30:
+                    print("  … (see the mutants-report artifact for the rest)", file=out)
+                    break
+                print(f"  {line.rstrip()}", file=out)
+        return 1
+
+    print(f"Mutant survivors ({missed}) within threshold ({max_missed}). Target: 0 (#382).", file=out)
+    return 0
+
+
+def summarize(output_dir: str, shard: str, summary, out=None) -> int:
+    """Render the weekly quality report as markdown into `summary`.
+
+    Advisory — the weekly does not gate, so this always returns 0. The one
+    thing it must never do is render absence as a table of zeros. Reading the
+    shallow path made every weekly summary show `0 missed / 0 caught /
+    0 unviable / 0 timeout` (#381), which is not merely wrong but *impossible*:
+    zero caught AND zero unviable would mean cargo-mutants found nothing to
+    test at all. It still rendered as a plausible table, which is why it was
+    read for four months without anyone registering it as a fault. Absence now
+    prints as absence.
+
+    Shares `report_dir()` and `_load_counts()` with the gating path on purpose:
+    the fact that cargo-mutants nests its report under `mutants.out/` is the
+    fact that cost four months, and it lives in exactly one place.
+    """
+    out = out or sys.stdout
+    rdir = report_dir(output_dir)
+
+    try:
+        counts = _load_counts(rdir)
+        note = _cross_check(rdir, counts)
+    except GateFailure as exc:
+        print(f"> ⚠️ **No usable cargo-mutants report** — {exc}", file=summary)
+        print(">", file=summary)
+        print("> Counts are omitted rather than rendered as 0. A zero table here "
+              "would be absence wearing the costume of a clean result.", file=summary)
+        print(f"::warning::no usable cargo-mutants report under {rdir}", file=out)
+        return 0
+
+    print(f"## cargo-mutants weekly — {shard}", file=summary)
+    print("", file=summary)
+    print(f"Report: `{rdir}` ({note})", file=summary)
+    print("", file=summary)
+    print("| Outcome | Count |", file=summary)
+    print("|---------|------:|", file=summary)
+    print(f"| 🟥 Missed  (test suite did not catch) | {counts['missed']} |", file=summary)
+    print(f"| 🟩 Caught  (test suite caught)        | {counts['caught']} |", file=summary)
+    print(f"| ⏱  Timeout                           | {counts['timeout']} |", file=summary)
+    print(f"| ⚪ Unviable (build failed)           | {counts['unviable']} |", file=summary)
+    print("", file=summary)
+
+    if counts["caught"] == 0:
+        print("> ⚠️ **0 caught** — the test suite did not run against these mutants; "
+              "the missed count below is not a quality signal.", file=summary)
+        print("", file=summary)
+        print("::warning::0 mutants caught — the test suite did not run", file=out)
+
+    if counts["missed"] > 0:
+        print("<details><summary>First 50 missed mutants</summary>", file=summary)
+        print("", file=summary)
+        print("```", file=summary)
+        with open(os.path.join(rdir, "missed.txt"), "r", encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= 50:
+                    break
+                if line.strip():
+                    print(line.rstrip(), file=summary)
+        print("```", file=summary)
+        print("</details>", file=summary)
+
+    print(f"Summarised {counts['missed']} missed / {counts['caught']} caught "
+          f"/ {counts['unviable']} unviable / {counts['timeout']} timeout.", file=out)
+    return 0
+
+
+# ── self-test ───────────────────────────────────────────────────────────────
+
+
+def _fixture(root: str, *, nested: bool = True, missed: int = 10, caught: int = 100,
+             unviable: int = 5, timeout: int = 0, outcomes: dict | None = None) -> str:
+    """Build a mutants-out tree. `nested=False` reproduces the #381 misreading:
+    the outcome files placed where the old gate LOOKED rather than where
+    cargo-mutants writes them."""
+    out = os.path.join(root, "mutants-out")
+    target = os.path.join(out, _REPORT_SUBDIR) if nested else out
+    os.makedirs(target, exist_ok=True)
+    for name, n in (("missed.txt", missed), ("caught.txt", caught),
+                    ("unviable.txt", unviable), ("timeout.txt", timeout)):
+        with open(os.path.join(target, name), "w", encoding="utf-8") as fh:
+            for i in range(n):
+                fh.write(f"crates/spar-analysis/src/x.rs:{i}:1: replace f -> usize with 0\n")
+    if outcomes is not None:
+        with open(os.path.join(target, "outcomes.json"), "w", encoding="utf-8") as fh:
+            json.dump(outcomes, fh)
+    return out
+
+
+def self_test() -> int:
+    import io
+
+    passed = failed = 0
+
+    def case(desc: str, want: int, build, max_missed: int = 210):
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = build(tmp)
+            buf = io.StringIO()
+            got = check(out_dir, max_missed, out=buf)
+            if got == want:
+                passed += 1
+                print(f"  ok   {desc}")
+            else:
+                failed += 1
+                print(f"  FAIL {desc}: got exit {got}, want {want}")
+                for line in buf.getvalue().splitlines()[:4]:
+                    print(f"         {line}")
+
+    print("check_mutants_report self-test")
+
+    # The bug itself. Both of these greened for four months.
+    case("no mutants-out at all (crashed or OOM'd run)", 1,
+         lambda t: os.path.join(t, "mutants-out"))
+    case("mutants-out exists but is empty", 1,
+         lambda t: (os.makedirs(os.path.join(t, "mutants-out")), os.path.join(t, "mutants-out"))[1])
+    case("REGRESSION #381: outcome files ONLY at the shallow path", 1,
+         lambda t: _fixture(t, nested=False, missed=500, caught=100))
+
+    # Normal operation.
+    case("valid report, 10 survivors, under threshold", 0,
+         lambda t: _fixture(t, missed=10, caught=100))
+    case("valid report, 0 survivors", 0,
+         lambda t: _fixture(t, missed=0, caught=100))
+    case("survivors exactly at the threshold", 0,
+         lambda t: _fixture(t, missed=210, caught=603))
+    case("survivors one over the threshold", 1,
+         lambda t: _fixture(t, missed=211, caught=603))
+
+    # Absence that scores as perfection.
+    case("report present but 0 caught (suite never ran)", 1,
+         lambda t: _fixture(t, missed=0, caught=0))
+    case("0 caught AND 0 missed (the impossible all-zero report)", 1,
+         lambda t: _fixture(t, missed=0, caught=0, unviable=0))
+
+    # Incomplete reports.
+    case("missed.txt removed", 1,
+         lambda t: (_fixture(t), os.remove(os.path.join(t, "mutants-out", _REPORT_SUBDIR, "missed.txt")),
+                    os.path.join(t, "mutants-out"))[2])
+    case("caught.txt removed", 1,
+         lambda t: (_fixture(t), os.remove(os.path.join(t, "mutants-out", _REPORT_SUBDIR, "caught.txt")),
+                    os.path.join(t, "mutants-out"))[2])
+
+    # The cross-check — the detector that did not exist.
+    case("outcomes.json agrees with the .txt counts", 0,
+         lambda t: _fixture(t, missed=10, caught=100, outcomes={"missed": 10, "caught": 100}))
+    case("outcomes.json disagrees (report misread)", 1,
+         lambda t: _fixture(t, missed=10, caught=100, outcomes={"missed": 210, "caught": 100}))
+    case("outcomes.json unparseable", 1,
+         lambda t: (_fixture(t), open(os.path.join(t, "mutants-out", _REPORT_SUBDIR, "outcomes.json"),
+                                      "w").write("{not json"), os.path.join(t, "mutants-out"))[2])
+    case("outcomes.json absent — passes, but says so", 0,
+         lambda t: _fixture(t, missed=10, caught=100))
+
+    # ── the weekly summary path ──
+    # It never gates, so its only failure mode is rendering a believable table
+    # that says nothing happened. These assert on the RENDERED MARKDOWN, not on
+    # an exit code — for an advisory report the text is the entire product.
+    def scase(desc: str, build, want_in=(), want_not_in=()):
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = build(tmp)
+            summary, log = io.StringIO(), io.StringIO()
+            summarize(out_dir, "shard 0/8", summary, out=log)
+            rendered = summary.getvalue()
+            bad = [s for s in want_in if s not in rendered]
+            bad += [f"UNWANTED {s!r}" for s in want_not_in if s in rendered]
+            if not bad:
+                passed += 1
+                print(f"  ok   {desc}")
+            else:
+                failed += 1
+                print(f"  FAIL {desc}: {bad}")
+
+    scase("weekly: no report — says absent, renders NO table",
+          lambda t: os.path.join(t, "mutants-out"),
+          want_in=("No usable cargo-mutants report",),
+          want_not_in=("| Outcome | Count |", "| 0 |"))
+    scase("weekly REGRESSION #381: shallow path must not render 0/0/0/0",
+          lambda t: _fixture(t, nested=False, missed=210, caught=603),
+          want_in=("No usable cargo-mutants report",),
+          want_not_in=("| Outcome | Count |",))
+    scase("weekly: real counts reach the table",
+          lambda t: _fixture(t, missed=210, caught=603, unviable=793, timeout=2),
+          want_in=("| 210 |", "| 603 |", "| 793 |", "| 2 |", "First 50 missed mutants"))
+    scase("weekly: 0 caught is flagged, not tabulated silently",
+          lambda t: _fixture(t, missed=0, caught=0, unviable=0),
+          want_in=("**0 caught**",))
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--output-dir",
+        default="mutants-out",
+        help="the value passed to `cargo mutants --output`; the report is read "
+             f"from <output-dir>/{_REPORT_SUBDIR}/",
+    )
+    ap.add_argument(
+        "--max-missed",
+        type=int,
+        default=None,
+        help="ratchet threshold — fail if more mutants survive than this. Lower it as tests improve; see #382.",
+    )
+    ap.add_argument("--self-test", action="store_true", help="run the built-in decision table")
+    ap.add_argument(
+        "--summary-file",
+        default=None,
+        help="render the advisory weekly markdown report to this file (append) "
+             "instead of gating — e.g. $GITHUB_STEP_SUMMARY. Never fails the job.",
+    )
+    ap.add_argument("--shard", default="", help="shard label for the summary heading")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    # Summary mode is advisory and deliberately separate from the gate: the
+    # weekly runs the whole workspace with no ratchet, so it has no threshold
+    # to check against. Annotations go to stdout, markdown to the file, so the
+    # ::warning:: still reaches the job log when stdout is not the summary.
+    if args.summary_file:
+        with open(args.summary_file, "a", encoding="utf-8") as fh:
+            return summarize(args.output_dir, args.shard, fh)
+
+    if args.max_missed is None:
+        ap.error("--max-missed is required (or use --self-test / --summary-file)")
+    return check(args.output_dir, args.max_missed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_required_contexts.py
+++ b/tools/check_required_contexts.py
@@ -8,7 +8,18 @@ reconciles the two. Three ways they drift, each failing differently:
 
   1. A job is added to a PR-triggered workflow and nobody adds it to the
      required set. It runs, it goes red, and the PR merges anyway. The gate
-     looks full; it is one job short. (`osate-corpus` is in this state today.)
+     looks full; it is one job short.
+
+     `osate-corpus` has this symptom today — and this gate deliberately does
+     NOT fix it, which is worth stating rather than letting the reader assume
+     otherwise. `aadl-interop.yml` carries a workflow-level
+     `on.pull_request.paths:` filter, so the classifier buckets it
+     UNDELIVERABLE and rules that it must *not* be required (see 3 — requiring
+     it would deadlock every PR outside those paths). The gate reports PASS
+     with the symptom open. The remedy is a change to that workflow — always
+     run, filter with a job-level `if:` — after which this gate will demand
+     the context be required. Until someone makes it, `osate-corpus` is a job
+     that can go red while the PR merges, and nothing here flags it.
 
   2. A job carries `continue-on-error: true`. It reports SUCCESS whatever
      happened — pass, fail, or never really ran. Requiring it enforces nothing,
@@ -63,6 +74,27 @@ validates it against PyYAML on the real workflow corpus wherever PyYAML happens
 to be available, which is how the restriction is kept honest rather than
 assumed.
 
+That leaves a gap worth naming, because it is the one an audit found: in CI —
+the only place this gate is load-bearing — `--cross-check` does NOT run, for the
+same PyYAML reason. So the safety of the reader in CI cannot rest on agreeing
+with a reference parser; it has to rest on the reader refusing what it cannot
+represent. Four constructs previously read wrong and silently, and two of them
+*flipped a verdict* rather than merely losing information:
+
+  * `pull_request: {branches: [main], paths: [...]}` (flow mapping) — read as an
+    opaque string, so `paths` disappeared, the job was ruled GATEABLE, and the
+    gate ordered you to require a context that would never be delivered. The
+    gate handing you the exact deadlock it exists to prevent.
+  * a file indented with four spaces — every job invisible, zero jobs, zero
+    violations, PASS. Fail-OPEN, which the paragraph above claims cannot happen.
+  * a folded/literal block scalar as a job `name:` — the context name read as
+    `>-`.
+  * YAML anchors and aliases in a name.
+
+All four now raise (`_reject_unsupported` plus the empty-`jobs:` check) and each
+has a fixture. `--cross-check` remains the belt for local work; the refusals are
+the braces that actually ship.
+
 Usage:
   tools/check_required_contexts.py                 # reconcile workflows <-> committed list
   tools/check_required_contexts.py --self-test     # fixture cases; run this FIRST in CI
@@ -84,7 +116,11 @@ import re
 import subprocess
 import sys
 
-WORKFLOW_GLOB = ".github/workflows/*.yml"
+#: `*.y*ml`, not `*.yml`. GitHub Actions loads BOTH extensions from
+#: .github/workflows/, so a `sneaky.yaml` holding a gateable job is invisible to
+#: a `*.yml` glob — the gate reports PASS on a repo it never fully read. That is
+#: failure mode 1 with the gate's own blind spot supplying the silence.
+WORKFLOW_GLOB = ".github/workflows/*.y*ml"
 LIST_PATH = ".github/required-contexts.txt"
 PROTECTED_BRANCH = "main"
 
@@ -130,6 +166,41 @@ def _strip_comment(line: str) -> str:
     return "".join(out).rstrip()
 
 
+#: YAML constructs this reader cannot represent, at positions where misreading
+#: one changes a verdict. Each is legal YAML and legal Actions, so "nobody writes
+#: that here" is a property of today's files, not of the format — and the failure
+#: is silent in the dangerous direction. The flow mapping is the sharp one:
+#:
+#:     on:
+#:       pull_request: {branches: [main], paths: ["src/**"]}
+#:
+#: reads as the *string* "{branches: ...}", `classify_workflow` does
+#: `if not isinstance(pr, dict): pr = {}`, the paths filter evaporates, and the
+#: job is ruled GATEABLE. The gate then instructs you to require a context that
+#: will not be delivered — it hands you the exact deadlock it exists to prevent.
+#: Refusing to parse is the only safe answer; a reader that guesses here is worse
+#: than no reader.
+def _reject_unsupported(val, path: str, lineno: int, where: str) -> None:
+    if not isinstance(val, str):
+        return
+    v = val.strip()
+    if not v:
+        return
+    if v.startswith("{"):
+        kind = "a flow mapping"
+    elif v[0] in "&*":
+        kind = "a YAML anchor or alias"
+    elif v[0] in "|>":
+        kind = "a block scalar"
+    else:
+        return
+    raise WorkflowSyntaxError(
+        f"{path}:{lineno}: {where} is {kind} ({v!r}), which this restricted "
+        f"reader cannot represent. Rewrite it as block-style YAML. Guessing "
+        f"here can flip a job's classification and deadlock every PR."
+    )
+
+
 def _scalar(val: str):
     val = val.strip()
     if not val:
@@ -164,6 +235,7 @@ def parse_workflow(text: str, path: str = "<str>") -> dict:
     trigger = None          # current key under `on:`
     job = None              # current key under `jobs:`
     listing = None          # (container, key) currently accumulating `- items`
+    saw_jobs = False        # a `jobs:` key was seen at indent 0
 
     for lineno, raw in enumerate(text.splitlines(), 1):
         line = _strip_comment(raw)
@@ -200,12 +272,17 @@ def parse_workflow(text: str, path: str = "<str>") -> dict:
             # so the trap the reference parser springs does not arise — but the
             # key still has to be matched in both spellings.
             section = "on" if key in ("on", "'on'", '"on"', "True", "true") else ("jobs" if key == "jobs" else None)
+            if section is not None:
+                _reject_unsupported(val, path, lineno, f"`{key}:`")
             if section == "on":
                 doc["on"] = {} if val is None else {t: {} for t in (val if isinstance(val, list) else [val])}
+            if section == "jobs":
+                saw_jobs = True
             trigger = job = None
             continue
 
         if indent == 2 and section == "on":
+            _reject_unsupported(val, path, lineno, f"`on.{key}:`")
             trigger = key
             doc["on"][key] = {} if val is None else val
             continue
@@ -213,6 +290,7 @@ def parse_workflow(text: str, path: str = "<str>") -> dict:
         if indent == 4 and section == "on" and trigger == "pull_request":
             if not isinstance(doc["on"].get("pull_request"), dict):
                 raise WorkflowSyntaxError(f"{path}:{lineno}: options under a non-mapping pull_request")
+            _reject_unsupported(val, path, lineno, f"`on.pull_request.{key}:`")
             if val is None:
                 doc["on"]["pull_request"][key] = []
                 listing = (doc["on"]["pull_request"], key, 6)
@@ -221,14 +299,31 @@ def parse_workflow(text: str, path: str = "<str>") -> dict:
             continue
 
         if indent == 2 and section == "jobs":
+            _reject_unsupported(val, path, lineno, f"`jobs.{key}:`")
             job = key
             doc["jobs"][key] = {}
             continue
 
         if indent == 4 and section == "jobs" and job is not None:
             if key in ("name", "continue-on-error"):
+                _reject_unsupported(val, path, lineno, f"`jobs.{job}.{key}:`")
                 doc["jobs"][job][key] = val
             continue
+
+    # A `jobs:` block that yielded nothing is not an empty workflow — it is a
+    # workflow this reader failed to see into, and the difference matters because
+    # the two render identically downstream: zero jobs means zero violations
+    # means PASS. That is fail-OPEN, and it is reachable without anything exotic
+    # — a file indented with four spaces puts every job id at indent 4, where the
+    # reader is not looking and the indent-2 fail-closed check never fires.
+    # Actions rejects a jobs-less workflow anyway, so this cannot false-alarm on
+    # a file that CI would actually run.
+    if saw_jobs and not doc["jobs"]:
+        raise WorkflowSyntaxError(
+            f"{path}: a `jobs:` block is present but no job was recognised at "
+            f"indent 2. This reader requires 2-space indentation; a workflow it "
+            f"cannot see into would silently report zero violations."
+        )
 
     return doc
 
@@ -320,7 +415,12 @@ def read_list(path: str) -> list[str]:
     out = []
     with open(path) as fh:
         for line in fh:
-            line = line.split("#", 1)[0].strip()
+            # Same comment rule as the workflow reader: `#` only opens a comment
+            # at line start or after whitespace. A naive split makes
+            # `--print > required-contexts.txt` a lossy round-trip for any
+            # context whose name contains `#` (`Test #1` -> `Test`), which the
+            # parser would then report as a stale entry AND a missing job.
+            line = _strip_comment(line).strip()
             if line:
                 out.append(line)
     return out
@@ -541,15 +641,57 @@ jobs:
     runs-on: ubuntu-latest
 """
 
-_JOB_IF_SCOPED = """
+_PATHS_IGNORE_SCOPED = """
+name: W
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+"""
+
+#: `pull_request` as a flow mapping. Valid YAML, valid Actions, and the reader
+#: sees the value as an opaque string — so the `paths` filter vanishes and the
+#: job is ruled GATEABLE. Must be refused, not guessed at.
+_FLOW_MAPPING = """
+name: W
+on:
+  pull_request: {branches: [main], paths: ["src/**"]}
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+"""
+
+#: Four-space indentation throughout. Every job id lands at indent 4, where the
+#: reader is not looking — and the indent-2 fail-closed check never fires. Before
+#: the `saw_jobs` check this parsed to zero jobs and PASSed.
+_FOUR_SPACE = """
+name: W
+on:
+    pull_request:
+        branches: [main]
+jobs:
+    a:
+        name: Alpha
+        runs-on: ubuntu-latest
+"""
+
+#: A folded block scalar as a job name. The reader would take the literal `>-`
+#: as the context name and demand that be required, while the real context
+#: ("Folded Name") goes unrequired — failure mode 1, caused by the gate.
+_BLOCK_SCALAR_NAME = """
 name: W
 on:
   pull_request:
     branches: [main]
 jobs:
   a:
-    name: Alpha
-    if: needs.changes.outputs.code == 'true'
+    name: >-
+      Folded Name
     runs-on: ubuntu-latest
 """
 
@@ -628,11 +770,31 @@ SELF_TESTS = [
         "required' rule would get wrong",
     ),
     (
-        "job-level if: is required, and must be",
-        _JOB_IF_SCOPED, ["Alpha"], 0,
-        "the distinction the whole gate turns on: an if:-skipped job reports "
-        "\"skipped\", which SATISFIES a required context — so job-level "
-        "filtering is gateable where workflow-level filtering is not",
+        "paths-ignore-scoped workflow required",
+        _PATHS_IGNORE_SCOPED, ["Alpha"], 1,
+        "`paths-ignore` deadlocks identically to `paths`. Without this case the "
+        "paths-ignore branch survives every other fixture — deleting it reds "
+        "nothing, which is what a guard nothing exercises is worth",
+    ),
+    (
+        "flow-mapping pull_request refused",
+        _FLOW_MAPPING, ["Alpha"], 2,
+        "the reader cannot see a flow mapping's `paths`, so it would rule the "
+        "job GATEABLE and order you to require an undeliverable context — the "
+        "gate handing you the deadlock it exists to prevent. Refusal, not a guess",
+    ),
+    (
+        "four-space indentation refused",
+        _FOUR_SPACE, [], 2,
+        "fail-OPEN, the one direction that must not exist: jobs at indent 4 are "
+        "invisible, zero jobs means zero violations means PASS on a file the "
+        "reader never read",
+    ),
+    (
+        "block-scalar job name refused",
+        _BLOCK_SCALAR_NAME, ["Folded Name"], 2,
+        "a folded name reads as the literal '>-'; requiring that string leaves "
+        "the real context ungated",
     ),
     (
         "templated matrix name required",
@@ -655,7 +817,12 @@ def self_test() -> int:
         with tempfile.TemporaryDirectory() as tmp:
             wf_dir = os.path.join(tmp, "wf")
             os.makedirs(wf_dir)
-            with open(os.path.join(wf_dir, "w.yml"), "w") as fh:
+            # Deliberately `.yaml`, the extension the original `*.yml` glob could
+            # not see. Every fixture therefore also exercises discovery: narrow
+            # the glob back and all of them go red at once, loudly. `.yml` needs
+            # no fixture — all ten real workflows use it, so the live run covers
+            # that leg on every PR.
+            with open(os.path.join(wf_dir, "w.yaml"), "w") as fh:
                 fh.write(wf_text)
             list_path = os.path.join(tmp, "required.txt")
             with open(list_path, "w") as fh:
@@ -664,7 +831,16 @@ def self_test() -> int:
             import io
 
             buf = io.StringIO()
-            got = run_check(os.path.join(wf_dir, "*.yml"), list_path, out=buf)
+            # `.y*ml`, matching the real glob — a fixture written as `.yaml`
+            # must be discovered, since Actions loads both extensions.
+            try:
+                got = run_check(os.path.join(wf_dir, "*.y*ml"), list_path, out=buf)
+            except WorkflowSyntaxError as exc:
+                # 2 == "refused to guess", the fail-closed exit main() renders.
+                # Distinct from 1 (a real violation) on purpose: one says the
+                # gate found a problem, the other says the gate cannot see.
+                got = 2
+                print(f"refused: {exc}", file=buf)
 
         mark = "ok  " if got == want else "FAIL"
         if got != want:
@@ -676,10 +852,24 @@ def self_test() -> int:
             for line in buf.getvalue().splitlines():
                 print(f"       {line}")
 
+    # The fixtures above run against a glob this function builds, so they cannot
+    # see WORKFLOW_GLOB itself — narrowing that constant back to `*.yml` would
+    # leave every fixture green while the production run stopped reading half the
+    # directory. Assert on the constant directly.
+    if not fnmatch.fnmatch(".github/workflows/x.yaml", WORKFLOW_GLOB):
+        print(f"  FAIL WORKFLOW_GLOB does not match `.yaml`: {WORKFLOW_GLOB!r}")
+        print("       proves: Actions loads .yml AND .yaml; a glob that misses "
+              "one reports PASS on a directory it never fully read")
+        failures += 1
+    else:
+        print("  ok   WORKFLOW_GLOB matches both .yml and .yaml")
+        print("       proves: no workflow file is invisible to the scan by extension")
+
+    total = len(SELF_TESTS) + 1
     if failures:
-        print(f"\n{failures} of {len(SELF_TESTS)} self-test(s) FAILED.")
+        print(f"\n{failures} of {total} self-test(s) FAILED.")
         return 1
-    print(f"\n{len(SELF_TESTS)} self-test(s) passed.")
+    print(f"\n{total} self-test(s) passed.")
     return 0
 
 

--- a/tools/check_required_contexts.py
+++ b/tools/check_required_contexts.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""Keep the required-status-check set honest against the workflows (issue #372).
+
+THE PROBLEM. A branch-protection "required status check" is a *claim*: it says
+"this PR cannot merge until that job passed." Whether the claim is true depends
+on facts that live somewhere else entirely — in the workflow files — and nothing
+reconciles the two. Three ways they drift, each failing differently:
+
+  1. A job is added to a PR-triggered workflow and nobody adds it to the
+     required set. It runs, it goes red, and the PR merges anyway. The gate
+     looks full; it is one job short. (`osate-corpus` is in this state today.)
+
+  2. A job carries `continue-on-error: true`. It reports SUCCESS whatever
+     happened — pass, fail, or never really ran. Requiring it enforces nothing,
+     and even *not* requiring it still renders a green tick beside its name in
+     the PR UI, which a reader reasonably takes as "this was checked."
+
+  3. A required job lives in a workflow with a workflow-level
+     `on.pull_request.paths:` filter. This is the trap, and it is worth stating
+     plainly because the obvious fix causes it: a workflow that does not trigger
+     reports *nothing at all* — not "skipped", nothing — so the required context
+     sits at "Expected — waiting for status" forever and the PR can never merge.
+     Every PR that misses those paths deadlocks.
+
+     The fix is NOT to add the context. It is to make the workflow always run
+     and move the filter to a job-level `if:`. An `if:`-skipped job reports
+     "skipped", and a skipped required context is SATISFIED. That distinction —
+     "did not run" vs "ran and skipped" — is the entire difference between a
+     deadlocked repo and a working path filter, and it is invisible in the
+     workflow YAML.
+
+So each job falls into exactly one of three buckets, and the bucket determines
+whether it may be required:
+
+  GATEABLE     PR-triggered, no workflow-level path filter, no
+               continue-on-error, static (non-templated) name  -> MUST be required
+  ADVISORY     continue-on-error: true                         -> must NOT be required,
+                                                                  and must say so in its name
+  UNDELIVERABLE workflow-level pull_request paths filter, or a
+               templated/matrix name with no static context    -> must NOT be required
+
+WHY A COMMITTED LIST RATHER THAN THE LIVE API. Reading branch protection
+(`GET /repos/{o}/{r}/branches/{b}/protection`) needs an admin token, and the
+Actions `GITHUB_TOKEN` is not one. A gate that cannot run in CI is not a gate,
+so the expected set is committed to `.github/required-contexts.txt` and this
+script reconciles WORKFLOWS <-> LIST hermetically on every PR. Reconciling
+LIST <-> BRANCH PROTECTION needs the admin token and is available via
+`--against-api` for a maintainer or a scheduled admin-credentialed run.
+
+That split is a real limitation, stated rather than hidden: this gate proves the
+committed list matches the workflows. It does not, by itself, prove GitHub is
+enforcing that list. Those are different claims and only one of them is
+mechanically checked here.
+
+WHY A HAND-ROLLED PARSER INSTEAD OF PyYAML. Same rule the human-scoped
+guardrail next to it in ci.yml follows: no workflow in this repo installs a
+Python package, so importing PyYAML would make a *required* check depend on an
+unverified runner package that a runner-image update could remove. The reader
+below handles only the fixed shape a GitHub workflow has at the three depths
+this gate reads, and is fail-closed — anything it does not fully recognise at
+those positions exits 2 (red) rather than being scanned past. `--cross-check`
+validates it against PyYAML on the real workflow corpus wherever PyYAML happens
+to be available, which is how the restriction is kept honest rather than
+assumed.
+
+Usage:
+  tools/check_required_contexts.py                 # reconcile workflows <-> committed list
+  tools/check_required_contexts.py --self-test     # fixture cases; run this FIRST in CI
+  tools/check_required_contexts.py --print         # emit the GATEABLE set (regenerate the list)
+  tools/check_required_contexts.py --against-api   # also diff against live branch protection
+  tools/check_required_contexts.py --cross-check   # agree with PyYAML on the real corpus (local)
+
+Exit: 0 clean, 1 violation, 2 usage/environment error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+WORKFLOW_GLOB = ".github/workflows/*.yml"
+LIST_PATH = ".github/required-contexts.txt"
+PROTECTED_BRANCH = "main"
+
+GATEABLE = "GATEABLE"
+ADVISORY = "ADVISORY"
+UNDELIVERABLE = "UNDELIVERABLE"
+NOT_PR = "NOT_PR"
+
+#: An advisory job's name is the only thing a PR reader sees. Requiring the
+#: marker is not cosmetics: `continue-on-error` severs the tick from the
+#: outcome, so an unmarked name renders a claim the run does not support.
+ADVISORY_MARKER = "advisory"
+
+
+class WorkflowSyntaxError(Exception):
+    """Something at a depth this gate reads was not recognised. Fail closed."""
+
+
+_KEY = re.compile(r"^(?P<indent> *)(?P<key>[A-Za-z_][\w.-]*|'[^']*'|\"[^\"]*\"): ?(?P<val>.*)$")
+_ITEM = re.compile(r"^(?P<indent> *)- +(?P<val>.*)$")
+
+
+def _strip_comment(line: str) -> str:
+    """Drop a trailing `#` comment, respecting quotes.
+
+    Naively splitting on `#` corrupts `name: Bazel test (//...)` the moment
+    someone writes a name containing one, and this gate's whole subject is job
+    names.
+    """
+    out, quote = [], None
+    for i, ch in enumerate(line):
+        if quote:
+            out.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in "'\"":
+            quote = ch
+            out.append(ch)
+        elif ch == "#" and (i == 0 or line[i - 1] in " \t"):
+            break
+        else:
+            out.append(ch)
+    return "".join(out).rstrip()
+
+
+def _scalar(val: str):
+    val = val.strip()
+    if not val:
+        return None
+    if val[0] in "'\"" and val[-1] == val[0] and len(val) >= 2:
+        return val[1:-1]
+    if val.startswith("[") and val.endswith("]"):
+        inner = val[1:-1].strip()
+        return [_scalar(x) for x in inner.split(",")] if inner else []
+    if val in ("true", "True"):
+        return True
+    if val in ("false", "False"):
+        return False
+    return val
+
+
+def parse_workflow(text: str, path: str = "<str>") -> dict:
+    """Extract exactly what this gate reads, and refuse anything else.
+
+    A GitHub workflow is not free-form YAML at these depths — the schema fixes
+    the structure, so a line reader keyed on indentation is sufficient AND
+    checkable. What it reads:
+
+        on.pull_request.{branches,paths,paths-ignore}   (indent 0/2/4)
+        jobs.<id>.{name,continue-on-error}              (indent 0/2/4)
+
+    Everything deeper (steps, strategy, with:) is deliberately invisible — a
+    step's `name:` sits at indent 8 and must not be mistaken for a job's.
+    """
+    doc: dict = {"on": None, "jobs": {}}
+    section = None          # None | "on" | "jobs"
+    trigger = None          # current key under `on:`
+    job = None              # current key under `jobs:`
+    listing = None          # (container, key) currently accumulating `- items`
+
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        line = _strip_comment(raw)
+        if not line.strip():
+            continue
+
+        item = _ITEM.match(line)
+        if item and listing is not None and len(item.group("indent")) >= listing[2]:
+            listing[0][listing[1]].append(_scalar(item.group("val")))
+            continue
+
+        m = _KEY.match(line)
+        if not m:
+            # Fail closed at exactly the positions a misread would change a
+            # verdict, and nowhere else. Being stricter than this rejects
+            # legitimate structure the gate provably never reads — `on.schedule`
+            # is a list of mappings, and refusing to parse a nightly cron would
+            # be a false alarm, not caution.
+            ind = len(line) - len(line.lstrip(" "))
+            reads_here = (ind == 2 and section in ("on", "jobs")) or (
+                ind == 4 and section == "on" and trigger == "pull_request"
+            )
+            if reads_here:
+                raise WorkflowSyntaxError(f"{path}:{lineno}: unrecognised where this gate reads: {line!r}")
+            continue
+
+        indent = len(m.group("indent"))
+        key = _scalar(m.group("key")) if m.group("key")[0] in "'\"" else m.group("key")
+        val = _scalar(m.group("val"))
+        listing = None
+
+        if indent == 0:
+            # YAML 1.1 parses a bare `on:` as the boolean True; here it is text,
+            # so the trap the reference parser springs does not arise — but the
+            # key still has to be matched in both spellings.
+            section = "on" if key in ("on", "'on'", '"on"', "True", "true") else ("jobs" if key == "jobs" else None)
+            if section == "on":
+                doc["on"] = {} if val is None else {t: {} for t in (val if isinstance(val, list) else [val])}
+            trigger = job = None
+            continue
+
+        if indent == 2 and section == "on":
+            trigger = key
+            doc["on"][key] = {} if val is None else val
+            continue
+
+        if indent == 4 and section == "on" and trigger == "pull_request":
+            if not isinstance(doc["on"].get("pull_request"), dict):
+                raise WorkflowSyntaxError(f"{path}:{lineno}: options under a non-mapping pull_request")
+            if val is None:
+                doc["on"]["pull_request"][key] = []
+                listing = (doc["on"]["pull_request"], key, 6)
+            else:
+                doc["on"]["pull_request"][key] = val
+            continue
+
+        if indent == 2 and section == "jobs":
+            job = key
+            doc["jobs"][key] = {}
+            continue
+
+        if indent == 4 and section == "jobs" and job is not None:
+            if key in ("name", "continue-on-error"):
+                doc["jobs"][job][key] = val
+            continue
+
+    return doc
+
+
+def _on(doc: dict):
+    """Return the workflow's trigger block."""
+    return doc.get("on")
+
+
+def classify_workflow(doc: dict) -> tuple[bool, list[str]]:
+    """(does it trigger on PRs against the protected branch, disqualifying reasons)."""
+    on = _on(doc)
+    if not isinstance(on, dict):
+        return False, []
+    if "pull_request" not in on:
+        return False, []
+    pr = on["pull_request"] or {}
+    if not isinstance(pr, dict):
+        pr = {}
+
+    branches = pr.get("branches")
+    if branches and not any(fnmatch.fnmatch(PROTECTED_BRANCH, b) for b in branches):
+        return False, []
+
+    reasons = []
+    if pr.get("paths"):
+        reasons.append(
+            "workflow-level `on.pull_request.paths` — a non-triggered workflow "
+            "reports nothing, so requiring this context deadlocks every PR that "
+            "misses those paths. Convert to always-run + a job-level `if:` first; "
+            "an if:-skipped job reports \"skipped\", which SATISFIES a required context"
+        )
+    if pr.get("paths-ignore"):
+        reasons.append(
+            "workflow-level `on.pull_request.paths-ignore` — same deadlock as "
+            "`paths`; move the filter to a job-level `if:`"
+        )
+    return True, reasons
+
+
+def classify_jobs(doc: dict) -> dict[str, tuple[str, str, list[str]]]:
+    """job key -> (bucket, rendered context name, reasons)."""
+    is_pr, wf_reasons = classify_workflow(doc)
+    out: dict[str, tuple[str, str, list[str]]] = {}
+
+    for key, job in (doc.get("jobs") or {}).items():
+        job = job or {}
+        name = job.get("name", key)
+        if not is_pr:
+            out[key] = (NOT_PR, name, ["workflow does not run on pull_request against " + PROTECTED_BRANCH])
+            continue
+
+        reasons = list(wf_reasons)
+
+        # `continue-on-error` is checked before the workflow-level reasons are
+        # acted on because the remedy differs: an advisory job should be marked,
+        # a path-scoped job should be restructured. Both are "must not be
+        # required", for unrelated causes.
+        if job.get("continue-on-error") is True:
+            out[key] = (ADVISORY, name, ["`continue-on-error: true` — reports success regardless of outcome"] + reasons)
+            continue
+
+        if "${{" in str(name):
+            reasons.append(
+                "name is templated (matrix or expression) — it renders to N "
+                "contexts at runtime, none equal to this literal, so no static "
+                "string can be required"
+            )
+
+        out[key] = ((UNDELIVERABLE if reasons else GATEABLE), name, reasons)
+
+    return out
+
+
+def scan(workflow_glob: str = WORKFLOW_GLOB) -> dict[str, tuple[str, str, str, list[str]]]:
+    """context name -> (bucket, workflow path, job key, reasons)."""
+    found: dict[str, tuple[str, str, str, list[str]]] = {}
+    for path in sorted(glob.glob(workflow_glob)):
+        with open(path) as fh:
+            doc = parse_workflow(fh.read(), path)
+        for key, (bucket, name, reasons) in classify_jobs(doc).items():
+            if bucket == NOT_PR:
+                continue
+            found[name] = (bucket, path, key, reasons)
+    return found
+
+
+def read_list(path: str) -> list[str]:
+    out = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.split("#", 1)[0].strip()
+            if line:
+                out.append(line)
+    return out
+
+
+def run_check(workflow_glob: str, list_path: str, out=None) -> int:
+    out = out or sys.stdout
+    found = scan(workflow_glob)
+    required = read_list(list_path)
+
+    gateable = {n for n, (b, *_) in found.items() if b == GATEABLE}
+    errors: list[str] = []
+
+    # 1. Every gateable job must be required. This is the miss that leaves the
+    #    gate one job short while looking full.
+    for name in sorted(gateable - set(required)):
+        _, path, key, _ = found[name]
+        errors.append(
+            f"{path}: job `{key}` produces context {name!r}, which runs on every "
+            f"PR and cannot fail open — but it is not in {list_path}. Either "
+            f"require it, or give it `continue-on-error` and mark it advisory."
+        )
+
+    # 2. Every required context must be produced by a gateable job. Catches both
+    #    stale entries (renamed/deleted jobs -> permanently "Expected") and
+    #    entries pointing at jobs that cannot deliver.
+    for name in required:
+        if name in gateable:
+            continue
+        if name not in found:
+            errors.append(
+                f"{list_path}: required context {name!r} is not produced by any "
+                f"job in any PR-triggered workflow. A required context nothing "
+                f"reports sits at \"Expected — waiting for status\" forever."
+            )
+            continue
+        bucket, path, key, reasons = found[name]
+        why = "; ".join(reasons) or "unknown"
+        errors.append(
+            f"{list_path}: required context {name!r} ({path}, job `{key}`) is "
+            f"{bucket} and must not be required: {why}"
+        )
+
+    # 3. An advisory job must say so in its name. `continue-on-error` makes the
+    #    tick unconditional; the name is the only place a reader can learn that.
+    for name, (bucket, path, key, _) in sorted(found.items()):
+        if bucket == ADVISORY and ADVISORY_MARKER not in name.lower():
+            errors.append(
+                f"{path}: job `{key}` is `continue-on-error` but its name "
+                f"{name!r} does not say so. It renders a green tick in the PR UI "
+                f"whatever happened; the name is the only signal that the tick "
+                f"is not a verdict. Add \"({ADVISORY_MARKER})\"."
+            )
+
+    counts = {b: sum(1 for v in found.values() if v[0] == b) for b in (GATEABLE, ADVISORY, UNDELIVERABLE)}
+    print(
+        f"scanned {len(found)} PR-triggered job(s): "
+        f"{counts[GATEABLE]} gateable, {counts[ADVISORY]} advisory, "
+        f"{counts[UNDELIVERABLE]} undeliverable; {len(required)} required context(s)",
+        file=out,
+    )
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}", file=out)
+        print(f"\nFAIL: {len(errors)} required-context violation(s).", file=out)
+        return 1
+
+    print("PASS: the committed required set is exactly the gateable set.", file=out)
+    return 0
+
+
+def cross_check(workflow_glob: str) -> int:
+    """Agree with PyYAML on the real corpus, or say exactly where we differ.
+
+    The restricted reader above is the price of not adding a package dependency
+    to a required check. That price is only worth paying if the reader is
+    *right*, and "it passed on the repo that already passes" does not show that.
+    So where a reference parser is available — a developer machine, not CI — the
+    two are run side by side over every real workflow file and every field this
+    gate actually reads.
+    """
+    try:
+        import yaml  # noqa: PLC0415 - deliberately optional, absent in CI
+    except ImportError:
+        print("::error::--cross-check needs PyYAML. It is deliberately NOT a")
+        print("::error::dependency of the gate itself; install it locally to run this.")
+        return 2
+
+    diffs = 0
+    files = sorted(glob.glob(workflow_glob))
+    for path in files:
+        text = open(path).read()
+        mine = parse_workflow(text, path)
+        ref = yaml.safe_load(text) or {}
+        ref_on = ref.get(True, ref.get("on"))
+
+        def norm_pr(on):
+            if not isinstance(on, dict) or "pull_request" not in on:
+                return None
+            pr = on["pull_request"] or {}
+            pr = pr if isinstance(pr, dict) else {}
+            return {k: pr.get(k) for k in ("branches", "paths", "paths-ignore")}
+
+        if norm_pr(mine["on"]) != norm_pr(ref_on):
+            print(f"::error::{path}: pull_request trigger differs — mine={norm_pr(mine['on'])!r} ref={norm_pr(ref_on)!r}")
+            diffs += 1
+
+        ref_jobs = ref.get("jobs") or {}
+        if set(mine["jobs"]) != set(ref_jobs):
+            print(f"::error::{path}: job id set differs — {set(mine['jobs']) ^ set(ref_jobs)}")
+            diffs += 1
+            continue
+        for jid, rj in ref_jobs.items():
+            rj = rj or {}
+            for field in ("name", "continue-on-error"):
+                if mine["jobs"][jid].get(field) != rj.get(field):
+                    print(
+                        f"::error::{path}: job `{jid}` field {field!r} differs — "
+                        f"mine={mine['jobs'][jid].get(field)!r} ref={rj.get(field)!r}"
+                    )
+                    diffs += 1
+
+    if diffs:
+        print(f"\nFAIL: {diffs} disagreement(s) with PyYAML across {len(files)} workflow(s).")
+        return 1
+    print(f"PASS: the restricted reader agrees with PyYAML on every field it reads, across {len(files)} workflow(s).")
+    return 0
+
+
+def against_api(list_path: str, repo: str) -> int:
+    """Diff the committed list against live branch protection. Needs an admin token."""
+    cmd = ["gh", "api", f"repos/{repo}/branches/{PROTECTED_BRANCH}/protection/required_status_checks"]
+    try:
+        raw = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    except FileNotFoundError:
+        print("::error::`gh` not found; --against-api needs the GitHub CLI.")
+        return 2
+    except subprocess.CalledProcessError as exc:
+        print(
+            "::error::could not read branch protection. This needs an ADMIN "
+            "token — the Actions GITHUB_TOKEN is not one, which is why the "
+            f"committed list exists at all. gh said: {exc.stderr.strip()}"
+        )
+        return 2
+
+    live = set(json.loads(raw).get("contexts") or [])
+    want = set(read_list(list_path))
+    if live == want:
+        print(f"PASS: branch protection on {PROTECTED_BRANCH} matches {list_path} ({len(want)} contexts).")
+        return 0
+    for name in sorted(want - live):
+        print(f"::error::{name!r} is in {list_path} but NOT enforced on {PROTECTED_BRANCH}.")
+    for name in sorted(live - want):
+        print(f"::error::{name!r} is enforced on {PROTECTED_BRANCH} but NOT in {list_path}.")
+    return 1
+
+
+# ── self-test ─────────────────────────────────────────────────────────────
+#
+# These run on every CI invocation via --self-test. A guardrail exercised only
+# against a repo that already satisfies it is indistinguishable from one that
+# returns 0 unconditionally: the live repo is a single input, and a single
+# input cannot demonstrate that distinct inputs give distinct verdicts.
+#
+# Each fixture kills exactly one guard. Deleting any guard reds this list.
+
+_CLEAN = """
+name: W
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+"""
+
+_ADVISORY_UNMARKED = """
+name: W
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+  b:
+    name: Beta
+    continue-on-error: true
+    runs-on: ubuntu-latest
+"""
+
+_ADVISORY_MARKED = """
+name: W
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+  b:
+    name: Beta (advisory)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+"""
+
+_PATH_SCOPED = """
+name: W
+on:
+  pull_request:
+    paths:
+      - "src/**"
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+"""
+
+_JOB_IF_SCOPED = """
+name: W
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  a:
+    name: Alpha
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+"""
+
+_TEMPLATED = """
+name: W
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  a:
+    name: Alpha ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [x, y]
+    runs-on: ubuntu-latest
+"""
+
+_WRONG_BRANCH = """
+name: W
+on:
+  pull_request:
+    branches: [release/*]
+jobs:
+  a:
+    name: Alpha
+    runs-on: ubuntu-latest
+"""
+
+SELF_TESTS = [
+    (
+        "clean: one gateable job, required",
+        _CLEAN, ["Alpha"], 0,
+        "the checker can return 0 at all — without this the other cases are "
+        "consistent with a script that always fails",
+    ),
+    (
+        "gateable job missing from the list",
+        _CLEAN, [], 1,
+        "guard 1: a job that runs on every PR and cannot fail open is not "
+        "silently left out of the gate (the osate-corpus shape)",
+    ),
+    (
+        "stale entry: required context no job produces",
+        _CLEAN, ["Alpha", "Ghost"], 1,
+        "guard 2a: a renamed or deleted job leaves a context stuck at "
+        "\"Expected — waiting for status\" forever",
+    ),
+    (
+        "advisory job required",
+        _ADVISORY_MARKED, ["Alpha", "Beta (advisory)"], 1,
+        "guard 2b: requiring a continue-on-error job enforces nothing — it "
+        "reports success whatever happened",
+    ),
+    (
+        "advisory job not marked in its name",
+        _ADVISORY_UNMARKED, ["Alpha"], 1,
+        "guard 3: an unmarked advisory job renders a green tick a reader takes "
+        "as a verdict",
+    ),
+    (
+        "advisory job marked and not required",
+        _ADVISORY_MARKED, ["Alpha"], 0,
+        "guard 3 accepts the remedy it demands, rather than being unsatisfiable",
+    ),
+    (
+        "path-scoped workflow required",
+        _PATH_SCOPED, ["Alpha"], 1,
+        "THE DEADLOCK TRAP: a non-triggered workflow reports nothing, so this "
+        "context never arrives and every PR missing those paths is unmergeable",
+    ),
+    (
+        "path-scoped workflow NOT required",
+        _PATH_SCOPED, [], 0,
+        "the trap is not 'fixed' by demanding the context — guard 1 must not "
+        "fire here, which is precisely what a mechanical 'every job must be "
+        "required' rule would get wrong",
+    ),
+    (
+        "job-level if: is required, and must be",
+        _JOB_IF_SCOPED, ["Alpha"], 0,
+        "the distinction the whole gate turns on: an if:-skipped job reports "
+        "\"skipped\", which SATISFIES a required context — so job-level "
+        "filtering is gateable where workflow-level filtering is not",
+    ),
+    (
+        "templated matrix name required",
+        _TEMPLATED, ["Alpha ${{ matrix.target }}"], 1,
+        "a matrix name renders to N runtime contexts, none equal to the literal",
+    ),
+    (
+        "workflow scoped to a different branch",
+        _WRONG_BRANCH, [], 0,
+        "a workflow that never runs against main is out of scope, not a miss",
+    ),
+]
+
+
+def self_test() -> int:
+    import tempfile
+
+    failures = 0
+    for name, wf_text, required, want, proves in SELF_TESTS:
+        with tempfile.TemporaryDirectory() as tmp:
+            wf_dir = os.path.join(tmp, "wf")
+            os.makedirs(wf_dir)
+            with open(os.path.join(wf_dir, "w.yml"), "w") as fh:
+                fh.write(wf_text)
+            list_path = os.path.join(tmp, "required.txt")
+            with open(list_path, "w") as fh:
+                fh.write("\n".join(required) + "\n")
+
+            import io
+
+            buf = io.StringIO()
+            got = run_check(os.path.join(wf_dir, "*.yml"), list_path, out=buf)
+
+        mark = "ok  " if got == want else "FAIL"
+        if got != want:
+            failures += 1
+        print(f"  {mark} {name}: exit {got} (want {want})")
+        print(f"       proves: {proves}")
+        if got != want:
+            print("       ---- output ----")
+            for line in buf.getvalue().splitlines():
+                print(f"       {line}")
+
+    if failures:
+        print(f"\n{failures} of {len(SELF_TESTS)} self-test(s) FAILED.")
+        return 1
+    print(f"\n{len(SELF_TESTS)} self-test(s) passed.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--workflows", default=WORKFLOW_GLOB)
+    p.add_argument("--list", dest="list_path", default=LIST_PATH)
+    p.add_argument("--self-test", action="store_true")
+    p.add_argument("--print", dest="do_print", action="store_true")
+    p.add_argument("--against-api", action="store_true")
+    p.add_argument("--cross-check", action="store_true")
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "pulseengine/spar"))
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.cross_check:
+        return cross_check(args.workflows)
+
+    if args.do_print:
+        for name, (bucket, *_rest) in sorted(scan(args.workflows).items()):
+            if bucket == GATEABLE:
+                print(name)
+        return 0
+
+    if args.against_api:
+        return against_api(args.list_path, args.repo)
+
+    return run_check(args.workflows, args.list_path)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except WorkflowSyntaxError as exc:
+        # Fail closed. A workflow shape the reader does not fully recognise is
+        # a workflow whose jobs it cannot classify, and an unclassifiable job is
+        # exactly the one that would slip through unrequired.
+        print(f"::error::{exc}", file=sys.stderr)
+        print(
+            "::error::The workflow reader is deliberately restricted (see the "
+            "module docstring) and stops rather than guessing. Either simplify "
+            "the construct or extend the reader — and re-run --cross-check.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)

--- a/tools/ci/check-tag-point.sh
+++ b/tools/ci/check-tag-point.sh
@@ -20,33 +20,52 @@
 #
 # Given tag vX.Y.Z at commit C with tag date T:
 #
+#   0. tag is lightweight, not annotated           -> fail (see below)
 #   1. C not an ancestor of origin/main            -> skip (release-branch tag)
-#   2. enumerate C..origin/main, dated before T    -> the excluded set
+#   2. enumerate C..origin/main on the FIRST-PARENT
+#      spine, dated before T                       -> the excluded set
 #   3. empty                                       -> pass
-#   4. non-empty, tag message states a tag point   -> pass, listing them
+#   4. non-empty, tag message carries a
+#      `Tag-Point:` trailer                        -> pass, listing them
 #   5. non-empty, it does not                      -> fail, listing them
 #
-# Step 2's `--before=T` is what makes the gate both race-proof and idempotent.
-# Race-proof: a merge landing seconds after the tag push cannot fail the job,
-# because it postdates T. Idempotent: both inputs (the tag object, and the set
-# of commits dated before T that are reachable from main) are immutable, so a
-# re-run months later returns the same verdict. A gate whose answer changes as
-# unrelated commits land is not a gate.
+# WHY --first-parent, AND WHY THE OBVIOUS VERSION IS WRONG. A clean-room audit
+# refuted the first design, which enumerated every commit in `C..origin/main`
+# dated before T. `--before` filters on COMMITTER DATE — when a commit was
+# written — but the question is when it LANDED ON MAIN. Those differ, and the
+# gap is unbounded: a branch whose commits are dated the 3rd, merged on the 10th,
+# injects commits "dated before T" into a range they were not reachable from at
+# tag time. Consequences, both demonstrated against a scratch repo:
+#
+#   * NOT IDEMPOTENT. Same tag object, same tagged commit, byte-identical
+#     ->  PASS at tag time, FAIL when re-run after that branch merged. A gate
+#     whose verdict drifts as unrelated commits land is exactly what #366
+#     rejected in its first design; this reintroduced it one level down.
+#   * OVER-REPORTS, contradicting the soundness direction this header used to
+#     claim ("weakens in the PERMISSIVE direction — it under-reports, never
+#     over-reports"). It is a false accusation against a tagger who did tag the
+#     tip of main. That claim was wrong and is deleted.
+#
+# The first-parent spine fixes both. It contains exactly the squash and merge
+# commits, whose committer dates ARE their landing times, so `--before` becomes
+# exact rather than approximate. A late-merged branch contributes its merge
+# commit (dated at merge time, correctly after T) and not its old constituents.
+# Detection is unaffected: the v0.31.0 miss (9557dd0) is a squash commit on the
+# spine. This repo squash-merges today, which made the defect latent rather than
+# active — main carries 91 merge commits, so "latent" is not "impossible".
 #
 # WHAT THIS DOES NOT DO — stated so it is not mistaken for coverage:
 #
-#   * It cannot verify the acknowledgement is TRUE. It greps the tag message for
-#     a stated tag point; a message saying "tag point: whatever" passes. This is
-#     a speed bump against autopilot, not a proof. Its value is forcing the
-#     tagger to look at the list — precisely what did not happen for v0.31.0 and
-#     v0.33.0.
+#   * It cannot verify the acknowledgement is TRUE. It requires a `Tag-Point:`
+#     trailer; a trailer saying "Tag-Point: whatever" passes. This is a speed
+#     bump against autopilot, not a proof. Its value is forcing the tagger to
+#     look at the list — precisely what did not happen for v0.31.0 and v0.33.0.
 #   * It cannot catch tagging a commit that is too NEW. Different failure.
 #   * It cannot catch work merged AFTER the tag. Nothing at tag time can, and
 #     step 2 deliberately stops trying.
-#   * It assumes tag dates and committer dates come from comparably-set clocks.
-#     They do here (one maintainer, one machine). A badly skewed clock would
-#     weaken step 2 in the PERMISSIVE direction — it under-reports, never
-#     over-reports.
+#   * On the first-parent spine it does not see commits that reached main other
+#     than through a merge or squash — a direct push to main. Branch protection
+#     forbids those.
 #
 # Usage:
 #   tools/ci/check-tag-point.sh v0.36.0     # explicit (backtesting, local runs)
@@ -74,13 +93,34 @@ if ! C="$(git rev-parse --verify --quiet "${TAG}^{commit}")"; then
   exit 2
 fi
 
-# `creatordate` is taggerdate for an annotated tag and committerdate for a
-# lightweight one. Releases here are signed annotated tags, but reading the
-# field that is defined for both means a lightweight tag degrades to a slightly
-# weaker check rather than to an empty `--before=`, which git would not reject.
-T="$(git for-each-ref "refs/tags/${TAG}" --format='%(creatordate:iso-strict)')"
+# A LIGHTWEIGHT TAG MAKES THIS GATE VACUOUS — it must be rejected, not tolerated.
+#
+# This header used to claim a lightweight tag "degrades to a slightly weaker
+# check". It degrades to NO check, and an audit demonstrated it on this repo:
+# the same commit tagged both ways gave FAIL (annotated) and PASS (lightweight).
+#
+# The mechanism: `creatordate` on a lightweight tag is the TAGGED COMMIT'S OWN
+# committer date. So `--before=T` asks for commits descended from C that predate
+# C — on a linear history, always empty. Unconditional PASS. Worse, the rule-4
+# grep reads `%(contents)`, which for a lightweight tag returns the COMMIT
+# message: the acknowledgement can be satisfied by text the tagger never wrote.
+#
+# The trigger is not exotic, it is the sloppier path: `git tag v0.36.0` instead
+# of `git tag -s v0.36.0`. The gate would disarm on exactly the mistake that
+# most needs gating. Repo policy is signed annotated tags regardless.
+OBJTYPE="$(git for-each-ref "refs/tags/${TAG}" --format='%(objecttype)')"
+if [ "${OBJTYPE}" != "tag" ]; then
+  echo "::error::${TAG} is a lightweight tag (objecttype=${OBJTYPE:-missing})."
+  echo "::error::This gate cannot evaluate one: its date is the tagged commit's"
+  echo "::error::own committer date, so the excluded set is always empty and the"
+  echo "::error::check silently passes whatever the tag point is."
+  echo "::error::Re-tag with a signed annotated tag:  git tag -s ${TAG}"
+  exit 1
+fi
+
+T="$(git for-each-ref "refs/tags/${TAG}" --format='%(taggerdate:iso-strict)')"
 if [ -z "${T}" ]; then
-  echo "::error::Could not read a creation date for ${TAG}."
+  echo "::error::Could not read a tagger date for ${TAG}."
   exit 2
 fi
 
@@ -94,7 +134,7 @@ if ! git merge-base --is-ancestor "${C}" origin/main; then
   exit 0
 fi
 
-EXCLUDED="$(git log --format='%h %ci %s' --before="${T}" "${C}..origin/main")"
+EXCLUDED="$(git log --first-parent --format='%h %ci %s' --before="${T}" "${C}..origin/main")"
 
 if [ -z "${EXCLUDED}" ]; then
   echo "PASS: ${TAG} at ${C} (${T}) — nothing predating the tag was left out."
@@ -103,9 +143,27 @@ fi
 
 COUNT="$(printf '%s\n' "${EXCLUDED}" | wc -l | tr -d ' ')"
 
-if git tag -l "${TAG}" --format='%(contents)' | grep -qiE 'tag[ -]point'; then
+# ANCHORED, NOT ANYWHERE. This was `grep -qiE 'tag[ -]point'` over the whole
+# message, which the same audit showed disarms itself: the commit that ADDS this
+# gate has the subject "ci(release): gate the tag point …", and release-notes tag
+# messages here list commit subjects verbatim (v0.35.0's does). So the first
+# release whose notes happen to quote that subject would auto-acknowledge — the
+# gate switching itself off with text nobody wrote as a statement.
+#
+# Anchoring to the start of a line separates the two cases exactly. A quoted
+# subject appears mid-line, after a short hash or a bullet; an acknowledgement is
+# something the tagger began a line with. Both spellings are accepted, because
+# the point is deliberateness, not syntax:
+#
+#     Tag-Point: bump commit abc1234 — held under the batching policy
+#     Tag point is the bump commit ff470a2, all 17 checks green.   <- v0.34.0
+#
+# Requiring the trailer form alone was tried and rejected: it fails v0.34.0,
+# whose acknowledgement is specific, deliberate, and correct. A gate that rejects
+# a real acknowledgement teaches people to route around it.
+if git tag -l "${TAG}" --format='%(contents)' | grep -qiE '^[[:space:]]*Tag[ -]point'; then
   echo "PASS (acknowledged): ${TAG} excludes ${COUNT} commit(s) that predate it,"
-  echo "and its message states the tag point:"
+  echo "and its message states the tag point on a line of its own:"
   printf '%s\n' "${EXCLUDED}" | sed 's/^/  excluded: /'
   exit 0
 fi
@@ -114,7 +172,13 @@ echo "::error::${TAG} was cut at ${C} (${T}), but ${COUNT} commit(s) were"
 echo "::error::already on main before that and are not in the release:"
 printf '%s\n' "${EXCLUDED}" | sed 's/^/::error::  /'
 echo "::error::"
-echo "::error::Either tag the tip of main, or state the tag point in the tag"
-echo "::error::message (e.g. \"Tag point is the bump commit abc1234; the tag was"
-echo "::error::deliberately held after the bump merged, under the batching policy.\")"
+echo "::error::Either tag the tip of main, or state the tag point at the START"
+echo "::error::of a line in the tag message, e.g.:"
+echo "::error::"
+echo "::error::  Tag point is the bump commit abc1234; the tag was deliberately"
+echo "::error::  held after the bump merged, under the batching policy."
+echo "::error::"
+echo "::error::Anchored, not anywhere: a mid-line mention (release notes quoting"
+echo "::error::a commit subject that contains the words) is not an acknowledgement"
+echo "::error::and no longer counts as one."
 exit 1

--- a/tools/ci/check-tag-point.sh
+++ b/tools/ci/check-tag-point.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Release-tag-point gate — issue #366.
+#
+# The failure this exists to catch: a release tag placed on a commit that is
+# *behind* main, silently excluding work that was already finished and merged.
+# It happened twice — v0.31.0 missed a parser fix by 5m06s, v0.33.0 excluded two
+# commits — and nothing in CI noticed either time.
+#
+# `check-versions` cannot catch it. That job measures the version *window*: it
+# asserts the tag matches Cargo.toml, and Cargo.toml reads X.Y.Z from the bump
+# commit until the next bump — a window that spans both the included and the
+# excluded commits. The invariant is circular with respect to the question.
+#
+# So this gate stops asking "which release does this commit belong to" (an
+# unanswerable question, whose answer would drift as unrelated commits land) and
+# asks the one that was actually at stake:
+#
+#   Is anything that was already finished being left out, and did you say so?
+#
+# Given tag vX.Y.Z at commit C with tag date T:
+#
+#   1. C not an ancestor of origin/main            -> skip (release-branch tag)
+#   2. enumerate C..origin/main, dated before T    -> the excluded set
+#   3. empty                                       -> pass
+#   4. non-empty, tag message states a tag point   -> pass, listing them
+#   5. non-empty, it does not                      -> fail, listing them
+#
+# Step 2's `--before=T` is what makes the gate both race-proof and idempotent.
+# Race-proof: a merge landing seconds after the tag push cannot fail the job,
+# because it postdates T. Idempotent: both inputs (the tag object, and the set
+# of commits dated before T that are reachable from main) are immutable, so a
+# re-run months later returns the same verdict. A gate whose answer changes as
+# unrelated commits land is not a gate.
+#
+# WHAT THIS DOES NOT DO — stated so it is not mistaken for coverage:
+#
+#   * It cannot verify the acknowledgement is TRUE. It greps the tag message for
+#     a stated tag point; a message saying "tag point: whatever" passes. This is
+#     a speed bump against autopilot, not a proof. Its value is forcing the
+#     tagger to look at the list — precisely what did not happen for v0.31.0 and
+#     v0.33.0.
+#   * It cannot catch tagging a commit that is too NEW. Different failure.
+#   * It cannot catch work merged AFTER the tag. Nothing at tag time can, and
+#     step 2 deliberately stops trying.
+#   * It assumes tag dates and committer dates come from comparably-set clocks.
+#     They do here (one maintainer, one machine). A badly skewed clock would
+#     weaken step 2 in the PERMISSIVE direction — it under-reports, never
+#     over-reports.
+#
+# Usage:
+#   tools/ci/check-tag-point.sh v0.36.0     # explicit (backtesting, local runs)
+#   tools/ci/check-tag-point.sh             # reads GITHUB_REF (CI)
+#
+# Exit: 0 pass or skip, 1 fail, 2 usage/environment error.
+
+set -euo pipefail
+
+TAG="${1:-}"
+if [ -z "${TAG}" ]; then
+  REF="${GITHUB_REF:-}"
+  case "${REF}" in
+    refs/tags/*) TAG="${REF#refs/tags/}" ;;
+    *)
+      echo "usage: $0 <tag>   (or set GITHUB_REF=refs/tags/vX.Y.Z)" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if ! C="$(git rev-parse --verify --quiet "${TAG}^{commit}")"; then
+  echo "::error::${TAG} does not resolve to a commit. If this is CI, the tag"
+  echo "::error::object was not fetched — the job needs fetch-depth: 0."
+  exit 2
+fi
+
+# `creatordate` is taggerdate for an annotated tag and committerdate for a
+# lightweight one. Releases here are signed annotated tags, but reading the
+# field that is defined for both means a lightweight tag degrades to a slightly
+# weaker check rather than to an empty `--before=`, which git would not reject.
+T="$(git for-each-ref "refs/tags/${TAG}" --format='%(creatordate:iso-strict)')"
+if [ -z "${T}" ]; then
+  echo "::error::Could not read a creation date for ${TAG}."
+  exit 2
+fi
+
+# Explicit refspec: do not rely on whatever remote.origin.fetch the checkout
+# action happened to configure. A missing refs/remotes/origin/main would make
+# the rev-list below fail loudly, but fetching it outright is one line.
+git fetch --no-tags --quiet origin "+refs/heads/main:refs/remotes/origin/main"
+
+if ! git merge-base --is-ancestor "${C}" origin/main; then
+  echo "${TAG} (${C}) is not an ancestor of origin/main — release-branch tag, skipping."
+  exit 0
+fi
+
+EXCLUDED="$(git log --format='%h %ci %s' --before="${T}" "${C}..origin/main")"
+
+if [ -z "${EXCLUDED}" ]; then
+  echo "PASS: ${TAG} at ${C} (${T}) — nothing predating the tag was left out."
+  exit 0
+fi
+
+COUNT="$(printf '%s\n' "${EXCLUDED}" | wc -l | tr -d ' ')"
+
+if git tag -l "${TAG}" --format='%(contents)' | grep -qiE 'tag[ -]point'; then
+  echo "PASS (acknowledged): ${TAG} excludes ${COUNT} commit(s) that predate it,"
+  echo "and its message states the tag point:"
+  printf '%s\n' "${EXCLUDED}" | sed 's/^/  excluded: /'
+  exit 0
+fi
+
+echo "::error::${TAG} was cut at ${C} (${T}), but ${COUNT} commit(s) were"
+echo "::error::already on main before that and are not in the release:"
+printf '%s\n' "${EXCLUDED}" | sed 's/^/::error::  /'
+echo "::error::"
+echo "::error::Either tag the tip of main, or state the tag point in the tag"
+echo "::error::message (e.g. \"Tag point is the bump commit abc1234; the tag was"
+echo "::error::deliberately held after the bump merged, under the batching policy.\")"
+exit 1


### PR DESCRIPTION
One branch carrying six reviewed PRs, because `main` has
`required_status_checks.strict = true` and this repo has no merge queue.
Under `strict`, the first merge advances `main` and every remaining PR must
update-branch and re-run all 18 required contexts. Six sequential merges is
six full CI rounds on an org-shared runner pool; this is one.

Most of this is not new work: six of the commits are the reviewed heads of
existing PRs, cherry-picked unmodified. Four additions arrived while the batch
was being assembled — a small change-filter fix (#379), a link that only became
addable once these landed together, and two gate repairs (#381, #383) that are
the substantive new items and are described below.

## What is in it

| commits | from | closes |
|---|---|---|
| `ci(fuzz): stop the scheduler_solver nightly OOMing on ASan bookkeeping` | #363 | #361 |
| `fix(rivet): stop double-loading safety/stpa …` + `correct the "loses nothing" claim` | #368 | #360 |
| `fix(artifacts): move 276 statuses onto rivet's lifecycle vocabulary` | #374 | #371 |
| `ci(release): gate the tag point …` + `a clean-room audit disarmed this gate three ways` | #376 | #366 |
| `fix(ci): gate required-context drift …` + `close four fail-open holes` | #377 | #372 |
| `fix(msrv): declare the Rust floor and gate it against the dependency closure` | #378 | — |
| `ci: allow-list rivet.yaml in the change filter` | new | #379 |
| `fix(artifacts): state the link that was deferred to avoid a flaky gate` | new | — |
| `fix(ci): the mutation gate reads a path cargo-mutants never writes` | new | #381 |
| `ci(fmt): check every workspace in the repo, and print how many` | new | refs #383 |

## The item that is not a cherry-pick: #381

`Mutation Testing` is a required status check. It runs for roughly three hours.
It has never once read its own results.

`cargo mutants --output DIR` creates `mutants.out` **inside** DIR, so the report
lands at `mutants-out/mutants.out/`. The gate read `mutants-out/missed.txt`, one
level up — a path that has never existed. `grep` failed into `|| echo 0`, the
`-f` test was false, `0 -gt 142` was false, exit 0. `git log -L` puts that read
path byte-identical since 563eb8c on 2026-03-22. Four months.

The proof is the job's own artifact. It uploads with `path: mutants-out/`, so the
artifact root *is* a listing of that directory — and it contains exactly one
entry, `mutants.out/`. Run 30563879100 (main @ `cd4d429`) uploaded **210
survivors against a threshold of 142** and reported green.

The tell was in the tree the whole time. 5d6d98a, 58 minutes after the gate went
hard:

> Current survivors: 142 (down from 220). Threshold will be lowered as tests
> improve. Target: 0.

That measurement was real and correct, and structurally impossible for CI to
have produced — CI was printing 0. Someone measured by hand, wrote the number
down, and shipped a gate that could not see it. Two numbers for one quantity sat
in the repository for four months and were never diffed. **That diff is now
automated**: the checker refuses to score a report whose `.txt` line counts
disagree with `outcomes.json`, so the only detector that would have worked from
day one is the one thing the gate can no longer skip.

Beyond the path, three changes, because a corrected path alone would still fail
open:

- **Absent report → fail.** The cargo-mutants step ends in `|| true` and the job
  runs on `lean-mem` because it is RAM-hungry, so "the run died" is expected —
  and it produces no files, which scores zero survivors, the best possible
  result. The whole reason this was invisible is that the error path yielded the
  ideal reading.
- **`caught == 0` → fail.** A report that exists but caught nothing means the
  suite never ran. Also scores zero survivors.
- **`timeout-minutes: 240`.** The job had none, inheriting GitHub's 6-hour
  default; the one run to reach `success` in the last 25 took 182.3 minutes.

**The logic is no longer in the workflow.** Inline shell in a YAML file is only
testable by pushing, which is exactly how a misread survived four months with
nobody able to run it against a report. It now lives in
`tools/check_mutants_report.py` with a **19-case decision table** that runs as
its own step *before* the gate — the same convention as the human-scoped,
required-context and MSRV guardrails already in this branch. The table's
load-bearing row is the #381 regression itself: a complete, valid set of outcome
files placed at the *shallow* path must exit 1. `mutants-weekly.yml` calls the
same script with `--summary-file`, so the nesting fact lives in one constant;
two copies of a path is how one gets fixed and the other does not.

`MAX_MISSED` is re-baselined **142 → 210**, the measured count on main. This
relaxes nothing that was ever in force — 142 was never enforced, so 210 is the
first value this gate has actually checked against. The 142 → 210 drift over four
blind months is precisely what a ratchet exists to prevent; #382 tracks walking
it back to zero and says not to raise it again.

`mutants-weekly.yml` had the same wrong path, where it rendered a summary table
of `0 missed / 0 caught / 0 unviable` — not merely wrong but impossible, since
zero caught *and* zero unviable would mean cargo-mutants found nothing to test.
It still read as a plausible table.

**This PR will be the first time the gate actually runs.** `crates/spar-analysis/`
is untouched between `cd4d429` and this branch's base, so 210 should hold; if it
comes in higher, that is the gate working and I will treat it as a finding rather
than adjust the number.

## What #381 turned up next: #383

#381 is not a mutation-testing bug. It is an instance of a property — *a check
whose "nothing happened" renders identically to "it worked"* — so all 18 required
contexts were audited against one question: **can this report success without
having measured the thing its name claims?** The audit is #386. It found 11 with
a path to green; four are live today. This branch fixes one of them.

`Format` runs `cargo fmt --all -- --check`. `--all` means "all members of *this*
workspace", not "all crates in the repo", and this repo has four workspaces — the
23-crate root plus `fuzz/`, `codegen-exec-oracle/` and `codegen-kiln-oracle/`,
each with its own `[workspace]` table. Two gates, one tree, opposite verdicts:

```
cargo fmt --all -- --check                                  -> 0
cargo fmt --manifest-path fuzz/Cargo.toml --all -- --check  -> 1   (13 diff lines)
```

The drift is tracked code: `fuzz/fuzz_targets/fuzz_codegen_roundtrip.rs:32`.
A required status check named `Format` has been green over unformatted Rust, and
nothing in CI has ever formatted `fuzz/`.

This one has no error path at all — cargo prints nothing on success, so 23-of-26
crates clean is byte-identical to 26-of-26 clean. The fix is therefore a
*mandated output* rather than a corrected path. `tools/check_fmt_workspaces.py`
discovers the workspace set, floors it at 4, and prints
`4 workspace(s) checked, 4 formatted.` on every path including success. **A count
is not producible by a broken scan** — that is the general fix #386 proposes, and
this is its first application outside #381.

Two details worth review attention:

- **Discovery, not a list.** Four hard-coded manifests would fix today's bug and
  re-open it the day someone adds a fifth workspace. The floor is what makes a
  discovery failure loud instead of green.
- **The prune list is load-bearing.** `target/` fills with vendored crates.io
  sources, many shipping their own `[workspace]` table. A naive walk on a machine
  that has built once finds dozens, clears the `>= 4` floor comfortably, and asks
  cargo to format other people's build cache. That bug *passes*, so it is two
  self-test rows rather than a comment.

`Clippy` has the identical `--workspace` gap and is **not** fixed here, so #383
stays open on that half.

**#369 stays open deliberately.** #378 discharges the gate but not the
nix-eval channel-rustc check it owes, which is blocked on #364 landing. The
commit carries no `Closes` for that reason.

## Why a merge commit rather than a squash

These are unrelated fixes with substantive rationale in their individual
messages; squashing them into one commit would discard that. Merge commits are
enabled on this repo, and the tag-point gate this PR *carries* walks
`--first-parent`, so the feature commits sit off the spine and only the merge
commit lands on it, dated at merge time — exactly the case its header
anticipates.

## Conflicts

Cherry-picking the nine cherry-picked commits in order produced **one** conflict:
a pure add/add in `.github/workflows/ci.yml` between #377's Required-context
guardrail steps and #378's MSRV guardrail steps. Resolved by keeping both, in the
order Human-scoped → Release-plane → Required-context → MSRV.

Worth recording that the earlier n-way *merge* of the same branches produced
**three**. A cherry-pick replays a patch against the accumulating tree, so each
earlier fix is already context when the next applies; an n-way merge reconciles
independent trees against one base, so every branch appending at the same anchor
collides with every other. Same content, different reconciliation, different
conflict count.

## The deferred link, now stated

`REQ-GUARD-STATUS-VOCAB-001` (from #374) deliberately omitted
`traces-to: REQ-GUARD-RELEASE-PLANE-001`, because that target artifact arrived
in a different unmerged PR and a `links:` target is resolved at validate time —
the link would have made the branch's oracle pass or fail depending on merge
order. A flaky gate is not a traceability improvement. Both artifacts are now
on `main` together, so the condition that forced the omission no longer holds
and the link is stated.

## Verification run locally before pushing

Exit codes captured from the commands themselves, not from a pipeline tail.

**Re-run on the rebased tree**, not carried over from the pre-rebase worktree.
That distinction mattered: `check_release_plane.py` did not exist on this branch
before the rebase (it arrives with #373), and one figure below moved — the
human-scoped artifact count went 887 → 888, because #373's merge added
`REQ-GUARD-RELEASE-PLANE-001`. Every number here is from the tree being pushed.

Five guardrail decision tables, 56 cases, all invoked **bare** (so the exec bit
is part of what is tested):

- `check_human_scoped.py --self-test` — 3 passed, exit 0
- `check_required_contexts.py --self-test` — 15 passed, exit 0
- `check_msrv.py --self-test` — 9 passed, exit 0
- `check_mutants_report.py --self-test` — 19 passed, exit 0
- `check_fmt_workspaces.py --self-test` — 10 passed, exit 0
- `check_release_plane.py --self-test` — 4 passed, exit 0

and `check_fmt_workspaces.py` bare against the rebased tree: `4 workspace(s)
checked, 4 formatted.`, exit 0 — the same command that exits 1 on `main`.

Then the same checkers against the real tree:

- `check_required_contexts.py` — scanned 21 PR-triggered jobs: 18 gateable,
  2 advisory, 1 undeliverable; 18 required contexts — PASS
- `check_msrv.py` — declared floor 1.89 (`[workspace.package]`, inherited by 23
  members), closure maximum 1.89 (set by `smol_str@0.3.6`; 152 of 212 declare
  one) — PASS
- `check_human_scoped.py` — 888 artifacts scanned, 6 human-scoped — exit 0
- `check_release_plane.py` — 11 files scanned, 88 `release:` keys on the artifact
  key plane that `rivet list --release` can see, **0** nested where it is blind —
  PASS. This is the post-#370 steady state measured on the merged tree: the 59
  misplaced assignments are gone and none came back through the rebase
- `check-tag-point.sh` backtested against real history: `v0.31.0` exit 1 and
  `v0.33.0` exit 1 (both historical misses correctly re-detected), `v0.34.0`
  exit 0 "PASS (acknowledged) … excludes 6 commit(s)", `v0.35.0` exit 0
  "nothing predating the tag was left out" — non-vacuous in both directions
- `rivet validate` — PASS, exit 0
- `#379` allow-list regex, extracted from the file rather than retyped, run over
  positive and negative controls: `rivet.yaml` allow-listed; `rivet.yaml.bak`,
  `subdir/rivet.yaml`, `myrivetXyaml`, `Cargo.toml`, `src/lib.rs` and
  `.github/workflows/ci.yml` all still classified as code
- the same classifier run over **this branch's own 43-file diff**: 35 code-ish,
  so `code=true` and the full suite runs — which is the reachability the two new
  checkers depend on, and `rivet.yaml` appears in the 43 but not in the 35, so
  the #379 commit is non-vacuous on the very PR that carries it
- `#381` both step bodies parsed out of the YAML with `yaml.safe_load` (not
  retyped) and executed against the real 15 MB artifact from run 30563879100:

  | input | new gate | old gate |
  |---|---|---|
  | no `mutants-out` at all (crashed / OOM run) | exit 1 | exit 0, "0 survivors" |
  | `mutants-out/` present, no `mutants.out/` | exit 1 | exit 0, "0 survivors" |
  | the real 210-missed / 603-caught report | exit 0, "Surviving mutants: 210" | **exit 0, "Surviving mutants: 0"** |
  | report present, `caught.txt` empty | exit 1 | exit 0, "0 survivors" |
  | 211 survivors — one over the threshold | exit 1 | exit 0, "0 survivors" |
  | weekly, no report | warns, omits the table | table of 0/0/0/0 |
  | weekly, real report | 210 / 603 / 2 / 793 | 0 / 0 / 0 / 0 |

  The third row is the one that matters: the old step body, taken verbatim from
  `origin/main` and handed the exact directory layout cargo-mutants produces,
  reports zero survivors and passes.

- `#383` the new checker run against the **real tree**, not only fixtures — on
  main's version of the fuzz target it exits 1 with `4 workspace(s) checked,
  3 formatted.` and reproduces the 13-line rustfmt diff; with `:32` reformatted
  it exits 0 with `4 workspace(s) checked, 4 formatted.`

**One assumption this PR's own CI is the measurement for:** the `fmt` job runs on
the `light` runner class, and it is the first `light` consumer of a
`tools/check_*.py` guardrail — the existing ones run on `rust-cpu` and
`lean-mem`. If `python3` is absent there the step exits 127 and the required
check goes red, which is the correct direction to fail; the job then moves to
`rust-cpu`.

Closes #360, #361, #366, #371, #372, #379, #381

Refs #383, #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
