### PR TITLE
feat(guard): clippy every workspace, and assert the fuzz target set (#383, #390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,16 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      # REQ-GUARD-GATE-EVIDENCE-002 (g), the clippy half of #383.
+      # `cargo clippy --workspace` means "all members of THIS workspace" — the
+      # same scope `cargo fmt --all` had — so this linted 1 of the repo's 4
+      # workspaces and reported green for all of them. The checker reuses
+      # check_fmt_workspaces' discovery rather than copying it: one definition,
+      # two callers, because a fact duplicated in two files is what made #381
+      # possible. Self-test first, same as every guardrail here.
+      - name: Clippy-scope guardrail self-test
+        run: tools/check_clippy_workspaces.py --self-test
+      - run: tools/check_clippy_workspaces.py
 
   # ── Tests ─────────────────────────────────────────────────────────────
   test:
@@ -538,6 +547,16 @@ jobs:
       # every filter is vacuous.
       - name: Verification-filter guardrail
         run: tools/check_verification_filters.py
+      # REQ-GUARD-GATE-EVIDENCE-002 (h). fuzz-nightly names its targets in a
+      # hand-written matrix `include` (each carries its own extra_args, #361),
+      # so the declared set and the run set are maintained separately and
+      # nothing compared them. A target dropped from either side leaves the
+      # nightly green having fuzzed a strict subset — no error, no warning, no
+      # smaller number in the log. Cheap: two file reads, no build.
+      - name: Fuzz-target guardrail self-test
+        run: tools/check_fuzz_targets.py --self-test
+      - name: Fuzz-target guardrail
+        run: tools/check_fuzz_targets.py
       - name: Release-plane guardrail
         run: |
           tools/check_release_plane.py \

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,12 @@ __pycache__/
 # far enough to produce either one.
 /tools/fixture-vm/nixos.qcow2
 /tools/fixture-vm/result
+
+# Nested-workspace build output. `/target` above is ROOT-ANCHORED, so it does
+# not cover the three sibling workspaces; before the clippy-scope guardrail
+# (REQ-GUARD-GATE-EVIDENCE-002 g) nothing routinely built in them, so the gap
+# never showed. It does now — running clippy repo-wide leaves untracked
+# `target/` in each, and untracked noise hides real changes.
+codegen-exec-oracle/target/
+codegen-kiln-oracle/target/
+fuzz/target/

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4128,6 +4128,80 @@ artifacts:
       - type: verifies
         target: REQ-GUARD-HUMAN-SCOPED-001
 
+  - id: TEST-GUARD-CLIPPY-SCOPE
+    type: feature
+    title: Clippy is proven to run in every workspace, not just cargo's default one
+    description: >
+      Verifies REQ-GUARD-GATE-EVIDENCE-002 (g) — the clippy half of #383.
+
+      `cargo clippy --workspace --all-targets` means "all members of THIS
+      workspace", so the `Clippy` required check linted 1 of the repo's 4
+      workspaces and reported green for the repo. The fmt half was fixed in
+      v0.36.0's predecessor work; clippy inherited the identical default and was
+      left, which is why the requirement is worded "every whole-repo tool uses
+      discovery, not just the one that was caught".
+
+      `tools/check_clippy_workspaces.py` REUSES `check_fmt_workspaces.discover`
+      and its `check()` rather than copying them — the wording is injected
+      (`tool`/`verb`/`fix_hint`) and the fmt defaults are unchanged, so the fmt
+      gate and its 10-case self-test are provably unaffected. Copying would have
+      put workspace discovery in two files, and a fact duplicated across two
+      copies that then disagree is exactly #381.
+
+      The self-test's discriminating pair is the runner's exit code: the SAME
+      four-workspace tree passes when the runner reports clean and FAILS when it
+      reports dirty. A wrapper that ignored its runner — the way to make this
+      gate vacuous — passes the first and fails the second. A third case pins
+      that a missing cargo is CANNOT_CHECK, not a pass.
+
+      MEASURED before wiring, so this is not a latent red: all four workspaces
+      (root, codegen-exec-oracle, codegen-kiln-oracle, fuzz) are already
+      clippy-clean under `-D warnings`. Live run prints
+      `4 workspace(s) checked, 4 lint-clean.`
+
+      NOT claimed: that the lint SET is adequate. This ensures the tool is
+      pointed at every workspace; a workspace with no `[lints]` configured
+      passes here and is still under-linted. Different obligation.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling]
+
+  - id: TEST-GUARD-FUZZ-TARGETS
+    type: feature
+    title: The fuzz targets run are proven equal to the fuzz targets declared
+    description: >
+      Verifies REQ-GUARD-GATE-EVIDENCE-002 (h).
+
+      `fuzz/Cargo.toml` declares harnesses as `[[bin]]`; `fuzz-nightly.yml` runs
+      them from a hand-written `matrix.include` (the `include` form is
+      deliberate — each target carries its own `extra_args`, and only
+      `fuzz_scheduler_solver` needs `-max_len=128`; a flat list would impose
+      that cap on two healthy fuzzers, #361). The cost is two separately
+      maintained lists that nothing compared.
+
+      Add a harness and forget the workflow, or delete a matrix entry, and the
+      nightly stays GREEN having fuzzed a strict subset — no error, no warning,
+      no smaller number anywhere in the log, because success is reported per leg
+      and nobody counts the legs. Nightly is also where this hides longest: it
+      is not on the PR gate, and `fuzz_scheduler_solver` was red 97/97 runs from
+      2026-04-25 before anyone looked. A silently ABSENT leg is strictly harder
+      to notice than a loudly failing one.
+
+      `tools/check_fuzz_targets.py` asserts set equality in BOTH directions,
+      because the two failures are different bugs: declared-but-not-run is a
+      harness never exercised; run-but-not-declared is a leg that cannot build
+      and fails looking like a toolchain problem. Either side coming back EMPTY
+      exits 2 — a parse that read nothing is a broken scan, not perfect
+      agreement about nothing, which is the specific way this check could have
+      been made vacuous.
+
+      7-case self-test including the regression itself; order-independence and
+      quoting are pinned so cosmetic edits to the matrix do not read as drift.
+      Live run: `All 3 declared fuzz targets are run.` Two file reads, no build.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling, fuzzing]
+
   - id: TEST-GUARD-VERIFICATION-FILTERS
     type: feature
     title: A verification step whose test filter selects nothing is proven to fail

