### PR TITLE
fix(release,guard): a short release cannot be signed; withdraw a false claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,18 @@ jobs:
         # Lower this number as tests improve; target 0. Raise it only against a
         # run whose outcomes.json has an end_time — a partial run reports FEWER
         # survivors than the truth, so a threshold taken from one is a ceiling
-        # set below the floor. Nothing here yet fails a truncated run: that
-        # detector, and the runner disk-pressure fault behind it, are #389.
+        # set below the floor.
+        #
+        # That is now ENFORCED rather than advice: check_mutants_report.py
+        # rejects a report whose `end_time` is null, so a truncated run cannot
+        # be scored at all (#389, closed by #401). The runner-side cause was
+        # fixed the same day — and note it was NOT the disk-pressure hook this
+        # comment used to blame, which only runs BETWEEN jobs. It was a tmpfiles
+        # sweep reaping cargo-mutants' worker trees after 2h, resting on the
+        # false assumption that a live job keeps their mtime fresh; it does not,
+        # because cargo-mutants copies each tree once at start and never touches
+        # it again. The age is now 8h, above GitHub's 6h job ceiling — which
+        # holds only while this job's timeout-minutes stays under ~7h.
         # Walking the number back down is #382.
         run: tools/check_mutants_report.py --output-dir mutants-out --max-missed 292
       - name: Upload mutants report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: binary-${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
 
@@ -176,6 +179,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: compliance-report
           path: ${{ steps.report.outputs.archive-path }}
 
@@ -238,6 +244,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: test-evidence
           path: spar-*-test-evidence.tar.gz
 
@@ -292,6 +301,9 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: wasm-bundle
           path: spar-wasm-browser-*.tar.gz
 
@@ -347,6 +359,9 @@ jobs:
         run: npx @vscode/vsce package --target ${{ matrix.target }} --no-dependencies
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: vsix-${{ matrix.target }}
           path: vscode-spar/*.vsix
 
@@ -408,6 +423,9 @@ jobs:
           ls -la sbom-out/
       - uses: actions/upload-artifact@v4
         with:
+          # An empty upload must not be silent: the release job gathers
+          # these with `find`, which exits 0 on no match (#402).
+          if-no-files-found: error
           name: sbom
           path: sbom-out/spar.cdx.json
 
@@ -454,9 +472,31 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
           # tar.gz / zip / vsix flow through unchanged.
+          #
+          # `find ... -exec cp` exits 0 when it matches NOTHING. With every
+          # upstream upload-artifact left at the default `if-no-files-found:
+          # warn`, an empty or partial `artifacts/` therefore produced an empty
+          # `release-assets/` in silence — and the checksum, attest, cosign and
+          # `gh release create` steps below all succeed over nothing, publishing
+          # a SIGNED, ATTESTED release containing no binaries (#402).
+          #
+          # Count what was gathered and fail on a shortfall, which is the shape
+          # the SBOM block immediately below already uses. The floor is derived,
+          # not guessed: build-binaries has 5 matrix targets and build-vsix has
+          # 5, so a complete release carries at least 10 of these three
+          # extensions before the wasm/compliance/evidence bundles are counted.
+          # If a target is added to either matrix, raise this with it.
+          MIN_RELEASE_ASSETS=10
           find artifacts -type f \
             \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.vsix" \) \
             -exec cp {} release-assets/ \;
+          N_ASSETS="$(find release-assets -type f | wc -l | tr -d ' ')"
+          echo "release assets gathered: ${N_ASSETS} (floor ${MIN_RELEASE_ASSETS})"
+          if [ "$N_ASSETS" -lt "$MIN_RELEASE_ASSETS" ]; then
+            echo "::error::only ${N_ASSETS} release asset(s) gathered, expected at least ${MIN_RELEASE_ASSETS}. Refusing to sign and publish a short release. Downloaded artifacts/ contained:"
+            find artifacts -type f | head -40
+            exit 1
+          fi
           # Version-stamp the SBOM per the release-asset naming
           # standard: <tool>-X.Y.Z.cdx.json (bare version, no `v`).
           VERSION="${GH_REF#refs/tags/}"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4986,8 +4986,32 @@ artifacts:
       classify_changed_paths.py, (f) #385 via check_lean_sorries.py, (g) #383's
       clippy half via check_clippy_workspaces.py, (h) via
       check_fuzz_targets.py. Each ships a self-test that runs BEFORE the gate it
-      guards is allowed to judge anything, and each was mutation-tested to show
-      its cases are load-bearing rather than merely green.
+      guards is allowed to judge anything.
+
+      A previous revision of this paragraph claimed "each was mutation-tested to
+      show its cases are load-bearing rather than merely green". That universal
+      was FALSE and is withdrawn (#405). Mutation results are recorded for two
+      of the six — (d) and (e) — and both were manual shell runs with no
+      committed harness, so they cannot be re-derived. An adversarial review
+      then falsified the universal directly: substituting
+      `filt` -> `filt.split('::')[-1]` in check_verification_filters.py leaves
+      13/13 green while changing vacuity semantics for the 16 of 60 filters that
+      contain `::`, and deleting the below-floor branch of check_lean_sorries.py
+      leaves 8/8 green.
+
+      The correlation is worth recording because it is the opposite of
+      reassuring: the two tools that CLAIMED mutation testing have the strongest
+      suites, and the two with live holes ((c)'s cross-package scope, #404;
+      (f)'s pattern width, #385) claimed nothing. The claim was reached for
+      where confidence was already high, which is where it adds least.
+
+      Mechanising it is #405 (`tools/check_self_test_potency.py`). Note what
+      that would and would not buy: mutation testing shows the cases PRESENT are
+      load-bearing; it cannot show the case set COVERS the hazard. Both live
+      holes prove it from the other side — one has a self-test case that affirms
+      the narrow behaviour as intended, the other has no case for the hole at
+      all, and a green potency run on either would be true and still miss the
+      defect.
 
       STATUS DELIBERATELY LEFT `proposed`. This artifact carries the
       `human-scoped` tag, so REQ-GUARD-HUMAN-SCOPED-001 forbids an agent


### PR DESCRIPTION
Batch 1 of the multi-persona review of REQ-GUARD-GATE-EVIDENCE-002 — the three
changes that need no design debate. Refs #402, #405.

Four independent reviewers (safety assessor, adversarial verifier, defect
archaeologist, release manager) all recommended holding `-002` at `proposed`.
This PR takes the uncontested subset; the two live obligation holes (#404, #385)
and the systemic layer (#403, #405, #406) follow separately.

## 1. `release.yml` can no longer publish a signed release with no binaries (#402)

`find … -exec cp` exits **0** when it matches nothing, and all six upstream
`upload-artifact` steps sat at the default `if-no-files-found: warn`. An empty or
partial `artifacts/` therefore produced an empty `release-assets/` in silence —
and `sha256sum`, the SLSA attestation, cosign, and `gh release create` all
succeed over nothing. The result is a signed, attested release containing no
binaries.

The gather is now counted against a floor, which is **the shape the SBOM block
ten lines below already used** — the pattern was recognised once and not applied
to its five siblings. The floor is derived, not guessed: `build-binaries` has 5
matrix targets and `build-vsix` has 5, so a complete release carries at least 10
of these three extensions before wasm/compliance/evidence are counted.

All six uploads now declare `if-no-files-found: error` — the value
`trace-fixtures.yml:453` already uses, so the repo demonstrably knew the
difference.

**`release.yml` only runs on tags, so CI will never exercise this.** The logic
was therefore exercised locally against four trees:

| artifacts present | exit |
|---|---|
| 0 — the #402 scenario | **1** |
| 4 — partial build | **1** |
| 10 — complete release | 0 |
| 13 — complete + extras | 0 |

The pre-fix form exits 0 on all four.

## 2. `ci.yml`'s mutants comment no longer contradicts the gate it calls

It still read *"Nothing here yet fails a truncated run: that detector, and the
runner disk-pressure fault behind it, are #389"* — false since #401 merged two
commits earlier. This is precisely the "code drifted out from under its comment"
species that #385's own fix narrative identifies as its root cause, so leaving it
would be leaving the same trap re-armed.

The replacement also fixes the attribution. The disk-pressure hook was a **red
herring** — `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` only runs *between* jobs. The
actual reaper was a tmpfiles sweep on a false premise: *"a job that's still
running keeps mtime fresh"*, which does not hold for cargo-mutants, since it
copies each worker's source tree once at start and never touches it again.

## 3. A false universal in the requirement is withdrawn (#405)

I wrote this into `REQ-GUARD-GATE-EVIDENCE-002` in #401:

> "Each ships a self-test that runs BEFORE the gate it guards is allowed to judge
> anything, **and each was mutation-tested to show its cases are load-bearing
> rather than merely green.**"

It is not true. Results exist for two of six, both manual shell runs with no
committed harness. An adversarial reviewer falsified the universal directly, and
I reproduced both mutants before writing this:

```
check_verification_filters.py:212   filt → filt.split('::')[-1]   13 passed → SURVIVES
check_lean_sorries.py               below-floor branch deleted     8 passed → SURVIVES
```

Mutant A is not cosmetic: **16 of the 60 distinct filters** in
`verification.yaml` contain `::`, and no self-test case has one, so the suite is
structurally blind to it.

The replacement text records the correlation rather than burying it: **the two
tools that claimed mutation testing have the strongest suites; the two with live
holes (#404, #385) claimed nothing.** The claim was reached for where confidence
was already high, which is where it adds least. It also states what mechanising
it (#405) would *not* buy — mutation testing shows the cases present are
load-bearing, not that the case set covers the hazard.

## Not in this PR

`REQ-GUARD-GATE-EVIDENCE-002` stays `proposed` and keeps its `human-scoped` tag.
Nothing here promotes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)