### PR TITLE
feat(guard): fail a verification step whose test filter selects nothing (#388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,20 @@ jobs:
         # not discriminate on plane at all. Mutation-tested: each of the four
         # fixtures kills exactly one guard, and deleting any guard reds this.
         run: tools/check_release_plane.py --self-test
+      # REQ-GUARD-GATE-EVIDENCE-002 (c). Self-test first, same reason as
+      # every guardrail above it: the decision table includes the #388
+      # regression (a filter selecting nothing must FAIL) and the pair that
+      # makes it a detector rather than an assertion — the SAME step passes as
+      # `proposed` and fails as `implemented`. A checker that ignored status
+      # would pass one and not the other, so the pair pins the semantics.
+      - name: Verification-filter guardrail self-test
+        run: tools/check_verification_filters.py --self-test
+      # The gate needs a real test inventory, which needs a build. It reuses
+      # the `test` job's cache rather than building its own; if the inventory
+      # comes back empty it exits 2 (broken scan) instead of reporting that
+      # every filter is vacuous.
+      - name: Verification-filter guardrail
+        run: tools/check_verification_filters.py
       - name: Release-plane guardrail
         run: |
           tools/check_release_plane.py \

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -266,6 +266,7 @@ artifacts:
         target: STPA-REQ-001
 
   - id: TEST-STPA-PARSER-COVERAGE
+    status: proposed
     type: feature
     title: Parser production coverage tests (STPA-REQ-003)
     description: >
@@ -391,7 +392,7 @@ artifacts:
 
   - id: VAL-R1
     type: feature
-    status: implemented
+    status: proposed
     verifies: [RENDER-REQ-004]
     title: Layout determinism tests (RENDER-REQ-004)
     description: >
@@ -410,7 +411,7 @@ artifacts:
 
   - id: VAL-R2
     type: feature
-    status: implemented
+    status: proposed
     verifies: [RENDER-REQ-001]
     title: Orthogonal routing tests (RENDER-REQ-001)
     description: >
@@ -429,7 +430,7 @@ artifacts:
 
   - id: VAL-R3
     type: feature
-    status: implemented
+    status: proposed
     verifies: [RENDER-REQ-002]
     title: Port positioning tests (RENDER-REQ-002)
     description: >
@@ -448,7 +449,7 @@ artifacts:
 
   - id: VAL-R4
     type: feature
-    status: implemented
+    status: proposed
     verifies: [RENDER-REQ-003, RENDER-REQ-005]
     title: HTML interactive feature tests (RENDER-REQ-003, RENDER-REQ-005)
     description: >
@@ -469,7 +470,7 @@ artifacts:
 
   - id: VAL-R5
     type: feature
-    status: implemented
+    status: proposed
     verifies: [RENDER-REQ-006]
     title: Semantic zoom tests (RENDER-REQ-006)
     description: >
@@ -3135,7 +3136,7 @@ artifacts:
     fields:
       method: automated-test
       steps:
-        - run: cargo test -p spar-trace-topology --lib -- identity::tests
+        - run: cargo test -p spar-trace-topology --lib -- identity_unknown
     status: implemented
     tags: [trace-topology, properties, identity, ip, v0100]
     links:
@@ -4126,6 +4127,47 @@ artifacts:
         target: REQ-GUARD-HUMAN-SCOPED-001
       - type: verifies
         target: REQ-GUARD-HUMAN-SCOPED-001
+
+  - id: TEST-GUARD-VERIFICATION-FILTERS
+    type: feature
+    title: A verification step whose test filter selects nothing is proven to fail
+    description: >
+      Verifies REQ-GUARD-GATE-EVIDENCE-002 (c).
+
+      `tools/check_verification_filters.py --self-test` runs a 13-case decision
+      table before the gate is allowed to judge anything, including the #388
+      regression itself: a filter selecting no test, on an artifact claiming
+      `implemented`, must exit 1.
+
+      The case that makes it a detector rather than an assertion is the PAIR —
+      the identical step passes as `proposed` and fails as `implemented`.
+      Distinct inputs, distinct outputs. A checker that ignored status would
+      give the same verdict to both, and the accept-half alone would not notice.
+
+      A missing `status:` fails closed rather than being read as "not
+      claiming", which is the leniency that would otherwise reopen the hole:
+      TEST-STPA-PARSER-COVERAGE had no status at artifact indent and would have
+      been exempted by its own malformedness.
+
+      The decision procedure is libtest's, not an approximation: filters are
+      substring matches over the full test path, so the gate collects the
+      inventory once via `cargo test --workspace --all-targets -- --list` and
+      answers every filter in memory. An empty inventory exits 2 — a broken
+      scan is not the finding that all 79 filters are vacuous.
+
+      MEASURED on 2026-08-05 against 3147 test names: 8 filters selected
+      nothing. One (TEST-TRACE-TOPOLOGY-IP-IDENTITY, `identity::tests`) named a
+      module path that does not exist while six real tests sat under
+      `engine::tests::identity_unknown_*` — fixed. The other seven have no
+      candidate test anywhere in the workspace and are now `proposed`, which is
+      what they always were.
+
+      NOT claimed: that a selected test is the RIGHT test. A filter may select
+      something unrelated to the requirement. This is a lower bound on honesty,
+      not a proof of relevance.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling]
 
   - id: TEST-GUARD-RELEASE-PLANE
     type: feature