--- a/codegen-exec-oracle/Cargo.lock
+++ b/codegen-exec-oracle/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.3",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "good_lp",
  "spar-hir-def",
@@ -1852,14 +1852,14 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
 ]
 
 [[package]]
 name = "spar-syntax"
-version = "0.25.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "spar-parser",

--- a/codegen-kiln-oracle/Cargo.lock
+++ b/codegen-kiln-oracle/Cargo.lock
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.3",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "good_lp",
  "spar-hir-def",
@@ -1036,14 +1036,14 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
 ]
 
 [[package]]
 name = "spar-syntax"
-version = "0.26.0"
+version = "0.35.0"
 dependencies = [
  "rowan",
  "spar-parser",

--- a/tools/check_clippy_workspaces.py
+++ b/tools/check_clippy_workspaces.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Run clippy in EVERY workspace, not just the one cargo defaults to.
+
+REQ-GUARD-GATE-EVIDENCE-002 (g). The clippy half of #383.
+
+WHY THIS EXISTS
+===============
+
+`cargo clippy --workspace --all-targets -- -D warnings` means "all members of
+*this* workspace" — the same scope `cargo fmt --all` had. spar has four:
+
+    Cargo.toml
+    codegen-exec-oracle/Cargo.toml
+    codegen-kiln-oracle/Cargo.toml
+    fuzz/Cargo.toml
+
+so the `Clippy` required check has been linting one of them and reporting green
+for the repo. Three workspaces have been unlinted while a required gate said
+otherwise. That is #383's second half; `check_fmt_workspaces.py` fixed the first
+and left this one, and the requirement is explicit that the obligation is
+"every whole-repo tool uses [discovery], not just the one that was caught".
+
+WHY THIS FILE IS THIN
+=====================
+
+The discovery, the `--min-workspaces` floor, the broken-scan-vs-removed-
+workspace distinction, and the always-print-a-count contract already exist and
+are already self-tested in `check_fmt_workspaces.py`. This imports them and
+supplies a clippy runner.
+
+Copying that logic instead would put workspace discovery in two files, and a
+fact duplicated in two places is exactly what made #381 possible — the report
+path was written twice and the two copies disagreed for four months. One
+definition, two callers.
+
+WHAT IT DOES NOT DO
+===================
+
+It does not pick the lint set. `-D warnings` and any `[lints]` tables are the
+repo's business; this only ensures the tool is pointed at every workspace. A
+workspace with no lints configured will pass here and still be under-linted —
+that is a different obligation.
+
+Measured 2026-08-06 before wiring: all four workspaces are already clippy-clean
+under `-D warnings`, so turning this on is not a latent red. If a future
+workspace lands dirty, that is the gate working, not this script mis-scoping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_fmt_workspaces import (  # noqa: E402  (path set above)
+    EXIT_CANNOT_CHECK,
+    MIN_WORKSPACES,
+    check,
+    discover,
+)
+
+
+def _cargo_clippy(root, manifest):
+    """Real runner: (exit_code, combined_output). Raises OSError if cargo is absent."""
+    proc = subprocess.run(
+        [
+            "cargo",
+            "clippy",
+            "--manifest-path",
+            manifest,
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def self_test() -> int:
+    """Assert the clippy wiring, not the discovery (which check_fmt_workspaces owns).
+
+    Two cases, and the pair is the point: the SAME tree passes when the runner
+    reports clean and fails when it reports dirty. A wrapper that ignored its
+    runner's exit code — the way to make this gate vacuous — passes the first
+    and fails the second.
+    """
+    import io
+    import tempfile
+
+    passed = failed = 0
+
+    def case(desc, want, runner):
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as td:
+            for sub in ("", "a", "b", "c"):
+                d = os.path.join(td, sub)
+                os.makedirs(d, exist_ok=True)
+                with open(os.path.join(d, "Cargo.toml"), "w", encoding="utf-8") as fh:
+                    fh.write('[workspace]\nmembers = []\n')
+            buf = io.StringIO()
+            got = check(
+                td,
+                runner=runner,
+                out=buf,
+                tool="clippy",
+                verb="lint-clean",
+                fix_hint="cargo clippy --manifest-path {manifest} --all-targets -- -D warnings",
+            )
+        if got == want:
+            passed += 1
+            print(f"  ok   {desc}")
+        else:
+            failed += 1
+            print(f"  FAIL {desc}: got {got}, want {want}")
+            for line in buf.getvalue().splitlines()[:5]:
+                print(f"         {line}")
+
+    print("check_clippy_workspaces self-test")
+    case("all workspaces lint-clean -> pass", 0, lambda r, m: (0, ""))
+    case("a dirty workspace -> FAIL (runner exit is honoured)", 1,
+         lambda r, m: (101, "error: unused variable"))
+    case("cargo missing is CANNOT_CHECK, not a pass", EXIT_CANNOT_CHECK,
+         lambda r, m: (_ for _ in ()).throw(OSError("no cargo")))
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--min-workspaces", type=int, default=MIN_WORKSPACES)
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    print("== clippy-scope guardrail ==")
+    print(f"workspaces discovered: {len(discover(a.root))}")
+    return check(
+        a.root,
+        min_workspaces=a.min_workspaces,
+        runner=_cargo_clippy,
+        tool="clippy",
+        verb="lint-clean",
+        fix_hint="cargo clippy --manifest-path {manifest} --all-targets -- -D warnings",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_fmt_workspaces.py
+++ b/tools/check_fmt_workspaces.py
@@ -121,7 +121,29 @@ def _cargo_fmt(root, manifest):
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
 
 
-def check(root, *, min_workspaces=MIN_WORKSPACES, runner=None, out=None):
+def check(
+    root,
+    *,
+    min_workspaces=MIN_WORKSPACES,
+    runner=None,
+    out=None,
+    tool="fmt",
+    verb="formatted",
+    fix_hint="cargo fmt --manifest-path {manifest} --all",
+):
+    """Discover every workspace, run `runner` in each, and always print the count.
+
+    `tool`/`verb`/`fix_hint` exist so the SAME discovery + floor + always-print-a-
+    count logic backs more than one gate. REQ-GUARD-GATE-EVIDENCE-002 (g) is
+    explicit that the obligation is "every whole-repo tool uses it, not just the
+    one that was caught" — clippy inherits `--workspace` exactly as `cargo fmt
+    --all` did, covering 1 of this repo's 4 workspaces (#383). Copying this
+    function for clippy would put the discovery in two places, which is the
+    drift that made #381 possible; injecting the wording keeps it in one.
+
+    Defaults reproduce the fmt wording verbatim, so existing callers and the
+    self-test below are unchanged by this parameterisation.
+    """
     out = out or sys.stdout
     runner = runner or _cargo_fmt
 
@@ -149,9 +171,9 @@ def check(root, *, min_workspaces=MIN_WORKSPACES, runner=None, out=None):
             file=sys.stderr,
         )
         print(
-            "::error::a workspace that vanishes from discovery is silently exempt "
-            "from formatting — that is #383. Lower --min-workspaces only when a "
-            "workspace was deliberately removed.",
+            f"::error::a workspace that vanishes from discovery is silently exempt "
+            f"from {tool} — that is #383. Lower --min-workspaces only when a "
+            f"workspace was deliberately removed.",
             file=sys.stderr,
         )
         return EXIT_VIOLATION
@@ -161,7 +183,7 @@ def check(root, *, min_workspaces=MIN_WORKSPACES, runner=None, out=None):
         try:
             code, output = runner(root, manifest)
         except OSError as exc:
-            print(f"::error::could not run cargo fmt for {manifest}: {exc}", file=sys.stderr)
+            print(f"::error::could not run cargo {tool} for {manifest}: {exc}", file=sys.stderr)
             return EXIT_CANNOT_CHECK
         if code == 0:
             print(f"  ok   {manifest}", file=out)
@@ -171,13 +193,17 @@ def check(root, *, min_workspaces=MIN_WORKSPACES, runner=None, out=None):
 
     # The positive count, always, on every path. This line is the fix.
     print(
-        f"{len(manifests)} workspace(s) checked, {len(manifests) - len(dirty)} formatted.",
+        f"{len(manifests)} workspace(s) checked, {len(manifests) - len(dirty)} {verb}.",
         file=out,
     )
 
     if dirty:
         for manifest, output in dirty:
-            print(f"::error::{manifest} is not formatted — run: cargo fmt --manifest-path {manifest} --all", file=sys.stderr)
+            print(
+                f"::error::{manifest} is not {verb} — run: "
+                + fix_hint.format(manifest=manifest),
+                file=sys.stderr,
+            )
             for line in output.splitlines()[:40]:
                 print(f"  | {line}", file=sys.stderr)
         return EXIT_VIOLATION

--- a/tools/check_fuzz_targets.py
+++ b/tools/check_fuzz_targets.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Fail when the fuzz targets RUN are not exactly the fuzz targets DECLARED.
+
+REQ-GUARD-GATE-EVIDENCE-002 (h).
+
+WHY THIS EXISTS
+===============
+
+`fuzz/Cargo.toml` declares the harnesses as `[[bin]]` entries. `fuzz-nightly.yml`
+runs them from a hand-written `matrix.include` list — one entry per target,
+because each carries its own `extra_args` (only `fuzz_scheduler_solver` needs
+`-max_len=128`, and a flat list would force that cap onto two healthy fuzzers;
+see #361). That per-target detail is a good reason for the `include` form and is
+staying.
+
+The cost of the `include` form is that the two lists are maintained separately
+and nothing compares them. Add a harness to `fuzz/Cargo.toml` and forget the
+workflow, or delete a matrix entry, and the job stays GREEN having fuzzed a
+strict subset. There is no error, no warning, and no smaller number anywhere in
+the log — the run simply says `success` for the legs it did run.
+
+That is the family this requirement is about: the shortfall renders as the ideal
+reading. A fuzz job that fuzzed two of three targets looks exactly like a fuzz
+job that fuzzed three, because success is reported per leg and nobody counts the
+legs.
+
+Nightly fuzzing is also where this hides longest — it is not on the PR gate, so
+a dropped target can go unnoticed for months. `fuzz_scheduler_solver` was red
+97/97 runs from 2026-04-25 before anyone looked (#361); a *silently absent* leg
+is strictly harder to notice than a loudly failing one.
+
+WHAT IT CHECKS
+==============
+
+Set equality, both directions, because the two failure modes are different bugs:
+
+  * declared but not run  -> a harness exists and is never exercised.
+  * run but not declared  -> the workflow names a target cargo-fuzz cannot
+    build; the leg fails, but as a build error that reads like a toolchain
+    problem rather than a stale matrix.
+
+It prints both sets and the count on every path, success included — a gate that
+says nothing on success cannot distinguish "compared three" from "compared
+none", the same reason `check_fmt_workspaces.py` always prints its count.
+
+stdlib-only, and both parsers are deliberately narrow: `[[bin]] name = "..."`
+from the manifest, `- target: ...` from the matrix. Neither file is arbitrary
+YAML/TOML in practice, and a dependency this gate cannot install is a gate that
+can fail to run — which reads as approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# `[[bin]]` … `name = "fuzz_x"` — the first `name` after each [[bin]] header.
+_BIN_HEADER = re.compile(r"^\s*\[\[bin\]\]\s*$", re.M)
+_NAME = re.compile(r'^\s*name\s*=\s*"([^"]+)"\s*$', re.M)
+# `- target: fuzz_x` inside the workflow matrix.
+_MATRIX_TARGET = re.compile(r"^\s*-\s+target:\s*(\S+)\s*$", re.M)
+
+
+def declared_targets(manifest_text: str) -> set[str]:
+    """Every `[[bin]]` name in fuzz/Cargo.toml."""
+    out: set[str] = set()
+    for m in _BIN_HEADER.finditer(manifest_text):
+        nm = _NAME.search(manifest_text, m.end())
+        if nm:
+            out.add(nm.group(1))
+    return out
+
+
+def matrix_targets(workflow_text: str) -> set[str]:
+    """Every `- target:` in the fuzz workflow matrix."""
+    return {m.group(1).strip('"\'') for m in _MATRIX_TARGET.finditer(workflow_text)}
+
+
+def check(manifest: Path, workflow: Path, out=sys.stdout) -> int:
+    declared = declared_targets(manifest.read_text(encoding="utf-8"))
+    run = matrix_targets(workflow.read_text(encoding="utf-8"))
+
+    print("== fuzz-target guardrail ==", file=out)
+    print(f"declared in {manifest}: {len(declared)}  {sorted(declared)}", file=out)
+    print(f"run by      {workflow}: {len(run)}  {sorted(run)}", file=out)
+
+    # An empty side is a broken scan, not a finding. Without this, deleting the
+    # [[bin]] section or renaming the matrix key would make both sets empty and
+    # the equality check would pass — the gate reporting perfect agreement
+    # about nothing.
+    if not declared:
+        print("::error::no `[[bin]]` targets found — the manifest parse read "
+              "nothing, which is a broken scan, not an empty fuzz suite.", file=out)
+        return 2
+    if not run:
+        print("::error::no `- target:` entries found — the workflow parse read "
+              "nothing, which is a broken scan, not a disabled job.", file=out)
+        return 2
+
+    missing = sorted(declared - run)
+    extra = sorted(run - declared)
+    if missing:
+        for t in missing:
+            print(f"::error::{t} is declared in fuzz/Cargo.toml but NOT run by "
+                  f"the workflow — it is never fuzzed and nothing says so.", file=out)
+    if extra:
+        for t in extra:
+            print(f"::error::{t} is run by the workflow but NOT declared in "
+                  f"fuzz/Cargo.toml — that leg cannot build.", file=out)
+    if missing or extra:
+        return 1
+
+    print(f"\nAll {len(declared)} declared fuzz targets are run.", file=out)
+    return 0
+
+
+_MANIFEST = """[package]
+name = "spar-fuzz"
+
+[[bin]]
+name = "fuzz_aadl_parse"
+path = "fuzz_targets/fuzz_aadl_parse.rs"
+
+[[bin]]
+name = "fuzz_scheduler_solver"
+path = "fuzz_targets/fuzz_scheduler_solver.rs"
+"""
+
+_WORKFLOW = """jobs:
+  fuzz:
+    strategy:
+      matrix:
+        include:
+          - target: fuzz_aadl_parse
+            extra_args: ""
+          - target: fuzz_scheduler_solver
+            extra_args: "-max_len=128"
+"""
+
+
+def self_test() -> int:
+    passed = failed = 0
+
+    def case(desc: str, want: int, manifest: str, workflow: str) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as td:
+            m = Path(td) / "Cargo.toml"
+            w = Path(td) / "fuzz.yml"
+            m.write_text(manifest, encoding="utf-8")
+            w.write_text(workflow, encoding="utf-8")
+            buf = io.StringIO()
+            got = check(m, w, out=buf)
+        if got == want:
+            passed += 1
+            print(f"  ok   {desc}")
+        else:
+            failed += 1
+            print(f"  FAIL {desc}: got {got}, want {want}")
+            for line in buf.getvalue().splitlines()[:5]:
+                print(f"         {line}")
+
+    print("check_fuzz_targets self-test")
+    case("declared set == run set", 0, _MANIFEST, _WORKFLOW)
+    # The bug this exists for: a harness that is never fuzzed.
+    case("REGRESSION: declared but NOT run must FAIL", 1,
+         _MANIFEST + '\n[[bin]]\nname = "fuzz_codegen_roundtrip"\n', _WORKFLOW)
+    case("run but NOT declared must FAIL", 1,
+         _MANIFEST, _WORKFLOW + "          - target: fuzz_ghost\n")
+    # Broken scans must not read as agreement.
+    case("empty manifest is a broken scan, not an empty suite", 2, "", _WORKFLOW)
+    case("empty workflow matrix is a broken scan, not a disabled job", 2,
+         _MANIFEST, "jobs:\n  fuzz:\n")
+    # Order and quoting are not signal.
+    case("matrix order does not matter", 0, _MANIFEST,
+         """jobs:
+  fuzz:
+    strategy:
+      matrix:
+        include:
+          - target: fuzz_scheduler_solver
+          - target: fuzz_aadl_parse
+""")
+    case("quoted matrix target is unquoted before comparing", 0, _MANIFEST,
+         _WORKFLOW.replace("- target: fuzz_aadl_parse", '- target: "fuzz_aadl_parse"'))
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--manifest", default="fuzz/Cargo.toml")
+    ap.add_argument("--workflow", default=".github/workflows/fuzz-nightly.yml")
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    return check(Path(a.manifest), Path(a.workflow))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**REQ-GUARD-GATE-EVIDENCE-002 (g) and (h)** — obligations 2 and 3 of v0.36.0's bug-fix track (plan #392, first obligation #393).

Both are the same shape: a whole-repo tool whose scope is smaller than its name claims, with the shortfall rendering as the ideal reading.

## (g) Clippy linted 1 of 4 workspaces

`cargo clippy --workspace --all-targets` means *"all members of **this** workspace"* — the same scope `cargo fmt --all` had.

```
Cargo.toml   codegen-exec-oracle/   codegen-kiln-oracle/   fuzz/
```

Three workspaces have been unlinted behind a **required** check reporting green. The fmt half of #383 was fixed and this half left — which is exactly why the requirement says *"every whole-repo tool uses discovery, not just the one that was caught"*.

`check_clippy_workspaces.py` **reuses** `check_fmt_workspaces.discover` and its `check()`; it does not copy them. Tool wording is injected (`tool`/`verb`/`fix_hint`) with fmt defaults, so the fmt gate is behaviourally byte-identical — verified: its 10-case self-test still passes and it still prints `4 workspace(s) checked, 4 formatted`. Copying would put discovery in two files, and two copies that drift apart is *how #381 happened*.

**Measured before wiring** — all four workspaces are already clippy-clean under `-D warnings` (run individually, exit 0 each), so this is not a latent red. Live: `4 workspace(s) checked, 4 lint-clean.`

The discriminating self-test case is the runner's exit code: the **same** tree passes when the runner reports clean and **fails** when it reports dirty. A wrapper that ignored its runner — how this gate would go vacuous — passes the first and fails the second.

## (h) The fuzz target list was never compared to its declaration

`fuzz/Cargo.toml` declares `[[bin]]` harnesses; `fuzz-nightly.yml` runs a hand-written `matrix.include`. The `include` form is deliberate and stays (only `fuzz_scheduler_solver` needs `-max_len=128`; a flat list would impose that cap on two healthy fuzzers, #361). Its cost is two lists nothing compares.

Drop either side and the nightly stays green **having fuzzed a strict subset** — no error, no warning, no smaller number in the log, because success is per-leg and nobody counts the legs. Nightly is where this hides longest: `fuzz_scheduler_solver` was red **97/97 runs** from 2026-04-25 before anyone looked, and a silently *absent* leg is harder to notice than a loudly failing one.

Set equality **both directions** — declared-but-not-run is a harness never exercised; run-but-not-declared is a leg that cannot build and fails looking like a toolchain problem. Either side **empty exits 2**: a parse that read nothing is a broken scan, not perfect agreement about nothing — the one way this check could itself go vacuous. 7-case self-test, two file reads, no build.

## Two things the gate surfaced by being run

Included rather than reverted:

- **`codegen-*/Cargo.lock` pinned `spar-analysis 0.25.0`** against a workspace at **0.35.0** — ten minor versions stale, because nothing routinely built there to refresh them. Otherwise every contributor who runs the new gate gets the same dirty diff.
- **`codegen-*/target/` and `fuzz/target/` were not gitignored** — `.gitignore:1` is `/target`, root-anchored. The gap never showed because nothing built there. It does now.

## Verified

- **9/9** guardrail self-tests pass on this tree
- both new gates run green for real
- release-plane and human-scoped gates still pass on the edited artifacts
- workflow + artifact YAML parse

Refs #383, #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)