### PR TITLE
feat(guard): a sorry cannot exempt itself by writing a comment (#385)

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -134,23 +134,36 @@ jobs:
       # Discharging the sorrys is a separate v0.10 PR. Once a sorry is
       # discharged, this step turns green automatically; no allowlist
       # to maintain.
+      # REQ-GUARD-GATE-EVIDENCE-002 (f), closes #385.
+      #
+      # The previous body was a two-stage grep that excluded any sorry
+      # carrying a same-line `-- TODO`. Its comment explained why that was
+      # safe: "the five tracked sorrys do NOT carry a same-line comment".
+      # That was true when written. The sorries then grew 5 -> 12 AND moved
+      # their TODO onto the same line, so an exclusion designed to be a no-op
+      # silently became universal — 12 in, 0 out, `if` never fires, and the
+      # step printed "No sorrys in proofs/Proofs/ — gate green."
+      #
+      # The gate was satisfied by exactly the thing it exists to prevent, and
+      # nobody edited it; the code drifted out from under its comment. The
+      # generalisable part: a self-exemption keyed on a pattern the exempted
+      # code itself controls cannot hold — the proof author writes both the
+      # `sorry` and the `-- TODO` that excuses it.
+      #
+      # Replaced by a declared ratchet. --max-sorries is the floor, and it is
+      # here (in the workflow) rather than in the proofs, so lowering it is a
+      # deliberate edit by someone other than the proof being exempted.
+      # 12 is the measured count on ae27ff1. LOWER IT as proofs land; the gate
+      # says so on every run where the real count is below the floor.
+      # Discharging these is REQ-PROOF-NC-MINPLUS-001 (v0.38.0).
+      - name: Lean-sorry guardrail self-test
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: tools/check_lean_sorries.py --self-test
       - name: Fail on sorry (post-build gate)
         if: always()
         working-directory: ${{ github.workspace }}
-        run: |
-          set -u
-          # Match bare `sorry` lines (any indent), excluding those with
-          # a same-line comment exemption (`-- TODO(...)` etc). The
-          # five tracked sorrys do NOT carry a same-line comment; the
-          # TODO sits on the prior line, so this gate flags all five.
-          if grep -rn -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/ \
-              | grep -v -E 'sorry[[:space:]]*--[[:space:]]*TODO'; then
-            echo ""
-            echo "::error::Lean proofs tree contains unfinished proofs (sorry)."
-            echo "::error::See proofs/README.md 'Known sorrys' and COMPLIANCE.md v0.9.1 for the tracked list."
-            exit 1
-          fi
-          echo "No sorrys in proofs/Proofs/ — gate green."
+        run: tools/check_lean_sorries.py --max-sorries 12
 
       # Codegen freshness gate (REQ-PROOF-SCHED-CODEGEN-001, #321).
       #

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4128,6 +4128,56 @@ artifacts:
       - type: verifies
         target: REQ-GUARD-HUMAN-SCOPED-001
 
+  - id: TEST-GUARD-LEAN-SORRY-FLOOR
+    type: feature
+    title: A `sorry` cannot exempt itself from the sorry gate by writing a comment
+    description: >
+      Verifies REQ-GUARD-GATE-EVIDENCE-002 (f). Closes #385.
+
+      `Fail on sorry (post-build gate)` is part of the required
+      `Lean proof typecheck (lake build)` context and permitted EVERY sorry in
+      the tree while printing `No sorrys in proofs/Proofs/ — gate green.` Its
+      pipeline excluded any sorry with a same-line `-- TODO`, and all 12 carry
+      `sorry -- TODO(v1.0.0)`: 12 in, 0 out, the `if` never fires.
+
+      HOW IT DRIFTED is the part worth keeping. The step's own comment read
+      "the five tracked sorrys do NOT carry a same-line comment; the TODO sits
+      on the prior line" — TRUE when written, and the exclusion was a
+      deliberate no-op against a form nobody used. The sorries then grew 5 to
+      12 and moved their TODO onto the same line. Nobody edited the guard; the
+      code drifted out from under its comment, and a no-op became universal.
+
+      The generalisable defect is not a careless filter: **a self-exemption
+      keyed on a pattern the exempted code itself controls cannot hold**, because
+      the proof author writes both the `sorry` and the `-- TODO` that excuses
+      it. The floor now lives in `proofs.yml`, which the proof does not edit in
+      the same commit.
+
+      PROVEN, 8-case self-test run before the gate judges anything. The
+      discriminating pair is the regression itself: `sorry -- TODO` COUNTS and
+      breaches a floor of 0, and the SAME file passes at a floor of 1 — so the
+      comment is signal for neither verdict. A checker that still honoured the
+      exemption passes the first and cannot fail it.
+
+      Ratchet direction is asserted too: a count BELOW the floor passes and
+      prints "lower --max-sorries to N", because a gate that failed on
+      improvement would be walked back rather than tightened. And an empty
+      scan exits 2 — zero-sorries-because-no-.lean-files-were-read is the exact
+      error-path-yields-ideal-reading shape this requirement is about.
+
+      MEASURED on ae27ff1: 11 .lean files scanned, 12 sorries (MinPlus.lean 4,
+      MinPlusPwa.lean 8), floor set to 12 so the gate is green and honest
+      rather than green and blind. Verified it can fail: at --max-sorries 11 it
+      exits 1 naming the breach.
+
+      NOT claimed: that the 12 remaining sorries are acceptable. The floor
+      records how many exist, not that they are fine — discharging them is
+      REQ-PROOF-NC-MINPLUS-001 (v0.38.0). This only stops the number rising
+      unnoticed, which is what it did between 5 and 12.
+    status: implemented
+    release: v0.36.0
+    tags: [process, guardrail, ci, tooling, lean, proofs]
+
   - id: TEST-GUARD-VERIFICATION-FILTERS
     type: feature
     title: A verification step whose test filter selects nothing is proven to fail

--- a/tools/check_lean_sorries.py
+++ b/tools/check_lean_sorries.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Gate Lean `sorry` count against a declared, shrinking floor.
+
+REQ-GUARD-GATE-EVIDENCE-002 (f). Closes #385.
+
+WHY THIS EXISTS
+===============
+
+`Fail on sorry (post-build gate)` in `proofs.yml` is part of the required
+`Lean proof typecheck (lake build)` context, and it permitted EVERY sorry in the
+tree while printing `No sorrys in proofs/Proofs/ — gate green.`
+
+Its pipeline was:
+
+    grep -rn -E '^[[:space:]]*sorry[[:space:]]*(--.*)?$' proofs/Proofs/ \\
+      | grep -v -E 'sorry[[:space:]]*--[[:space:]]*TODO'
+
+12 sorries in, 0 out, `if` never fires. Every one carries `sorry -- TODO(v1.0.0)`,
+so the exemption pattern matched all of them. **The gate was satisfied by exactly
+the thing it exists to prevent.**
+
+HOW IT DRIFTED, which is the part worth keeping
+-----------------------------------------------
+
+The step's own comment says:
+
+    # The five tracked sorrys do NOT carry a same-line comment; the
+    # TODO sits on the prior line, so this gate flags all five.
+
+That was TRUE when written. The exclusion was deliberately a no-op — a defensive
+filter against a form nobody used. Since then the sorries grew 5 -> 12 and moved
+their TODO onto the same line, and the no-op silently became universal. Nobody
+edited the guard; the code drifted out from under its comment.
+
+So the lesson is not "someone wrote a bad filter". It is that **a self-exemption
+keyed on a pattern the exempted code itself controls cannot hold** — the proof
+author writes both the `sorry` and the `-- TODO` that excuses it. An exemption
+must be declared somewhere the exempted party does not edit in the same commit.
+
+THE REPLACEMENT
+===============
+
+A ratchet, the same shape as the mutants gate:
+
+* Count every bare `sorry`, with NO comment-based exemption. A `-- TODO` is a
+  note to humans, not a permit.
+* Compare against `--max-sorries`, a floor declared in the workflow.
+* count > floor  -> FAIL. New sorries cannot be admitted by writing a comment.
+* count < floor  -> PASS, and say loudly that the floor should be lowered. That
+  is how the ratchet walks down. Improving must never fail.
+* The count and the per-file breakdown print on EVERY path, success included,
+  so "12 permitted" is visible rather than inferred from silence.
+
+An empty scan exits 2. Zero files matched means the walk is broken (wrong path,
+renamed directory), and zero-sorries-because-nothing-was-read is the exact
+failure this whole requirement is about: the error path producing the ideal
+reading.
+
+NOT CLAIMED: that the remaining sorries are acceptable. The floor records how
+many exist, not that they are fine. Discharging them is REQ-PROOF-NC-MINPLUS-001
+(v0.38.0); this only stops the number rising unnoticed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# A bare `sorry` on its own line, with or without a trailing comment. The
+# trailing comment is CAPTURED, not excluded — that was the bug.
+_SORRY = re.compile(r"^[ \t]*sorry[ \t]*(--.*)?$")
+
+
+def scan(root: Path) -> dict[str, list[tuple[int, str]]]:
+    """{relative path: [(line_no, line_text)]} for every bare sorry."""
+    found: dict[str, list[tuple[int, str]]] = {}
+    for path in sorted(root.rglob("*.lean")):
+        hits = []
+        for n, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if _SORRY.match(line):
+                hits.append((n, line.strip()))
+        if hits:
+            found[str(path)] = hits
+    return found
+
+
+def check(root: Path, max_sorries: int, out=sys.stdout) -> int:
+    if not root.is_dir():
+        print(f"::error::not a directory: {root} — the scan cannot run, so it "
+              f"reports nothing rather than zero sorries.", file=out)
+        return 2
+
+    lean_files = list(root.rglob("*.lean"))
+    if not lean_files:
+        print(f"::error::no .lean files under {root} — a broken scan, not a "
+              f"sorry-free tree. Zero-because-nothing-was-read is the failure "
+              f"this gate exists to prevent.", file=out)
+        return 2
+
+    found = scan(root)
+    total = sum(len(v) for v in found.values())
+
+    print("== lean-sorry guardrail ==", file=out)
+    print(f".lean files scanned: {len(lean_files)}", file=out)
+    print(f"sorries found:       {total}   (declared floor: {max_sorries})", file=out)
+    for path, hits in found.items():
+        print(f"  {len(hits):3}  {path}", file=out)
+        for n, text in hits:
+            print(f"       :{n}  {text}", file=out)
+
+    if total > max_sorries:
+        print("", file=out)
+        print(f"::error::{total} sorries exceed the declared floor of {max_sorries}.", file=out)
+        print("::error::A `-- TODO` comment is a note, not a permit — it does not "
+              "exempt a sorry from this count (#385). Discharge the proof, or "
+              "raise the floor in proofs.yml deliberately and say why.", file=out)
+        return 1
+
+    if total < max_sorries:
+        print("", file=out)
+        print(f"::notice::{total} sorries is BELOW the floor of {max_sorries} — "
+              f"lower --max-sorries to {total} in proofs.yml so the ratchet holds "
+              f"the ground that was gained.", file=out)
+
+    print(f"\n{total} sorries, at or under the declared floor of {max_sorries}.", file=out)
+    return 0
+
+
+def self_test() -> int:
+    passed = failed = 0
+
+    def case(desc: str, want: int, files: dict[str, str], floor: int) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for name, body in files.items():
+                p = root / name
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(body, encoding="utf-8")
+            buf = io.StringIO()
+            got = check(root, floor, out=buf)
+        if got == want:
+            passed += 1
+            print(f"  ok   {desc}")
+        else:
+            failed += 1
+            print(f"  FAIL {desc}: got {got}, want {want}")
+            for line in buf.getvalue().splitlines()[:6]:
+                print(f"         {line}")
+
+    PLAIN = "theorem t : True := by\n  sorry\n"
+    TODO = "theorem t : True := by\n  sorry -- TODO(v1.0.0)\n"
+    DONE = "theorem t : True := by\n  trivial\n"
+
+    print("check_lean_sorries self-test")
+    # THE BUG. A `-- TODO` sorry must COUNT. Under the old gate this was exempt,
+    # which is how all 12 became invisible.
+    case("REGRESSION #385: `sorry -- TODO` COUNTS and can breach the floor", 1,
+         {"A.lean": TODO}, 0)
+    case("...and the same file passes when the floor admits it", 0,
+         {"A.lean": TODO}, 1)
+    # Plain sorries behave identically — the comment is not signal either way.
+    case("bare sorry over floor fails", 1, {"A.lean": PLAIN}, 0)
+    case("bare sorry at floor passes", 0, {"A.lean": PLAIN}, 1)
+    # The ratchet direction: improving must never fail.
+    case("below floor PASSES (ratchet may be tightened, not a failure)", 0,
+         {"A.lean": DONE}, 3)
+    # Counting across files.
+    case("counts across multiple files", 1,
+         {"A.lean": PLAIN, "sub/B.lean": TODO}, 1)
+    # Broken scans must not read as clean.
+    case("no .lean files is a broken scan, not a clean tree", 2, {"README.md": "x"}, 0)
+    # A `sorry` inside a word or mid-expression is not a bare sorry.
+    case("`sorryAx` / inline text is not a bare sorry", 0,
+         {"A.lean": "def sorryAx := 1\n-- mentions sorry in prose\n"}, 0)
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--root", default="proofs/Proofs")
+    ap.add_argument("--max-sorries", type=int, default=12)
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+    return check(Path(a.root), a.max_sorries)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**REQ-GUARD-GATE-EVIDENCE-002 (f)** — v0.36.0 bug-fix track. Written during the GitHub Actions outage, so CI here will be red for infrastructure reasons until the [incident](https://www.githubstatus.com/) clears; see #395 for the same situation.

## The defect

`Fail on sorry (post-build gate)` is part of the **required** `Lean proof typecheck (lake build)` context. It permitted every sorry in the tree while printing:

```
No sorrys in proofs/Proofs/ — gate green.
```

It excluded any sorry with a same-line `-- TODO`, and **all twelve are `sorry -- TODO(v1.0.0)`**. Twelve in, zero out, the `if` never fires. *The gate was satisfied by exactly the thing it exists to prevent.*

## How it drifted — the part worth keeping

The step's own comment said:

> *"The five tracked sorrys do NOT carry a same-line comment; the TODO sits on the prior line, so this gate flags all five."*

**That was true when written.** The exclusion was a deliberate no-op against a form nobody used. The sorries then grew 5 → 12 *and* moved their TODO onto the same line — and the no-op silently became universal. Nobody edited the guard; the code drifted out from under its comment.

So the defect isn't a careless filter. It's that **a self-exemption keyed on a pattern the exempted code itself controls cannot hold** — the proof author writes both the `sorry` and the `-- TODO` that excuses it, in one commit, and no review step sees the exemption grow.

## The replacement

A ratchet, same shape as the mutants gate. No comment-based exemption at all — a `-- TODO` is a note to humans, not a permit — and the floor lives in `proofs.yml`, *not* in the proofs.

| condition | behaviour |
|---|---|
| count > floor | **FAIL** — new sorries cannot be admitted by writing a comment |
| count < floor | **PASS**, loudly saying to lower the floor. Improving must never fail, or the ratchet gets walked back instead of tightened |
| empty scan | **exit 2** — zero sorries because no `.lean` was read is the error-path-yields-ideal-reading shape this requirement names |

Count plus per-file, per-line breakdown prints on **every** path including success, so "12 permitted" is visible rather than inferred from silence.

## Measured

On `ae27ff1`: **11 `.lean` files scanned, 12 sorries** (`MinPlus.lean` 4, `MinPlusPwa.lean` 8). Floor set to **12** — green and honest rather than green and blind. **Verified it can go red:** at `--max-sorries 11` it exits 1 naming the breach.

8-case self-test runs before the gate judges anything. The discriminating pair is the regression itself: `sorry -- TODO` **counts** and breaches a floor of 0, and the *same file* passes at a floor of 1 — the comment is signal for neither verdict. A checker still honouring the exemption passes the first case and cannot fail it. Also pinned: `sorryAx` and "sorry" in prose are not bare sorries.

## Not claimed

That the 12 remaining sorries are acceptable. The floor records how many exist, not that they're fine — discharging them is REQ-PROOF-NC-MINPLUS-001 (v0.38.0). This only stops the number rising unnoticed, which is exactly what it did between 5 and 12.

Refs #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)