### PR TITLE
chore(release): v0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "spar"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "spar-annex"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "rowan",
  "spar-syntax",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "rowan",
  "salsa",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "spar-codegen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion",
  "la-arena",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "spar-dbc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "can-dbc",
  "expect-test",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "salsa",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "la-arena",
  "rowan",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "spar-insight"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mcp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "spar-mermaid"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "spar-network"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "good_lp",
  "spar-base-db",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "spar-parser"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "expect-test",
  "proptest",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "spar-render"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "etch",
  "la-arena",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "spar-solver"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "criterion",
  "good_lp",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "spar-syntax"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "expect-test",
  "rowan",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "spar-sysml2"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "expect-test",
  "la-arena",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "spar-trace-topology"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "pcap-parser",
  "serde",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "spar-transform"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "la-arena",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "spar-variants"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1626,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "spar-verify"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "spar-verify-macros",
 ]
 
 [[package]]
 name = "spar-verify-macros"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "spar-wasm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "etch",
  "la-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 edition = "2024"
 # The floor is NOT a free choice — it is the maximum `rust-version` over the
 # whole resolved dependency closure, which cargo enforces whether or not it is

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5090,6 +5090,6 @@ artifacts:
       is a distinct obligation (execution evidence, not list parity) and is left
       to a successor; this requirement closes the list-parity hole #406 names and
       no more.
-    status: implemented
+    status: verified
     release: v0.36.0
     tags: [process, guardrail, ci, tooling, fuzzing]

--- a/vscode-spar/package.json
+++ b/vscode-spar/package.json
@@ -3,7 +3,7 @@
   "displayName": "AADL (spar)",
   "description": "AADL v2.2/v2.3 language support with live architecture visualization",
   "publisher": "pulseengine",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Release bump for **v0.36.0**, cutting the fuzz-target guardrail fix shipped in #409 (merged to main as `d68fed5`).

- `[workspace.package] version` in `Cargo.toml`: `0.35.0` → `0.36.0`
- `Cargo.lock`: all 23 workspace crates rebumped via `cargo update --workspace` (no third-party dependency versions changed — 79 unchanged)
- `vscode-spar/package.json`: `0.35.0` → `0.36.0`
- `REQ-GUARD-FUZZ-SMOKE-001`: `implemented` → `verified`, `release: v0.36.0`

## Why

#409 taught `tools/check_fuzz_targets.py` to audit the **required** `fuzz-smoke` context's target list (`ci.yml`) rather than only the advisory nightly matrix — closing the list-parity hole #406 named. This release records that requirement as verified and ships it.

The status flip stays within the guardrail's `{implemented, verified, accepted}` claiming set, so no new verification-filter enforcement is introduced; the linked `TEST-GUARD-FUZZ-SMOKE` steps already passed green on #409.

## Scope

Version/lockfile/artifact metadata only — no source changes. All feature code and its oracles landed and passed full CI (incl. Mutation Testing + Lean) on #409 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014yCpJNEKSzo76htFjW91op)_