### PR TITLE
plan(v0.36.0): scope the gate-evidence release and close two open V's

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3134,7 +3134,7 @@ artifacts:
       standard-property-backed base/size core first rather than over-claiming a
       register/binding convention that is not yet decided.
     status: proposed
-    release: v0.36.0
+    release: v0.37.0
     tags: [codegen, target-artifacts, hardware, wit]
     links:
       - type: traces-to
@@ -3266,7 +3266,7 @@ artifacts:
       the committed scheduling_verified.rs, so a regenerated recurrence that
       introduces a new multiplication cannot land silently.
     status: proposed
-    release: v0.36.0
+    release: v0.37.0
     tags: [proofs, ordeal, certificate, rta, overflow, v0360, human-scoped]
     links:
       - type: traces-to
@@ -4750,6 +4750,27 @@ artifacts:
       prints "Surviving mutants: 0" and exits 0. It uploaded 210 survivors against
       a threshold of 142 and reported green.
 
+      CORRECTION (2026-08-05), and it sharpens rather than weakens the case: run
+      30563879100 DID NOT FINISH. Its `outcomes.json` records `end_time: null`
+      and `total_mutants: 1608`, while the log shows cargo-mutants had found
+      1737 — it lost its per-worker source trees 3h02m in and `|| true` swallowed
+      the crash. So 210 is the survivor count of the 92% that ran, not of this
+      codebase; the completed run reports 292 (30586785648).
+
+      The phrase "each `wc -l` agreeing with `outcomes.json`" above is therefore
+      true and worth nothing. cargo-mutants writes `total_mutants` incrementally,
+      so a truncated report is INTERNALLY PERFECT — 210+603+793+2 == 1608 ==
+      total_mutants — and the cross-check obligation in (a), which is the right
+      detector for #381, is structurally blind to this. The discriminator is
+      `end_time`. That second blindness is tracked as #389 and is an obligation
+      of REQ-GUARD-GATE-EVIDENCE-002, not of this requirement: arming it against
+      a job that demonstrably crashes on one runner would make a required
+      context flap on infrastructure.
+
+      This correction is itself the requirement's own discipline applied to the
+      requirement: a number quoted as evidence, re-derived from the artifact
+      rather than re-read from the sentence that quoted it.
+
       THE TELL WAS IN THE TREE. 5d6d98a, 58 minutes after the gate went hard:
       "Current survivors: 142 (down from 220)." That measurement was real and
       correct, and structurally impossible for CI to have produced, because CI
@@ -4843,3 +4864,73 @@ artifacts:
     status: implemented
     release: v0.36.0
     tags: [process, guardrail, ci, tooling, mutation-testing, formatting]