--- a/tools/check_verification_filters.py
+++ b/tools/check_verification_filters.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Fail when a verification step's test filter selects no tests.
+
+REQ-GUARD-GATE-EVIDENCE-002 (c).
+
+WHY THIS EXISTS
+===============
+
+`cargo test -p X -- some_filter` EXITS 0 WHEN THE FILTER MATCHES NOTHING. It
+prints
+
+    running 0 tests
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out
+
+and returns success. `tools/run_verification.py` scores a step with
+
+    return proc.returncode == 0
+
+and sends both streams to DEVNULL, so a filter naming a test that does not
+exist is indistinguishable from one naming a test that passes. The V closes on
+paper either way.
+
+This is not hypothetical. Executed on 2026-07-30:
+
+    $ cargo test -p spar-wasm -- layout_is_deterministic
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out
+    EXIT=0
+
+VAL-R1..VAL-R5 are `status: implemented` and between them close the V for six
+`RENDER-REQ-*` and four `ARCH-R*`. Every one of their filters selects nothing.
+
+The shape is the one REQ-GUARD-GATE-EVIDENCE-001 names: the error path produces
+the ideal reading. "No tests matched" and "all matched tests passed" are the
+same exit code, and the second is the better-looking of the two.
+
+HOW IT DECIDES
+==============
+
+libtest's filter is a SUBSTRING match over the full test path (`--exact` opts
+out; nothing here uses it). So the question "does this filter select anything?"
+is answerable exactly, without running any test, given the inventory of test
+names — which `cargo test -- --list` prints as
+
+    module::tests::name: test
+
+The inventory is collected once per invocation and every filter is checked
+against it in memory. That keeps the check O(one build) rather than O(149
+cargo invocations), and makes the decision procedure identical to libtest's
+rather than an approximation of it.
+
+A filter that selects nothing fails, naming the artifact, the step and the
+filter. A count is printed on every path, success included — for the same
+reason `check_fmt_workspaces.py` prints one: a gate that says nothing on
+success cannot distinguish "checked everything" from "checked nothing".
+
+WHAT IT DOES NOT CLAIM
+======================
+
+* It does not check that the selected tests PASS. That is
+  `run_verification.py`'s job and it does it correctly. This answers only the
+  prior question — whether there was anything to run.
+* A non-empty selection does not mean the right test. A filter may select a
+  test that has nothing to do with the requirement. This is a lower bound on
+  honesty, not a proof of relevance.
+* Steps that are not `cargo test` (scripts, `lake`, shell) are counted and
+  reported as unclassified rather than silently ignored. Silence is what this
+  file exists to remove.
+
+stdlib-only: no workflow in this repo installs a Python package, and a required
+check that depends on an unverified runner package is a check that can fail to
+run — which reads as approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# `- run: <cmd>` inside a verification artifact's steps list.
+_RUN = re.compile(r"^\s*-\s+run:\s*(?P<cmd>.+?)\s*$", re.M)
+# `  - id: <ID>` at artifact level.
+_ID = re.compile(r"^  - id:\s*(?P<id>\S+)\s*$", re.M)
+# `    status: <value>` at artifact level.
+_STATUS = re.compile(r"^    status:\s*(?P<status>\S+)\s*$", re.M)
+# Statuses that ASSERT the evidence exists. A `proposed` or `draft` artifact
+# naming a test that does not exist yet is a plan, not a false claim, and
+# failing it would push authors to write the artifact only after the test —
+# which inverts the order this methodology depends on. `rejected` and
+# `withdrawn` assert nothing.
+_CLAIMING = {"implemented", "verified", "accepted"}
+# `cargo test [-p PKG] [...] -- FILTER [more]`. The filter is the first
+# non-flag token after the bare `--`.
+_CARGO_TEST = re.compile(r"\bcargo\s+test\b")
+# `path::to::test_name: test` from `cargo test -- --list`.
+_LIST_LINE = re.compile(r"^(?P<name>\S+):\s+test\s*$", re.M)
+
+
+def parse_steps(yaml_text: str) -> list[tuple[str, str, str]]:
+    """[(artifact_id, status, run_cmd)] in file order, without a YAML dependency.
+
+    Deliberately narrow, and it FAILS rather than guesses: every `- run:` is
+    attributed to the most recent `  - id:` above it, and a `- run:` appearing
+    before any id is an error, not an orphan silently dropped.
+    """
+    marks = [(m.start(), "id", m.group("id")) for m in _ID.finditer(yaml_text)]
+    marks += [(m.start(), "status", m.group("status")) for m in _STATUS.finditer(yaml_text)]
+    marks += [(m.start(), "run", m.group("cmd")) for m in _RUN.finditer(yaml_text)]
+    marks.sort()
+    out: list[tuple[str, str, str]] = []
+    current: str | None = None
+    status = "<none>"
+    pending: list[tuple[str, str]] = []
+    for _pos, kind, val in marks:
+        if kind == "id":
+            out.extend((aid, status, cmd) for aid, cmd in pending)
+            pending = []
+            current, status = val, "<none>"
+        elif kind == "status":
+            status = val
+        elif current is None:
+            raise ValueError(f"`- run: {val}` appears before any artifact id")
+        else:
+            pending.append((current, _unquote(val)))
+    out.extend((aid, status, cmd) for aid, cmd in pending)
+    return out
+
+
+def _unquote(val: str) -> str:
+    """Strip YAML's surrounding quotes from a scalar.
+
+    Steps in this repo are quoted deliberately: an unquoted `- run:` ending in
+    `plp::` breaks serde_yaml, so several steps are written
+    `- run: "cargo test -p spar-network --lib -- cqf"`.
+
+    Without this, the regex hands back a command whose last token is `cqf"` and
+    the filter check reports a vacuous filter for a step that is fine. The
+    first run of this gate did exactly that for 8 of the 18 it flagged — a
+    detector manufacturing findings out of its own misparse, which is the same
+    species as everything it was written to catch. Only the direction of the
+    error differed: it failed loudly rather than flatteringly, which is the one
+    reason it was caught in the first read.
+    """
+    v = val.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+        return v[1:-1]
+    return v
+
+
+def extract_filter(cmd: str) -> tuple[str | None, str | None]:
+    """(package, filter) for a cargo-test command; (None, None) otherwise.
+
+    Returns (pkg, None) when the command runs a whole package with no filter —
+    that selects everything, so it can never be vacuous in this sense.
+    """
+    if not _CARGO_TEST.search(cmd):
+        return (None, None)
+    toks = cmd.split()
+    pkg = None
+    for i, t in enumerate(toks):
+        if t in ("-p", "--package") and i + 1 < len(toks):
+            pkg = toks[i + 1]
+        elif t.startswith("--package="):
+            pkg = t.split("=", 1)[1]
+    if "--" not in toks:
+        return (pkg, None)
+    tail = toks[toks.index("--") + 1 :]
+    for t in tail:
+        if not t.startswith("-"):
+            return (pkg, t)
+    return (pkg, None)
+
+
+def collect_inventory(manifest_dir: Path) -> set[str]:
+    """Every test name cargo knows about, via `cargo test -- --list`."""
+    proc = subprocess.run(
+        ["cargo", "test", "--workspace", "--all-targets", "--", "--list"],
+        cwd=manifest_dir,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "cargo test --list failed; cannot build a test inventory, so no "
+            "filter can be judged. Refusing to report success.\n"
+            + proc.stderr[-2000:]
+        )
+    return {m.group("name") for m in _LIST_LINE.finditer(proc.stdout)}
+
+
+def check(yaml_path: Path, inventory: set[str], out=sys.stdout) -> int:
+    steps = parse_steps(yaml_path.read_text(encoding="utf-8"))
+    filtered: list[tuple[str, str, str, str]] = []
+    whole_pkg = 0
+    other = 0
+    for aid, status, cmd in steps:
+        pkg, filt = extract_filter(cmd)
+        if pkg is None and filt is None:
+            other += 1
+        elif filt is None:
+            whole_pkg += 1
+        else:
+            filtered.append((aid, status, cmd, filt))
+
+    empty = [
+        (aid, status, cmd, filt)
+        for aid, status, cmd, filt in filtered
+        if not any(filt in name for name in inventory)
+    ]
+    # `<none>` is NOT lenient. An artifact whose status this reader cannot find
+    # is unclassifiable, and an unclassifiable artifact with a filter that
+    # selects nothing is exactly the case that must not pass quietly. Same
+    # fail-closed rule check_required_contexts.py uses for input its narrow
+    # parser cannot represent. TEST-STPA-PARSER-COVERAGE is the live instance:
+    # no `status:` at artifact indent, its fields nested a level deeper.
+    vacuous = [e for e in empty if e[1] in _CLAIMING or e[1] == "<none>"]
+    planned = [e for e in empty if e[1] not in _CLAIMING and e[1] != "<none>"]
+
+    print("== verification-filter guardrail ==", file=out)
+    print(f"steps read:               {len(steps)}", file=out)
+    print(f"  cargo test + filter:    {len(filtered)}", file=out)
+    print(f"  cargo test, whole pkg:  {whole_pkg}", file=out)
+    print(f"  not a cargo test:       {other}", file=out)
+    print(f"test names in inventory:  {len(inventory)}", file=out)
+    print(f"filters selecting nothing: {len(empty)}", file=out)
+    print(f"  claiming evidence (FAIL): {len(vacuous)}", file=out)
+    print(f"  proposed/draft (ok):      {len(planned)}", file=out)
+
+    if not inventory:
+        print(
+            "::error::the test inventory is empty, so every filter would look "
+            "vacuous. That is a broken scan, not a finding.",
+            file=out,
+        )
+        return 2
+
+    for aid, status, cmd, filt in planned:
+        print(f"  note: {aid} ({status}) plans a test that does not exist yet: {filt!r}", file=out)
+
+    if vacuous:
+        print("", file=out)
+        for aid, status, cmd, filt in vacuous:
+            print(f"::error::{aid} (status={status}): filter {filt!r} selects no test", file=out)
+            print(f"    step: {cmd}", file=out)
+        print(
+            "\nA filter that matches nothing exits 0. These steps have been "
+            "scored as passing without running anything.",
+            file=out,
+        )
+        return 1
+
+    print(
+        f"\nAll {len(filtered) - len(planned)} evidence-claiming filtered steps "
+        f"select at least one test.",
+        file=out,
+    )
+    return 0
+
+
+def self_test() -> int:
+    """Decision table. Includes the #388 regression itself."""
+    import io
+
+    passed = failed = 0
+
+    def case(desc: str, want: int, yaml_text: str, inv: set[str]) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "v.yaml"
+            p.write_text(yaml_text, encoding="utf-8")
+            buf = io.StringIO()
+            got = check(p, inv, out=buf)
+        if got == want:
+            passed += 1
+            print(f"  ok   {desc}")
+        else:
+            failed += 1
+            print(f"  FAIL {desc}: got {got}, want {want}")
+            for line in buf.getvalue().splitlines()[:6]:
+                print(f"         {line}")
+
+    INV = {"render::tests::render_basic_aadl", "graph::tests::test_graph_with_connections"}
+
+    Y_GOOD = """artifacts:
+  - id: TEST-OK
+    status: implemented
+    fields:
+      steps:
+        - run: cargo test -p spar-wasm -- render_basic
+"""
+    Y_BAD = """artifacts:
+  - id: VAL-R1
+    status: implemented
+    fields:
+      steps:
+        - run: cargo test -p spar-wasm -- layout_is_deterministic
+"""
+    Y_PLANNED = """artifacts:
+  - id: VAL-FUTURE
+    status: proposed
+    fields:
+      steps:
+        - run: cargo test -p spar-wasm -- not_written_yet
+"""
+    Y_WHOLE = """artifacts:
+  - id: TEST-WHOLE
+    status: implemented
+    fields:
+      steps:
+        - run: cargo test -p spar-parser
+"""
+    Y_OTHER = """artifacts:
+  - id: TEST-SCRIPT
+    status: implemented
+    fields:
+      steps:
+        - run: tools/check_msrv.py --self-test
+"""
+    Y_MIXED = Y_GOOD + Y_BAD.replace("artifacts:\n", "")
+
+    print("check_verification_filters self-test")
+    # The bug itself.
+    case("REGRESSION #388: filter selecting nothing must FAIL", 1, Y_BAD, INV)
+    # Normal operation.
+    case("filter selecting a real test passes", 0, Y_GOOD, INV)
+    case("whole-package step is never vacuous", 0, Y_WHOLE, INV)
+    case("non-cargo step is counted, not judged", 0, Y_OTHER, INV)
+    case("one good + one vacuous still fails", 1, Y_MIXED, INV)
+    # Broken scan must not read as clean.
+    case("empty inventory is a broken scan, not a pass", 2, Y_GOOD, set())
+    # Status semantics: a plan is not a false claim.
+    case("proposed artifact planning a future test PASSES", 0, Y_PLANNED, INV)
+    case("NO status is unclassifiable, so it fails closed", 1,
+         Y_PLANNED.replace("    status: proposed\n", ""), INV)
+    case("...but the SAME step claiming implemented FAILS", 1,
+         Y_PLANNED.replace("proposed", "implemented"), INV)
+    # Substring semantics, which is what libtest does.
+    case("filter matching as a SUBSTRING passes", 0,
+         Y_GOOD.replace("render_basic", "basic_aadl"), INV)
+    case("near-miss substring still fails", 1,
+         Y_GOOD.replace("render_basic", "render_basicX"), INV)
+    # A QUOTED step is YAML syntax, not part of the filter. The first run of
+    # this gate flagged 8 steps as vacuous purely because the closing quote was
+    # read as the last character of the filter (`cqf"` instead of `cqf`).
+    # Without this case the parser could regress to that and the suite would
+    # still be green, because every other fixture here is unquoted.
+    Y_QUOTED = """artifacts:
+  - id: TEST-QUOTED
+    status: implemented
+    fields:
+      steps:
+        - run: "cargo test -p spar-wasm --lib -- render_basic"
+"""
+    case("double-quoted step: quotes are YAML, not filter", 0, Y_QUOTED, INV)
+    case("single-quoted step: same", 0,
+         Y_QUOTED.replace('"cargo', "'cargo").replace('basic"', "basic'"), INV)
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--verification", default="artifacts/verification.yaml")
+    ap.add_argument("--manifest-dir", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument(
+        "--inventory-json",
+        help="read the test inventory from a JSON array instead of running cargo",
+    )
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    if a.inventory_json:
+        inv = set(json.loads(Path(a.inventory_json).read_text(encoding="utf-8")))
+    else:
+        inv = collect_inventory(Path(a.manifest_dir))
+    return check(Path(a.verification), inv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**REQ-GUARD-GATE-EVIDENCE-002 (c)** — first obligation of the v0.36.0 bug-fix track (plan: #392).

## The defect

`cargo test -p X -- some_filter` **exits 0 when the filter matches nothing**:

```
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out
```

and `run_verification.py` scores a step with `proc.returncode == 0`, both streams to `DEVNULL`. A filter naming a test that does not exist is indistinguishable from one naming a test that passes. The V closes on paper either way — the error path produces the ideal reading.

## Measured, not estimated

Against a real inventory of **3147** test names: **8 of 79** filtered steps select nothing.

| artifact | filter | disposition |
|---|---|---|
| `TEST-TRACE-TOPOLOGY-IP-IDENTITY` | `identity::tests` | **fixed** → `identity_unknown`, selects 6 |
| `VAL-R1`…`VAL-R5` | render filters | no candidate anywhere → `implemented` → `proposed` |
| `VAL-MCP-001`, `TEST-STPA-PARSER-COVERAGE` | `mcp`, `production_` | no candidate anywhere → `proposed` |

`VAL-R1..R5` were `implemented` and between them closed the V for six `RENDER-REQ-*` and four `ARCH-R*`. The `identity` one named a module path that does not exist while six real tests sat under `engine::tests::identity_unknown_*`.

## How it decides

libtest's filter is a **substring match** over the full test path, so the gate collects the inventory once via `cargo test --workspace --all-targets -- --list` and answers every filter in memory — libtest's own decision procedure, not a heuristic, and one build instead of 79 cargo invocations. An empty inventory exits **2**: a broken scan is not the finding that all 79 filters are vacuous.

**A `proposed` artifact naming a future test passes.** It is a plan, not a false claim; failing it would push authors to write the artifact only *after* the test, inverting the order this methodology depends on. **A missing status fails closed** — `TEST-STPA-PARSER-COVERAGE` had no `status:` at artifact indent and would otherwise have been exempted by its own malformedness.

13-case self-test runs *before* the gate judges anything. The case that makes it a detector rather than an assertion is the **pair**: the identical step passes as `proposed` and fails as `implemented`. A checker ignoring status returns the same verdict for both, and the accept-half alone would never notice.

## The gate's first run was wrong, and that is in the commit message

It reported **18** vacuous filters. Eight were its own misparse: steps here are quoted deliberately (an unquoted `- run:` ending in `plp::` breaks `serde_yaml`), and the regex read the closing quote as part of the filter — `cqf"` instead of `cqf`. A detector manufacturing findings from its own parse: the same species as everything it exists to catch, differing only in that it failed *loudly* rather than flatteringly, which is the sole reason it was caught on first read. `_unquote` fixes it; two self-test cases pin it, since every other fixture in the table is unquoted.

## Verified

- 13/13 self-test
- gate exits 0 on the corrected tree — 0 claiming evidence, 7 honestly `proposed`
- all seven guardrail self-tests pass; human-scoped and release-plane gates still pass on the edited artifacts

Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)