+
+  - id: REQ-GUARD-GATE-EVIDENCE-002
+    type: requirement
+    title: A gate shall prove its measurement was COMPLETE, not merely present
+    description: >
+      Successor to REQ-GUARD-GATE-EVIDENCE-001, which took the two instances
+      known when it was written and said so ("two obligations, one per instance
+      found so far"). Six more were found on 2026-08-05 while landing #387 and
+      #364, and they are one species: -001 makes a gate prove it READ a
+      measurement; none of these gates fail to read one. They read a measurement
+      that did not cover what the gate's name claims, and every one of them
+      renders that shortfall as its IDEAL value.
+
+      (c) A TEST FILTER THAT MATCHES NOTHING SHALL NOT PASS. `cargo test -p X --
+      <filter>` exits 0 when the filter selects no tests, printing "0 passed; 0
+      failed; N filtered out". `tools/run_verification.py` scores a step by
+      `returncode == 0`, so a filter naming a test that does not exist is
+      indistinguishable from one naming a test that passes. Seven verification
+      artifacts cite tests that have never existed (#388); five are VAL-R1..R5,
+      `status: implemented`, closing the V for six RENDER-REQ-* and four ARCH-R*.
+      The gate shall assert a non-zero selected-test count, and a step whose
+      filter selects nothing shall fail.
+
+      (d) A CRASHED RUN SHALL NOT SCORE. cargo-mutants writes `total_mutants`
+      incrementally, so a run killed part-way is internally self-consistent:
+      run 30563879100 records 210+603+793+2 == 1608 == total_mutants and agrees
+      with `outcomes.json` on every count, while the log shows it had found 1737
+      and lost its worker trees 3h02m in. -001's cross-check obligation cannot
+      see this. The discriminator is `outcomes.json: end_time`, null on a
+      truncated run. A truncated run UNDER-reports survivors, so it fails
+      flatteringly, and any threshold derived from one is a ceiling set below
+      the floor (#389). Blocked on the runner-side `_tmp` reaping that causes
+      it — arming the detector alone would make a required context flap on
+      infrastructure.
+
+      (e) A CHANGE FILTER SHALL NOT FAIL OPEN. `Detect changed paths` gates 11
+      of the 18 required contexts via `if: needs.changes.outputs.code == 'true'`.
+      A job skipped by job-level `if:` reports `skipped`, and `skipped` SATISFIES
+      a required context. So a filter that wrongly reports "no code changed"
+      silently converts eleven gates into eleven passes (#384).
+
+      (f) AN EXEMPTION MECHANISM SHALL NOT EXEMPT EVERYTHING. The Lean "fail on
+      sorry" gate enforces zero un-exempted obligations, and all twelve `sorry`s
+      are self-exempted, so the gate is satisfied by the thing it exists to
+      prevent (#385). The exemption list shall be a declared floor that shrinks,
+      and the gate shall print the exempted count on every path.
+
+      (g) A SCOPE SHALL BE DISCOVERED, NOT INHERITED — FOR EVERY TOOL, NOT ONE.
+      -001(b) fixed this for `cargo fmt`; `cargo clippy --all-targets` inherits
+      the same default and covers 1 of the repo's 4 workspaces (#383, Clippy
+      half). The workspace discovery in `tools/check_fmt_workspaces.py` is the
+      mechanism; the obligation is that every whole-repo tool uses it.
+
+      (h) A TARGET LIST SHALL BE ASSERTED AGAINST ITS DECLARATION. `fuzz-nightly`
+      names its three targets in three hand-written steps. A target removed from
+      the workflow, or added to `fuzz/Cargo.toml` and not to the workflow, leaves
+      the job green having fuzzed a strict subset. The set run shall be asserted
+      equal to the set declared.
+
+      THE COMMON SHAPE, stated once because it is the reason these are one
+      requirement and not six: an operation that can produce "nothing happened"
+      must render differently from "it worked". Absent report, unmatched filter,
+      unread directory, killed process, skipped job, self-granted exemption,
+      dropped target — each decays into the metric's best value. The detector is
+      always the same: distinct inputs must produce distinct outputs. A guard
+      whose ERROR path yields its IDEAL reading is unfalsifiable by construction,
+      and no amount of watching it pass distinguishes clean from blind.
+    status: proposed
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling, human-scoped]

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4127,6 +4127,61 @@ artifacts:
       - type: verifies
         target: REQ-GUARD-HUMAN-SCOPED-001
 
+  - id: TEST-GUARD-RELEASE-PLANE
+    type: feature
+    title: Release-plane guardrail is proven able to fail before it is allowed to judge
+    description: >
+      Closes the right side of the V for REQ-GUARD-RELEASE-PLANE-001, which had
+      a working oracle in CI and no verification artifact pointing at it — the
+      implementation was gated, the TRACE was not, so a rivet query for the
+      requirement's evidence returned nothing.
+
+      `tools/check_release_plane.py --self-test` runs first (ci.yml:520-526) and
+      the gate itself second (ci.yml:527). Ordering is the point, and it is the
+      same ordering the mutants and fmt guardrails use: the self-test exercises
+      the decision table, including a fixture where `release:` sits on the plane
+      rivet does NOT read, so a refactor that stopped detecting the misplacement
+      fails on the fixture rather than passing vacuously over real artifacts.
+
+      NOT claimed: that the checker sees every way a `release:` can be
+      misplaced. #375 records a live gap — its FIELD constant matches a
+      top-level `release:` but not one nested in a `fields:` bag, and there are
+      six such cases in `safety/stpa/architecture.yaml`. That is scoped as its
+      own work, not silently folded in here.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling]
+
+  - id: TEST-GUARD-STATUS-VOCAB
+    type: feature
+    title: rivet validate is shown to REJECT an off-vocabulary status, not merely to accept a good one
+    description: >
+      Closes the right side of the V for REQ-GUARD-STATUS-VOCAB-001.
+
+      This requirement has no dedicated checker — unlike every other guardrail
+      in v0.36.0, there is no `tools/check_status_vocab.py`. Its only oracle is
+      `rivet validate (artifacts)`, a required context. That makes the usual
+      evidence ("the gate is green") worth nothing on its own: green is also
+      what a validator that ignores the `status` field would print, and #371
+      existed precisely because 276 off-vocabulary statuses sat in the tree
+      while that context was green — they were on `feature.status`, a plane the
+      validator's query surface did not reach.
+
+      So the evidence must be a MUTATION, not an observation. Inject a single
+      off-vocabulary `status:` (e.g. `passing`, one of the values #371 removed)
+      into a scratch copy of an artifact file, run the CI-pinned rivet against
+      it, and require a non-zero exit naming the offending value; then remove it
+      and require zero. Distinct inputs, distinct outputs. Asserting only the
+      second half is what four months of #381 looked like.
+
+      Pinned rivet, deliberately: the local toolchain is version-skewed against
+      the gate (local v0.15.0 reports a NO-GO with 440 errors where the CI-pinned
+      v0.4.3 is green), so a mutation checked against the wrong binary proves
+      nothing about the gate.
+    status: proposed
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling]
+
   - id: TEST-GUARD-GATE-EVIDENCE
     type: feature
     title: The mutation gate fails on absence, on a report that measured nothing, and on self-disagreement


### PR DESCRIPTION
Release planning for **v0.36.0**, driven from rivet's `release:` field rather than a milestone. No code changes — artifacts only.

## What planning actually found

v0.36.0 already held six artifacts. The work was determining what blocks the four `implemented` ones from `verified`, and two things did.

**Two requirements had no verification artifact at all.** `REQ-GUARD-RELEASE-PLANE-001` and `REQ-GUARD-STATUS-VOCAB-001` were referenced by nothing in `artifacts/verification.yaml`. Both would have been flipped to `verified` at release time on the strength of "the gate is green" — which is the assertion this entire release exists to reject.

| | oracle | gap |
|---|---|---|
| `REQ-GUARD-RELEASE-PLANE-001` | `check_release_plane.py`, self-test `ci.yml:520-526` + gate `:527` | trace only — bookkeeping |
| `REQ-GUARD-STATUS-VOCAB-001` | **none** — only `rivet validate` | real: nothing proves rivet *rejects* a bad status |

The second is the interesting one. There is no `check_status_vocab.py`, so "the gate is green" proves nothing — green is also what a validator blind to the field would print, and that is exactly what #371 *was*: 276 off-vocabulary statuses under a green required context, on a plane the query surface never reached. So `TEST-GUARD-STATUS-VOCAB` specifies a **mutation**, not an observation: inject `status: passing`, require non-zero; remove it, require zero. Left `proposed` — that test does not exist yet.

## Scope

**v0.36.0 — "A gate shall prove it measured something"**

- `REQ-GUARD-HUMAN-SCOPED-001` · `REQ-GUARD-RELEASE-PLANE-001` · `REQ-GUARD-STATUS-VOCAB-001` · `REQ-GUARD-GATE-EVIDENCE-001` — all `implemented`, all landed
- **`REQ-GUARD-GATE-EVIDENCE-002`** (new) — six instances found 2026-08-05: vacuous test filters (#388), crashed mutants run scoring as good (#389), changed-paths failing open across 11 of 18 required contexts (#384), a Lean sorry gate whose twelve obligations are all self-exempted (#385), clippy inheriting the scope fmt was fixed for (#383), and a fuzz target list of three hand-written steps

A successor rather than an amendment: -001 says *"two obligations, one per instance found so far"* and is about to be verified on already-executed evidence. Appending would un-verify proven work.

**Deferred to v0.37.0, deliberately:** `REQ-PROOF-RTA-OVERFLOW-001` (the re-aimed ordeal beachhead — ordeal is not yet a Cargo dependency, so it needs the integration + cargo-vet exemption + QF_BV encoding of the 42 arithmetic sites in `scheduling_verified.rs`) and `REQ-CODEGEN-TARGET-ARTIFACTS-002`. Holding four finished guardrails behind an unstarted feature is the wrong trade. Bumping `release:` is the scope decision; the commit is its log.

## A correction to -001's own evidence

It cites run 30563879100: *"210 missed, 603 caught, 793 unviable, 2 timeout, each `wc -l` agreeing with `outcomes.json`"*.

**That run did not finish** — `end_time: null`, 1608 of the 1737 mutants it had found. 210 is the survivor count of the 92% that ran; the completed run reports 292.

The agreement it cites as proof is the tell. cargo-mutants writes `total_mutants` incrementally, so a truncated report is internally perfect — `210+603+793+2 == 1608 == total_mutants` — and -001's cross-check obligation, the correct detector for #381, is structurally blind to it. Its case against #381 is untouched; the number quoted beside it was not what it looked like. Re-derived from the artifact rather than re-read from the sentence that quoted it.

## Verified locally

- YAML parses; **0 duplicate ids across 433 artifacts** (the #360 trap)
- All six guardrail self-tests pass
- Both real gates green on the edited tree: release-plane `90 on-plane / 0 nested`, human-scoped `433 scanned, 7 tagged`

Refs #375, #383, #384, #385, #388, #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)